### PR TITLE
git commit -m "fix: Render HTML tags properly in TourCard food and pr…

### DIFF
--- a/src/components/unique/experiences/dreamdhow/components/TourCard.jsx
+++ b/src/components/unique/experiences/dreamdhow/components/TourCard.jsx
@@ -11,8 +11,8 @@ import CTAButton from "./CTAButton";
  * @param {Array} props.images - Array of image paths
  * @param {string} props.departure - Departure information
  * @param {string} props.activities - Activities description
- * @param {string} props.food - Food information
- * @param {string} props.pricing - Pricing details
+ * @param {string} props.food - Food information (can include HTML)
+ * @param {string} props.pricing - Pricing details (can include HTML)
  * @param {string} props.kids - Kids pricing
  * @param {string} props.ctaText - CTA button text
  * @param {string} props.ctaLink - CTA button link
@@ -56,9 +56,13 @@ const TourCard = ({
         <strong>Activities:</strong> {activities}
       </p>
       <p>
-        <strong>Food:</strong> {food}
+        <strong>Food:</strong>{" "}
+        <span dangerouslySetInnerHTML={{ __html: food }} />
       </p>
-      <p dangerouslySetInnerHTML={{ __html: pricing }} />
+      <p>
+        <strong>Private boat:</strong>{" "}
+        <span dangerouslySetInnerHTML={{ __html: pricing }} />
+      </p>
       <p>
         <strong>Kids:</strong> {kids}
       </p>


### PR DESCRIPTION
## 🐛 Fix HTML Rendering in TourCard

Fixes HTML tags displaying as plain text in the Food and Pricing fields.

### Problem
The `<strong>` tags were being rendered as literal text instead of bold formatting.

### Solution
Wrapped HTML content in `<span>` with `dangerouslySetInnerHTML` while keeping field labels as plain text.

### Changes
- Food field: Now properly renders bold text for "Dinner:" and "Snacks:"
- Pricing field: Fixed structure to show "Private boat:" label + HTML content

**Before:** `<strong>Dinner:</strong>` displayed as text
**After:** **Dinner:** displays as bold

Ready to merge! ✅