### PR TITLE
removed text decoration on hover in hamburgermenu

### DIFF
--- a/src/components/header/components/HamburgerMenuBox.scss
+++ b/src/components/header/components/HamburgerMenuBox.scss
@@ -72,7 +72,6 @@
 
       &:hover {
         color: vars.$hover-color;
-        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
Removed unnecessary text-decoration on hover for the hamburger menu. The existing underline styling provides a better visual effect, making the UI cleaner and more consistent.