### PR TITLE
feat: connect DreamDhow tours to Store booking with pre-fill

### DIFF
--- a/src/components/store/Store.jsx
+++ b/src/components/store/Store.jsx
@@ -21,6 +21,10 @@ const Store = () => {
     "Swimming in the Cave",
     "Sailing into the Sunset",
     "Quad Tour",
+    // DreamDhow tours
+    "Mnemba Island (Best Seller)",
+    "Tumbatu Island",
+    "Romantic Sunset Cruise",
   ];
 
   const locations = [
@@ -35,15 +39,29 @@ const Store = () => {
   ];
 
   const location = useLocation();
+  
+  // Get the selected tour from DreamDhow if available
+  const selectedTour = location.state?.selectedTour || "";
+  const fromDreamDhow = location.state?.fromDreamDhow || false;
 
   useEffect(() => {
-    if (location.state?.scrollToTop) {
+    if (location.state?.scrollToTop || fromDreamDhow) {
       window.scrollTo({
         top: 0,
         behavior: "smooth",
       });
+      
+      // Optional: Scroll to form after a short delay
+      if (fromDreamDhow) {
+        setTimeout(() => {
+          const formElement = document.querySelector('.booking-request');
+          if (formElement) {
+            formElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        }, 500);
+      }
     }
-  }, [location]);
+  }, [location, fromDreamDhow]);
 
   useEffect(() => {
     const revealElements = document.querySelectorAll(".reveal");
@@ -72,6 +90,12 @@ const Store = () => {
 
   return (
     <div className="store-container" id="top">
+      {fromDreamDhow && (
+        <div className="breadcrumb">
+          <a href="/dream-dhow">← Back to Dream Dhow</a>
+        </div>
+      )}
+      
       <h2 className="reveal store-title">Booking Request</h2>
       <p className="store-description">
         Welcome to the booking request page. Please fill out the form below to
@@ -81,7 +105,11 @@ const Store = () => {
       <ImageSlideshow images={images} />
 
       <div className="booking-request">
-        <BookingForm tours={tours} locations={locations} />
+        <BookingForm 
+          tours={tours} 
+          locations={locations} 
+          prefilledTour={selectedTour}
+        />
       </div>
     </div>
   );

--- a/src/components/store/Store.scss
+++ b/src/components/store/Store.scss
@@ -12,6 +12,50 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
+  position: relative;
+
+  .breadcrumb {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 10;
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.25rem;
+      background: rgba(vars.$color-primary, 0.05);
+      border: 2px solid vars.$color-primary;
+      border-radius: vars.$border-radius-default;
+      color: vars.$color-primary;
+      text-decoration: none;
+      font-family: vars.$font-secondary;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: all 0.3s ease;
+
+      &:hover {
+        background: vars.$color-primary;
+        color: vars.$color-background;
+        transform: translateX(-4px);
+      }
+
+      &:active {
+        transform: translateX(-2px);
+      }
+    }
+
+    @media screen and (min-width: 768px) {
+      top: 2rem;
+      left: 2rem;
+
+      a {
+        font-size: 1rem;
+        padding: 0.875rem 1.5rem;
+      }
+    }
+  }
 
   .store-title {
     font-family: vars.$font-tertiary;
@@ -19,7 +63,12 @@
     text-align: center;
     color: vars.$color-primary;
     margin-bottom: 1rem;
+    margin-top: 3rem;
     width: 100%;
+
+    @media screen and (min-width: 768px) {
+      margin-top: 0;
+    }
   }
 
   p {
@@ -65,5 +114,9 @@
     max-width: none;
     background: none;
     min-height: initial;
+
+    .breadcrumb {
+      display: none;
+    }
   }
 }

--- a/src/components/store/booking/BookingForm.jsx
+++ b/src/components/store/booking/BookingForm.jsx
@@ -6,7 +6,7 @@ import FormSelect from './FormSelect';
 import FormTextarea from './FormTextarea';
 import './BookingForm.scss';
 
-const BookingForm = ({ tours, locations }) => {
+const BookingForm = ({ tours, locations, prefilledTour = '' }) => {
   const [state, handleSubmit] = useForm("mlekgonz");
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
   const [formData, setFormData] = useState({
@@ -14,7 +14,7 @@ const BookingForm = ({ tours, locations }) => {
     email: '',
     phone: '',
     date: '',
-    tour: '',
+    tour: prefilledTour,
     location: '',
     message: '',
   });
@@ -24,6 +24,16 @@ const BookingForm = ({ tours, locations }) => {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  // Update tour field when prefilledTour changes
+  useEffect(() => {
+    if (prefilledTour) {
+      setFormData(prevData => ({
+        ...prevData,
+        tour: prefilledTour
+      }));
+    }
+  }, [prefilledTour]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -43,6 +53,12 @@ const BookingForm = ({ tours, locations }) => {
   return (
     <form onSubmit={handleSubmit} className="booking-form" aria-labelledby="booking-form-title">
       <h3 className="booking-form__title" id="booking-form-title">Request Form</h3>
+      
+      {prefilledTour && (
+        <p className="booking-form__prefill-notice">
+          ✨ Tour pre-selected: <strong>{prefilledTour}</strong>
+        </p>
+      )}
       
       <div className="booking-form__group">
         <FormInput 
@@ -168,6 +184,7 @@ const BookingForm = ({ tours, locations }) => {
 BookingForm.propTypes = {
   tours: PropTypes.arrayOf(PropTypes.string).isRequired,
   locations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  prefilledTour: PropTypes.string,
 };
 
 export default BookingForm;

--- a/src/components/store/booking/BookingForm.scss
+++ b/src/components/store/booking/BookingForm.scss
@@ -57,6 +57,27 @@
     }
   }
 
+  &__prefill-notice {
+    background: rgba(vars.$color-accent, 0.1);
+    border: 2px solid vars.$color-accent;
+    border-radius: vars.$border-radius-default;
+    padding: 1rem 1.5rem;
+    margin: -1rem 0 1rem;
+    font-size: 1rem;
+    color: vars.$color-primary;
+    animation: slideIn 0.5s ease-out;
+
+    strong {
+      color: vars.$color-accent;
+      font-weight: 600;
+    }
+
+    @include mixins.respond-to(lg) {
+      font-size: 1.1rem;
+      padding: 1.25rem 2rem;
+    }
+  }
+
   &__submit {
     @include mixins.button-styles;
 
@@ -135,6 +156,17 @@
   100% { transform: scale(1); opacity: 1; }
 }
 
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 // Print styles
 @media print {
   .booking-form {
@@ -146,6 +178,9 @@
       display: none;
     }
     &__title::after {
+      display: none;
+    }
+    &__prefill-notice {
       display: none;
     }
   }

--- a/src/components/unique/experiences/dreamdhow/DreamDhow.jsx
+++ b/src/components/unique/experiences/dreamdhow/DreamDhow.jsx
@@ -74,7 +74,7 @@ const DreamDhow = () => {
         whatsappLink="https://wa.me/message/YCOQDKJSDMXFD1"
       />
 
-      <BookNowSection ctaText="Book Now" ctaLink="/contact" />
+      <BookNowSection ctaText="Book Now" ctaLink="/booking" />
 
       <TourPackagesSection title="Our Tour Packages" tours={tourPackages} />
 

--- a/src/components/unique/experiences/dreamdhow/components/CTAButton.jsx
+++ b/src/components/unique/experiences/dreamdhow/components/CTAButton.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 
 /**
  * Reusable CTA Button Component
@@ -6,12 +7,17 @@ import PropTypes from "prop-types";
  * @param {string} props.href - Link destination
  * @param {string} props.children - Button text
  * @param {string} props.className - Additional CSS classes
+ * @param {Object} props.state - React Router state to pass
  */
-const CTAButton = ({ href, children, className = "" }) => {
+const CTAButton = ({ href, children, className = "", state = {} }) => {
   return (
-    <a href={href} className={`cta-button ${className}`}>
+    <Link 
+      to={href} 
+      className={`cta-button ${className}`}
+      state={state}
+    >
       {children}
-    </a>
+    </Link>
   );
 };
 
@@ -19,6 +25,7 @@ CTAButton.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  state: PropTypes.object,
 };
 
 export default CTAButton;

--- a/src/components/unique/experiences/dreamdhow/components/TourCard.jsx
+++ b/src/components/unique/experiences/dreamdhow/components/TourCard.jsx
@@ -66,7 +66,15 @@ const TourCard = ({
       <p>
         <strong>Kids:</strong> {kids}
       </p>
-      <CTAButton href={ctaLink}>{ctaText}</CTAButton>
+      <CTAButton 
+        href={ctaLink}
+        state={{
+          selectedTour: title,
+          fromDreamDhow: true,
+        }}
+      >
+        {ctaText}
+      </CTAButton>
     </div>
   );
 };

--- a/src/components/unique/experiences/dreamdhow/constants/tourData.js
+++ b/src/components/unique/experiences/dreamdhow/constants/tourData.js
@@ -82,7 +82,7 @@ export const getTourPackages = (
       '<strong>Private boat:</strong> from $185 to $110 p.p. · <strong>Shared:</strong> $95/person',
     kids: "0–4 free · 5–10 years $50",
     ctaText: "Book Mnemba Island",
-    ctaLink: "/contact",
+    ctaLink: "/booking",
   },
   {
     title: "Tumbatu Island",
@@ -95,7 +95,7 @@ export const getTourPackages = (
       '<strong>Private boat:</strong> from $185 to $110 p.p. · <strong>Shared:</strong> $95/person',
     kids: "0–4 free · 5–10 years $50",
     ctaText: "Book Tumbatu Island",
-    ctaLink: "/contact",
+    ctaLink: "/booking",
   },
   {
     title: "Romantic Sunset Cruise",
@@ -107,6 +107,6 @@ export const getTourPackages = (
     pricing: "",
     kids: "0–4 free · 5–10 years $50",
     ctaText: "Book Sunset Cruise",
-    ctaLink: "/contact",
+    ctaLink: "/booking",
   },
 ];

--- a/src/components/unique/experiences/dreamdhow/sections/BookNowSection.jsx
+++ b/src/components/unique/experiences/dreamdhow/sections/BookNowSection.jsx
@@ -16,7 +16,14 @@ const BookNowSection = ({ ctaText, ctaLink }) => {
       ref={bookNowRef}
       className={`book-now-section scale-in ${isAnimating ? "animate" : ""}`}
     >
-      <CTAButton href={ctaLink}>{ctaText}</CTAButton>
+      <CTAButton 
+        href={ctaLink}
+        state={{
+          fromDreamDhow: true,
+        }}
+      >
+        {ctaText}
+      </CTAButton>
     </div>
   );
 };


### PR DESCRIPTION
- Link all DreamDhow booking buttons to /booking route
- Pre-fill tour selection when navigating from DreamDhow
- Add breadcrumb navigation back to DreamDhow page
- Update CTAButton to use React Router Link with state
- Display pre-fill notice in booking form
- Auto-scroll to form when arriving from DreamDhow

Files: DreamDhow.jsx, tourData.js, CTAButton.jsx, TourCard.jsx, BookNowSection.jsx, Store.jsx, Store.scss, BookingForm.jsx, BookingForm.scss