### PR TITLE
Mobile UX pass: nav, planner, weather, filters, footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#1A4D6E" />
     <meta name="description" content="Destination Paradise offers bespoke excursions, luxury safaris, and unforgettable packages in Zanzibar & Tanzania." />
     <meta property="og:title" content="Destination Paradise — your next trip to paradise" />

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -24,6 +24,12 @@ const ThemeIcon = ({ theme }) => (
   )
 );
 
+const THEME_MODES = [
+  { mode: 'auto', label: 'Auto' },
+  { mode: 'light', label: 'Light' },
+  { mode: 'dark', label: 'Dark' },
+];
+
 const FOOTER_ICONS = {
   home: ['M3 10.5 12 3l9 7.5', 'M5 9.5V21h5v-6h4v6h5V9.5'],
   compass: ['M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z', 'm15.5 8.5-2 5-5 2 2-5 5-2Z'],
@@ -147,15 +153,71 @@ export function WhatsAppFab({ locationKey }) {
       style={placement.isParked ? { top: `${placement.top}px` } : undefined}
     >
       <WhatsAppIcon />
-      <span className="whatsapp-fab__dot" aria-hidden="true"></span>
       <span className="whatsapp-fab__label">Chat with the team</span>
     </a>
   );
 }
 
-export default function SiteFooter({ theme = 'light', onThemeToggle }) {
-  const nextTheme = theme === 'dark' ? 'light' : 'dark';
+const TYPED_TAGLINE = 'your next trip to paradise...';
 
+function TypedTagline() {
+  const [typed, setTyped] = useState('');
+  const [done, setDone] = useState(false);
+  const elRef = useRef(null);
+
+  useEffect(() => {
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) {
+      setTyped(TYPED_TAGLINE);
+      setDone(true);
+      return undefined;
+    }
+    const el = elRef.current;
+    if (!el || !('IntersectionObserver' in window)) {
+      setTyped(TYPED_TAGLINE);
+      setDone(true);
+      return undefined;
+    }
+    let timeoutId;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0].isIntersecting) return;
+        observer.disconnect();
+        let i = 0;
+        const tick = () => {
+          i += 1;
+          setTyped(TYPED_TAGLINE.slice(0, i));
+          if (i >= TYPED_TAGLINE.length) {
+            setDone(true);
+            return;
+          }
+          const pause = TYPED_TAGLINE[i - 1] === ' ' ? 80 : 48 + (i % 4) * 14;
+          timeoutId = window.setTimeout(tick, pause);
+        };
+        timeoutId = window.setTimeout(tick, 220);
+      },
+      { threshold: 0.4 },
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  return (
+    <p
+      ref={elRef}
+      className={`footer__script footer__script--typed${done ? ' is-done' : ''}`}
+      aria-label={TYPED_TAGLINE}
+    >
+      <span aria-hidden="true">{typed}</span>
+      <span className="footer__script-cursor" aria-hidden="true" />
+    </p>
+  );
+}
+
+export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThemeModeChange }) {
   return (
     <footer className="footer">
       <div className="footer__inner">
@@ -165,7 +227,7 @@ export default function SiteFooter({ theme = 'light', onThemeToggle }) {
             <span className="footer__logo-text">Destination Paradise<small>Zanzibar &amp; Tanzania</small></span>
           </div>
           <p>A small, local travel company on the shores of Zanzibar. Unhurried days, traditional boats, and guides who grew up here.</p>
-          <p className="footer__script">your next trip to paradise...</p>
+          <TypedTagline />
           <div className="footer__socials">
             <a href={WHATSAPP_URL} target="_blank" rel="noreferrer" aria-label="WhatsApp"><WhatsAppIcon /></a>
             <a href={SOCIAL_LINKS.instagram} target="_blank" rel="noreferrer" aria-label="Instagram"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75"><rect x="2" y="2" width="20" height="20" rx="5" /><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" /><line x1="17.5" y1="6.5" x2="17.51" y2="6.5" strokeWidth="2" /></svg></a>
@@ -208,15 +270,28 @@ export default function SiteFooter({ theme = 'light', onThemeToggle }) {
         </div>
       </div>
       <div className="footer__theme-row">
-        <button
-          className="footer__theme-toggle"
-          type="button"
-          aria-label={`Switch to ${nextTheme} theme`}
-          onClick={() => onThemeToggle?.(nextTheme)}
-        >
-          <ThemeIcon theme={theme} />
-          <span>{theme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
-        </button>
+        <div className="footer__theme-toggle" role="radiogroup" aria-label="Theme preference">
+          {THEME_MODES.map((option) => {
+            const isActive = themeMode === option.mode;
+            const iconTheme = option.mode === 'auto' ? theme : option.mode;
+            const label = option.mode === 'auto' ? `Auto ${theme}` : option.label;
+
+            return (
+              <button
+                key={option.mode}
+                className={`footer__theme-option${isActive ? ' is-active' : ''}`}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                aria-label={`${label} mode`}
+                onClick={() => onThemeModeChange?.(option.mode)}
+              >
+                <ThemeIcon theme={iconTheme} />
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
       <div className="footer__bottom">
         <span className="footer__copyright">© {new Date().getFullYear()} Destination Paradise · Zanzibar, Tanzania</span>

--- a/src/components/SiteLayout.jsx
+++ b/src/components/SiteLayout.jsx
@@ -3,29 +3,49 @@ import { Outlet, useLocation } from 'react-router-dom';
 import SiteNav from './SiteNav.jsx';
 import SiteFooter, { WhatsAppFab } from './SiteFooter.jsx';
 import PageScrollCue from './PageScrollCue.jsx';
-import { announceTheme, applyTheme, persistTheme, readStoredTheme } from '../utils/theme.js';
+import {
+  announceTheme,
+  applyTheme,
+  normalizeThemeMode,
+  persistThemeMode,
+  readStoredThemeMode,
+  resolveThemeForMode,
+  watchAutomaticTheme,
+} from '../utils/theme.js';
 
 export default function SiteLayout() {
   const location = useLocation();
-  const [theme, setTheme] = useState(readStoredTheme);
+  const [themeState, setThemeState] = useState(() => {
+    const mode = readStoredThemeMode();
+    return { mode, theme: resolveThemeForMode(mode) };
+  });
+  const { mode, theme } = themeState;
 
   useEffect(() => {
     const nextTheme = applyTheme(theme);
-    persistTheme(nextTheme);
-    announceTheme(nextTheme);
-  }, [theme]);
+    persistThemeMode(mode, nextTheme);
+    announceTheme(nextTheme, mode);
+  }, [mode, theme]);
 
   useEffect(() => {
-    const onThemeChange = (event) => {
-      const nextTheme = event.detail?.theme;
-      if (nextTheme) setTheme((current) => (current === nextTheme ? current : nextTheme));
-    };
-    window.addEventListener('dp-theme-change', onThemeChange);
-    return () => window.removeEventListener('dp-theme-change', onThemeChange);
-  }, []);
+    if (mode !== 'auto') return undefined;
 
-  const toggleTheme = (nextTheme) => {
-    setTheme((current) => nextTheme || (current === 'dark' ? 'light' : 'dark'));
+    return watchAutomaticTheme((nextTheme) => {
+      setThemeState((current) => {
+        if (current.mode !== 'auto' || current.theme === nextTheme) return current;
+        return { ...current, theme: nextTheme };
+      });
+    });
+  }, [mode]);
+
+  const setThemeMode = (nextMode) => {
+    const normalizedMode = normalizeThemeMode(nextMode);
+    const nextTheme = resolveThemeForMode(normalizedMode, theme);
+    setThemeState((current) => (
+      current.mode === normalizedMode && current.theme === nextTheme
+        ? current
+        : { mode: normalizedMode, theme: nextTheme }
+    ));
   };
 
   useEffect(() => {
@@ -50,7 +70,7 @@ export default function SiteLayout() {
     <>
       <SiteNav />
       <Outlet />
-      <SiteFooter theme={theme} onThemeToggle={toggleTheme} />
+      <SiteFooter theme={theme} themeMode={mode} onThemeModeChange={setThemeMode} />
       <PageScrollCue />
       <WhatsAppFab locationKey={`${location.pathname}${location.hash}`} />
     </>

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -45,32 +45,32 @@ export default function SiteNav() {
       const focusable = navRef.current.querySelectorAll(
         'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select'
       );
-      
-      if (focusable.length > 0) {
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
 
-        const handleTab = (e) => {
-          if (e.key === 'Tab') {
-            if (e.shiftKey && document.activeElement === first) {
-              e.preventDefault();
-              last.focus();
-            } else if (!e.shiftKey && document.activeElement === last) {
-              e.preventDefault();
-              first.focus();
-            }
+      const handleKey = (e) => {
+        if (e.key === 'Escape') {
+          setNavOpen(false);
+          return;
+        }
+        if (e.key === 'Tab' && focusable.length > 0) {
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
           }
-        };
-        
-        document.addEventListener('keydown', handleTab);
-        return () => {
-          document.body.style.overflow = '';
-          document.removeEventListener('keydown', handleTab);
-        };
-      }
-    } else {
-      document.body.style.overflow = '';
+        }
+      };
+
+      document.addEventListener('keydown', handleKey);
+      return () => {
+        document.body.style.overflow = '';
+        document.removeEventListener('keydown', handleKey);
+      };
     }
+    document.body.style.overflow = '';
     return () => { document.body.style.overflow = ''; };
   }, [navOpen]);
 
@@ -87,6 +87,15 @@ export default function SiteNav() {
           <img src="/assets/brand/destination-paradise-logo-96.webp" alt="Destination Paradise" width="48" height="48" decoding="async" />
           <span className="nav__logo-text">Destination Paradise<small>Zanzibar &amp; Tanzania</small></span>
         </Link>
+        {navOpen && (
+          <button
+            type="button"
+            className="nav__backdrop"
+            aria-label="Close menu"
+            tabIndex={-1}
+            onClick={() => setNavOpen(false)}
+          />
+        )}
         <ul className={`nav__menu${navOpen ? ' nav__menu--open' : ''}`} id="navMenu" onClick={closeMenuFromLink}>
           {NAV_ITEMS.map((item) => (
             <li className={`nav__item${item.mobileOnly ? ' nav__item--mobile-only' : ''}`} key={item.to}>
@@ -105,22 +114,18 @@ export default function SiteNav() {
             <span className="nav__cta-text">Book Now</span> <BookingIcon size={16} />
           </Link>
           <button
-            className="nav__burger"
+            className={`nav__burger${navOpen ? ' nav__burger--open' : ''}`}
             type="button"
             aria-label={navOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={navOpen}
             aria-controls="navMenu"
             onClick={() => setNavOpen((v) => !v)}
           >
-            {navOpen ? (
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            ) : (
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-              </svg>
-            )}
+            <span className="nav__burger-box" aria-hidden="true">
+              <span className="nav__burger-line" />
+              <span className="nav__burger-line" />
+              <span className="nav__burger-line" />
+            </span>
           </button>
         </div>
       </div>

--- a/src/components/homepage/PlannerSection.jsx
+++ b/src/components/homepage/PlannerSection.jsx
@@ -105,6 +105,8 @@ export default function PlannerSection({ initialPrompt }) {
     const contact = extractContact(finalHistory);
     if (!contact.email) {
       handoffInflightRef.current = false;
+      setHandoffState('error');
+      setHandoffError('Share your email in the chat first so we can reply.');
       return;
     }
 
@@ -212,7 +214,7 @@ export default function PlannerSection({ initialPrompt }) {
           </div>
         </div>
 
-        <div className="planner__chat" key={resetKey}>
+        <div className="planner__chat" id="planner-chat" key={resetKey}>
           <header className="planner__header">
             <div className="planner__avatar">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
@@ -305,8 +307,8 @@ export default function PlannerSection({ initialPrompt }) {
               rows={1}
               placeholder={
                 handoffState === 'sent' || handoffState === 'updated'
-                  ? 'Need to update? Type the change here…'
-                  : "Tell me what you're dreaming of…"
+                  ? 'Type an update here…'
+                  : 'Tell me your dream trip…'
               }
               value={input}
               onChange={(e) => {
@@ -330,8 +332,22 @@ export default function PlannerSection({ initialPrompt }) {
               </svg>
             </button>
           </form>
-          <footer className="planner__foot planner__foot--simple">
-            <span>Itineraries are drafts. A human reviews and prices everything before you book.</span>
+          <footer className="planner__foot">
+            <span className="planner__foot-note">Itineraries are drafts. A human reviews and prices everything before you book.</span>
+            <button
+              type="button"
+              className="planner__handoff"
+              onClick={() => submitHandoff(history)}
+              disabled={
+                isInputBusy ||
+                handoffState === 'sent' ||
+                history.filter((m) => m.role === 'user').length < 1
+              }
+            >
+              {handoffState === 'sent' || handoffState === 'updated'
+                ? 'Sent to team ✓'
+                : 'Send to team'}
+            </button>
           </footer>
         </div>
       </div>

--- a/src/components/homepage/WeatherSection.jsx
+++ b/src/components/homepage/WeatherSection.jsx
@@ -1,4 +1,176 @@
+import { useEffect, useState } from 'react';
+
+const STONE_TOWN_LAT = -6.165;
+const STONE_TOWN_LON = 39.199;
+const TIMEZONE = 'Africa/Dar_es_Salaam';
+
+const FALLBACK = {
+  temp: 29,
+  humidity: 74,
+  seaTemp: 27,
+  sunrise: '06:24',
+  sunset: '18:36',
+  code: 1,
+  isDay: 1,
+  description:
+    'Mostly sunny with a soft Indian Ocean breeze. The long rains are easing — mornings are clear, and the reef visibility holds through early afternoon.',
+};
+
+const describe = (code, isDay) => {
+  const nightClear = 'Clear night over the channel — warm air, gentle breeze off the reef.';
+  if (code === 0) return isDay ? 'Clear skies and steady Indian Ocean breeze — ideal beach and snorkeling conditions.' : nightClear;
+  if (code === 1) return isDay ? 'Mostly sunny with high cloud — reef visibility holds through the afternoon.' : 'Mostly clear night with high cloud — warm and calm.';
+  if (code === 2) return isDay ? 'Partly cloudy with warm trade winds — comfortable beach and dhow conditions.' : 'Partly cloudy night — soft trade winds and warm air.';
+  if (code === 3) return isDay ? 'Overcast but warm — good light for Stone Town walks and spice tours.' : 'Overcast and warm tonight — calm seas expected by morning.';
+  if (code === 45 || code === 48) return 'Coastal fog easing through the morning — clearer by midday.';
+  if (code >= 51 && code <= 57) return 'Light drizzle drifting in from the channel — short, warm, and passing.';
+  if (code >= 61 && code <= 67) return 'Rain showers passing through — typical of the long rains, mornings often clear.';
+  if (code >= 80 && code <= 82) return 'Tropical showers between sunny spells — bring a light layer.';
+  if (code >= 95) return 'Thunderstorms expected — best to plan indoor time at Stone Town or the spa.';
+  return FALLBACK.description;
+};
+
+function WeatherIcon({ code, isDay }) {
+  const common = {
+    width: 90,
+    height: 90,
+    viewBox: '0 0 64 64',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.5,
+    strokeLinecap: 'round',
+    strokeLinejoin: 'round',
+  };
+  const fillSoft = 'rgba(255,111,97,.2)';
+  const fillMoon = 'rgba(207, 225, 238, .25)';
+
+  const clearDay = (
+    <svg {...common} className="wx-icon wx-icon--sun">
+      <g className="wx-sun-rays">
+        <path d="M32 8v6M32 50v6M12 32H6M58 32h-6M17 17l-4-4M51 51l-4-4M17 47l-4 4M51 13l-4 4" />
+      </g>
+      <circle className="wx-sun-disc" cx="32" cy="32" r="11" fill={fillSoft} />
+    </svg>
+  );
+  const clearNight = (
+    <svg {...common} className="wx-icon wx-icon--moon">
+      <path className="wx-moon" d="M44 36a16 16 0 1 1-16-22 12 12 0 0 0 16 16c0 2-.05 4-.05 6Z" fill={fillMoon} />
+      <circle className="wx-star wx-star--1" cx="50" cy="18" r="1.2" fill="currentColor" stroke="none" />
+      <circle className="wx-star wx-star--2" cx="14" cy="14" r="1" fill="currentColor" stroke="none" />
+      <circle className="wx-star wx-star--3" cx="56" cy="32" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+  const partlyDay = (
+    <svg {...common} className="wx-icon wx-icon--partly-day">
+      <g className="wx-sun-rays">
+        <path d="M22 10v4M10 24H6M14 14l-3-3M30 14l3-3" />
+      </g>
+      <circle className="wx-sun-disc" cx="22" cy="24" r="8" fill={fillSoft} />
+      <path className="wx-cloud" d="M26 40a8 8 0 0 1 15-3 6 6 0 0 1 1 12H28a6 6 0 0 1-2-9Z" fill="rgba(207,225,238,.15)" />
+    </svg>
+  );
+  const partlyNight = (
+    <svg {...common} className="wx-icon wx-icon--partly-night">
+      <path className="wx-moon" d="M30 22a10 10 0 1 1-10-14 8 8 0 0 0 10 10v4Z" fill={fillMoon} />
+      <path className="wx-cloud" d="M26 40a8 8 0 0 1 15-3 6 6 0 0 1 1 12H28a6 6 0 0 1-2-9Z" fill="rgba(207,225,238,.15)" />
+    </svg>
+  );
+  const cloudy = (
+    <svg {...common} className="wx-icon wx-icon--cloud">
+      <path className="wx-cloud wx-cloud--solo" d="M18 40a10 10 0 0 1 19-4 8 8 0 0 1 1 16H20a8 8 0 0 1-2-12Z" fill="rgba(207,225,238,.18)" />
+    </svg>
+  );
+  const fog = (
+    <svg {...common} className="wx-icon wx-icon--fog">
+      <path className="wx-cloud wx-cloud--solo" d="M18 32a10 10 0 0 1 19-4 8 8 0 0 1 1 16H20a8 8 0 0 1-2-12Z" fill="rgba(207,225,238,.18)" />
+      <path className="wx-fog-line wx-fog-line--1" d="M14 48h36" />
+      <path className="wx-fog-line wx-fog-line--2" d="M18 54h28" />
+    </svg>
+  );
+  const rain = (
+    <svg {...common} className="wx-icon wx-icon--rain">
+      <path className="wx-cloud wx-cloud--solo" d="M18 32a10 10 0 0 1 19-4 8 8 0 0 1 1 16H20a8 8 0 0 1-2-12Z" fill="rgba(207,225,238,.2)" />
+      <path className="wx-drop wx-drop--1" d="M22 50l-2 6" />
+      <path className="wx-drop wx-drop--2" d="M32 50l-2 6" />
+      <path className="wx-drop wx-drop--3" d="M42 50l-2 6" />
+    </svg>
+  );
+  const storm = (
+    <svg {...common} className="wx-icon wx-icon--storm">
+      <path className="wx-cloud wx-cloud--solo" d="M18 30a10 10 0 0 1 19-4 8 8 0 0 1 1 16H20a8 8 0 0 1-2-12Z" fill="rgba(255,111,97,.18)" />
+      <path className="wx-bolt" d="M30 44l-4 8h6l-3 8" />
+    </svg>
+  );
+
+  if (code === 0) return isDay ? clearDay : clearNight;
+  if (code === 1) return isDay ? clearDay : clearNight;
+  if (code === 2) return isDay ? partlyDay : partlyNight;
+  if (code === 3) return cloudy;
+  if (code === 45 || code === 48) return fog;
+  if (code >= 51 && code <= 67) return rain;
+  if (code >= 80 && code <= 82) return rain;
+  if (code >= 95) return storm;
+  return isDay ? clearDay : clearNight;
+}
+
+const formatTime = (iso) => {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: TIMEZONE,
+  }).format(date);
+};
+
 export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
+  const [weather, setWeather] = useState(FALLBACK);
+  const [isLive, setIsLive] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const forecastUrl = `https://api.open-meteo.com/v1/forecast?latitude=${STONE_TOWN_LAT}&longitude=${STONE_TOWN_LON}&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,is_day&daily=sunrise,sunset&timezone=${encodeURIComponent(TIMEZONE)}`;
+    const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${STONE_TOWN_LAT}&longitude=${STONE_TOWN_LON}&hourly=sea_surface_temperature&timezone=${encodeURIComponent(TIMEZONE)}`;
+
+    Promise.all([
+      fetch(forecastUrl).then((r) => (r.ok ? r.json() : Promise.reject(new Error('forecast')))),
+      fetch(marineUrl).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+    ])
+      .then(([forecast, marine]) => {
+        if (cancelled || !forecast?.current) return;
+        const current = forecast.current;
+        const daily = forecast.daily || {};
+        const nowHour = new Date().getHours();
+        const seaSeries = marine?.hourly?.sea_surface_temperature;
+        const seaTempRaw = Array.isArray(seaSeries) ? seaSeries[nowHour] : null;
+
+        const isDay = current.is_day === 1 ? 1 : 0;
+        const tempSource = typeof current.apparent_temperature === 'number'
+          ? current.apparent_temperature
+          : current.temperature_2m;
+        setWeather({
+          temp: Math.round(tempSource),
+          humidity: Math.round(current.relative_humidity_2m),
+          seaTemp: typeof seaTempRaw === 'number' ? Math.round(seaTempRaw) : FALLBACK.seaTemp,
+          sunrise: formatTime(daily.sunrise?.[0]) || FALLBACK.sunrise,
+          sunset: formatTime(daily.sunset?.[0]) || FALLBACK.sunset,
+          code: current.weather_code,
+          isDay,
+          description: describe(current.weather_code, isDay),
+        });
+        setIsLive(true);
+      })
+      .catch(() => {
+        /* keep fallback */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section className="weather reveal" id="weather">
       <div className="weather-card">
@@ -7,18 +179,15 @@ export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
               <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0z" /><circle cx="12" cy="10" r="3" />
             </svg>
-            Stone Town, Zanzibar · Live
+            Stone Town, Zanzibar{isLive ? ' · Live' : ''}
           </div>
           <div className="weather__row">
             <div className="weather__icon">
-              <svg width="90" height="90" viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                <circle cx="32" cy="32" r="11" fill="rgba(255,111,97,.2)" />
-                <path d="M32 8v6M32 50v6M12 32H6M58 32h-6M17 17l-4-4M51 51l-4-4M17 47l-4 4M51 13l-4 4" />
-              </svg>
+              <WeatherIcon code={weather.code} isDay={weather.isDay} />
             </div>
-            <div className="weather__temp">29<sup>°</sup></div>
+            <div className="weather__temp">{weather.temp}<sup>°</sup></div>
           </div>
-          <p className="weather__desc">Mostly sunny with a soft Indian Ocean breeze. The long rains are easing — mornings are clear, and the reef visibility holds through early afternoon.</p>
+          <p className="weather__desc">{weather.description}</p>
           <div className="weather__facts">
             <div className="weather-fact">
               <div className="weather-fact__head">
@@ -29,7 +198,7 @@ export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
                 </svg>
                 <div className="weather-fact__label">Sea temp</div>
               </div>
-              <div className="weather-fact__value">27°C</div>
+              <div className="weather-fact__value">{weather.seaTemp}°C</div>
             </div>
             <div className="weather-fact">
               <div className="weather-fact__head">
@@ -38,7 +207,7 @@ export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
                 </svg>
                 <div className="weather-fact__label">Humidity</div>
               </div>
-              <div className="weather-fact__value">74%</div>
+              <div className="weather-fact__value">{weather.humidity}%</div>
             </div>
             <div className="weather-fact">
               <div className="weather-fact__head">
@@ -54,7 +223,7 @@ export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
                 </svg>
                 <div className="weather-fact__label">Sunrise</div>
               </div>
-              <div className="weather-fact__value">06:24</div>
+              <div className="weather-fact__value">{weather.sunrise}</div>
             </div>
             <div className="weather-fact">
               <div className="weather-fact__head">
@@ -70,7 +239,7 @@ export default function WeatherSection({ MONTHS, SCORES, NOW_MONTH }) {
                 </svg>
                 <div className="weather-fact__label">Sunset</div>
               </div>
-              <div className="weather-fact__value">18:36</div>
+              <div className="weather-fact__value">{weather.sunset}</div>
             </div>
           </div>
         </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,10 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
+import { applyTheme, readStoredTheme } from './utils/theme.js';
 import './styles/tokens.css';
+
+applyTheme(readStoredTheme());
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -17,7 +17,7 @@ const MapSection = lazy(() => import('../components/homepage/MapSection.jsx'));
 const PlannerSection = lazy(() => import('../components/homepage/PlannerSection.jsx'));
 import ContactSection from '../components/homepage/ContactSection.jsx';
 import NewsletterSection from '../components/homepage/NewsletterSection.jsx';
-import { announceTheme, applyTheme, normalizeTheme, readStoredTweaks } from '../utils/theme.js';
+import { readStoredTheme, readStoredThemeMode, readStoredTweaks } from '../utils/theme.js';
 
 const PINS = DESTINATION_MAP_PINS;
 
@@ -42,13 +42,15 @@ const MONTHS = [
 const SCORES = [72, 78, 62, 42, 56, 82, 92, 95, 90, 80, 55, 68];
 const NOW_MONTH = new Date().getMonth();
 
-const TWEAKS_DEFAULTS = { hero: 'photo', layout: '3up', theme: 'light' };
+const TWEAKS_DEFAULTS = { hero: 'photo', layout: '3up', theme: 'light', themeMode: 'auto' };
 const BEST_SELLING_EXCURSION_IDS = ['safari-blue', 'mnemba', 'spice-tour'];
 
 function loadTweaks() {
+  const theme = readStoredTheme();
+  const themeMode = readStoredThemeMode();
   const saved = readStoredTweaks();
-  if (saved) return { ...TWEAKS_DEFAULTS, ...saved, theme: normalizeTheme(saved.theme) };
-  return { ...TWEAKS_DEFAULTS };
+  if (saved) return { ...TWEAKS_DEFAULTS, ...saved, theme, themeMode };
+  return { ...TWEAKS_DEFAULTS, theme, themeMode };
 }
 
 export default function Homepage() {
@@ -58,17 +60,22 @@ export default function Homepage() {
   const [tweaksGearVisible, setTweaksGearVisible] = useState(false);
   const [plannerPrompt, setPlannerPrompt] = useState(null);
 
-  // Persist theme + tweaks
+  // Persist design-preview tweaks. The active theme is managed globally.
   useEffect(() => {
-    const nextTheme = applyTheme(tweaks.theme);
-    try { localStorage.setItem('dp_tweaks', JSON.stringify({ ...tweaks, theme: nextTheme })); } catch (e) { /* noop */ }
-    announceTheme(nextTheme);
+    try { localStorage.setItem('dp_tweaks', JSON.stringify(tweaks)); } catch (e) { /* noop */ }
   }, [tweaks]);
 
   useEffect(() => {
     const onThemeChange = (event) => {
       const theme = event.detail?.theme;
-      if (theme) setTweaks((current) => (current.theme === theme ? current : { ...current, theme }));
+      const themeMode = event.detail?.mode;
+      if (theme) {
+        setTweaks((current) => (
+          current.theme === theme && (!themeMode || current.themeMode === themeMode)
+            ? current
+            : { ...current, theme, ...(themeMode ? { themeMode } : {}) }
+        ));
+      }
     };
     window.addEventListener('dp-theme-change', onThemeChange);
     return () => window.removeEventListener('dp-theme-change', onThemeChange);
@@ -156,7 +163,8 @@ export default function Homepage() {
       id: Date.now(),
       text: `I'm looking for ${experienceText}${dateText} for ${guests}. Can you suggest the best fit and ask me anything else you need?`,
     });
-    document.getElementById('planner')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const target = document.getElementById('planner-chat') || document.getElementById('planner');
+    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   const islandPins = PINS.filter((p) => p.region === 'Zanzibar');
@@ -206,7 +214,6 @@ export default function Homepage() {
         {[
           { key: 'hero', label: 'Hero variant', opts: [['photo', 'Photo'], ['split', 'Split'], ['video', 'Video']] },
           { key: 'layout', label: 'Excursion layout', opts: [['3up', '3-up'], ['2up', 'Feature'], ['carousel', 'Carousel']] },
-          { key: 'theme', label: 'Theme', opts: [['light', 'Light'], ['dark', 'Dark']] },
         ].map((g) => (
           <div className="tweaks-group" key={g.key}>
             <label className="tweaks-group__label">{g.label}</label>

--- a/src/styles/excursions.css
+++ b/src/styles/excursions.css
@@ -665,34 +665,24 @@ html[data-theme="dark"] .exc-prac {
   .exc-filter {
     position: static;
     max-width: none;
-    margin: 0 -1rem 1.65rem;
-    padding: .2rem 1rem 1.05rem;
+    margin: 0 0 1.5rem;
+    padding: .2rem 0 0;
     display: flex;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    gap: .5rem;
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    scroll-snap-type: x proximity;
-    scrollbar-width: none;
-  }
-
-  .exc-grid-wrap > .exc-filter::-webkit-scrollbar,
-  .exc-filter::-webkit-scrollbar {
-    display: none;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: .45rem;
+    overflow: visible;
   }
 
   .exc-filter__btn {
     flex: 0 0 auto;
-    min-height: 42px;
-    scroll-snap-align: start;
-    padding: .56rem .82rem;
+    min-height: 38px;
+    padding: .45rem .75rem;
     border-color: color-mix(in srgb, var(--text-soft) 62%, transparent);
     background: var(--surface);
     color: var(--text-soft);
     opacity: 1;
-    font-size: .86rem;
+    font-size: .82rem;
     line-height: 1.1;
     white-space: nowrap;
   }

--- a/src/styles/homepage/floating-chat.css
+++ b/src/styles/homepage/floating-chat.css
@@ -42,12 +42,32 @@
   outline: 3px solid rgba(37, 211, 102, .28);
   outline-offset: 3px;
 }
-.whatsapp-fab__dot {
-  width: 7px; height: 7px; border-radius: 50%; background: #25D366;
-  box-shadow: 0 0 0 3px rgba(37, 211, 102, .18);
+.whatsapp-fab::before,
+.whatsapp-fab::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid rgba(37, 211, 102, .55);
+  pointer-events: none;
+  animation: whatsapp-fab-pulse 2.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
 }
-.whatsapp-fab:hover .whatsapp-fab__dot,
-.whatsapp-fab:focus-visible .whatsapp-fab__dot {
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, .2);
+.whatsapp-fab::after {
+  animation-delay: 1.3s;
+}
+.whatsapp-fab:hover::before,
+.whatsapp-fab:hover::after,
+.whatsapp-fab:focus-visible::before,
+.whatsapp-fab:focus-visible::after {
+  animation-play-state: paused;
+  opacity: 0;
+}
+@keyframes whatsapp-fab-pulse {
+  0%   { transform: scale(1);    opacity: .65; }
+  70%  { transform: scale(1.35); opacity: 0; }
+  100% { transform: scale(1.35); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .whatsapp-fab::before,
+  .whatsapp-fab::after { animation: none; opacity: 0; }
 }

--- a/src/styles/homepage/footer.css
+++ b/src/styles/homepage/footer.css
@@ -41,34 +41,71 @@
 [data-theme="dark"] .footer__brand .footer__script {
   color: var(--dp-accent);
 }
+.footer__script--typed { display: inline-flex; align-items: baseline; min-height: 1.4em; }
+.footer__script-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 2px;
+  background: currentColor;
+  vertical-align: text-bottom;
+  animation: footer-script-blink 1.05s steps(1) infinite;
+}
+.footer__script--typed.is-done .footer__script-cursor {
+  animation: footer-script-blink 1.05s steps(1) infinite;
+  opacity: .55;
+}
+@keyframes footer-script-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .footer__script-cursor { animation: none; opacity: 0; }
+}
 .footer__theme-toggle {
   min-height: 42px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: .55rem;
-  padding: .55rem .85rem;
+  gap: .25rem;
+  padding: .25rem;
   border-radius: 999px;
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--surface-raised) 92%, transparent);
   color: var(--text-soft);
-  cursor: pointer;
   font-family: var(--dp-font-sans);
   font-size: 13px;
   font-weight: 700;
-  transition: color .25s ease, border-color .25s ease, background .25s ease, transform .25s ease;
 }
-.footer__theme-toggle:hover,
-.footer__theme-toggle:focus-visible {
+.footer__theme-option {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .45rem;
+  padding: .42rem .7rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  transition: color .25s ease, background .25s ease, transform .25s ease;
+}
+.footer__theme-option:hover,
+.footer__theme-option:focus-visible {
   color: var(--dp-accent);
-  border-color: var(--dp-accent);
   background: color-mix(in srgb, var(--dp-accent) 8%, var(--surface-raised));
 }
-.footer__theme-toggle:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--dp-accent) 22%, transparent);
-  outline-offset: 3px;
+.footer__theme-option.is-active {
+  color: var(--dp-accent);
+  background: color-mix(in srgb, var(--dp-accent) 14%, var(--surface-raised));
 }
-.footer__theme-toggle svg { flex-shrink: 0; }
+.footer__theme-option:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--dp-accent) 22%, transparent);
+  outline-offset: 2px;
+}
+.footer__theme-option svg { flex-shrink: 0; }
 .footer__theme-row {
   max-width: 1240px;
   margin: 2rem auto 0;

--- a/src/styles/homepage/mobile.css
+++ b/src/styles/homepage/mobile.css
@@ -15,9 +15,12 @@ html, body { max-width: 100%; }
   overflow-wrap: anywhere;
 }
 
-/* ---- Nav: keep CTA compact, give burger a real tap target ---- */
-.nav__cta { padding: .55rem .95rem; font-size: 13px; white-space: nowrap; }
-.nav__burger { padding: .6rem; min-width: 44px; min-height: 44px; }
+/* ---- Nav: burger gets a real tap target; CTA hides on mobile (menu has Book) ---- */
+.nav__burger { padding: 0; min-width: 44px; min-height: 44px; }
+
+@media (max-width: 960px) {
+  .nav__cta { display: none; }
+}
 
 @media (max-width: 720px) {
   .nav { padding: .65rem 1rem .65rem 1.6rem; gap: .5rem; }
@@ -25,19 +28,14 @@ html, body { max-width: 100%; }
   .nav__logo-text { font-size: 1rem; white-space: nowrap; }
   .nav__logo-text small { font-size: 8px; letter-spacing: .2em; }
   .nav__right { gap: .45rem; }
-  .nav__cta { padding: .5rem .8rem; font-size: 12px; }
 }
 
-/* Below ~480 the CTA still bloats — shrink to icon-only */
 @media (max-width: 480px) {
-  .nav__cta-text { display: none; }
-  .nav__cta { padding: .55rem .65rem; gap: 0; }
   .nav__logo-text small { display: none; }
   .nav__logo-text { font-size: .95rem; }
 }
 
 @media (max-width: 360px) {
-  .nav__cta { display: none; } /* burger already exposes Book in menu */
   .nav__logo img { height: 32px; }
 }
 
@@ -509,16 +507,17 @@ html, body { max-width: 100%; }
   .footer__inner { gap: 1.5rem; }
   .footer__col h4 { margin-bottom: .65rem; }
   .footer__col ul { gap: .5rem; }
-  .footer__theme-row { margin-top: 1.5rem; justify-content: flex-start; }
+  .footer__theme-row { margin-top: 1.5rem; justify-content: center; }
   .footer__bottom {
     margin-top: 1.75rem; padding-top: 1rem;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: .8rem;
-    text-align: left;
+    text-align: center;
   }
+  .footer__policy-links { display: inline-flex; flex-wrap: wrap; justify-content: center; gap: .85rem; }
   .footer__policy-links a:first-child { margin-left: 0; }
-  .footer__bottom a { margin-left: 0; margin-right: .85rem; }
+  .footer__bottom a { margin-left: 0; margin-right: 0; }
 }
 
 /* ---- WhatsApp FAB: shrink to icon-only on phones ---- */
@@ -573,6 +572,5 @@ html, body { max-width: 100%; }
 
 /* ---- Tap-target floor for small icon buttons ---- */
 @media (max-width: 720px) {
-  .nav__item a { padding: .55rem 0; }
   .planner__reset { width: 36px; height: 36px; }
 }

--- a/src/styles/homepage/nav.css
+++ b/src/styles/homepage/nav.css
@@ -2,12 +2,18 @@
 .nav {
   position: fixed; top: 0; left: 0; right: 0; z-index: 1000;
   padding: 0.62rem clamp(1rem, 3vw, 2.25rem);
-  background: var(--page-bg);
+  border-bottom: 1px solid var(--border);
+  min-height: var(--nav-height);
+}
+.nav::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   background: color-mix(in srgb, var(--page-bg) 82%, transparent);
   backdrop-filter: saturate(1.4) blur(14px);
   -webkit-backdrop-filter: saturate(1.4) blur(14px);
-  border-bottom: 1px solid var(--border);
-  min-height: var(--nav-height);
+  pointer-events: none;
 }
 .nav__inner {
   width: min(100%, 1200px);
@@ -57,47 +63,113 @@
 
 .nav__right { display: flex; align-items: center; gap: 1rem; }
 
-.nav__burger { display: none; background: transparent; border: none; color: var(--text); cursor: pointer; padding: .4rem; }
+.nav__burger {
+  display: none;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: -.2rem;
+}
+.nav__burger-box {
+  position: relative;
+  display: inline-block;
+  width: 22px;
+  height: 16px;
+}
+.nav__burger-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  transition: transform .3s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity .2s ease,
+              top .3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.nav__burger-line:nth-child(1) { top: 0; }
+.nav__burger-line:nth-child(2) { top: 50%; transform: translateY(-50%); }
+.nav__burger-line:nth-child(3) { top: 100%; transform: translateY(-100%); }
+.nav__burger--open .nav__burger-line:nth-child(1) {
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+.nav__burger--open .nav__burger-line:nth-child(2) {
+  opacity: 0;
+  transform: translateY(-50%) scaleX(.2);
+}
+.nav__burger--open .nav__burger-line:nth-child(3) {
+  top: 50%;
+  transform: translateY(-50%) rotate(-45deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav__burger-line { transition: none; }
+}
+.nav__backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 30, 46, .28);
+  border: none;
+  padding: 0;
+  cursor: default;
+  z-index: 1;
+}
 @media (max-width: 960px) {
+  .nav__backdrop { display: block; }
+  .nav__cta { display: none; }
+  .nav__logo, .nav__right { position: relative; z-index: 3; }
   .nav__menu {
-    position: absolute; top: 100%; left: 0; right: 0;
-    height: calc(100dvh - var(--nav-height));
-    overflow-y: auto;
+    position: fixed; inset: 0;
+    overflow: hidden;
     overscroll-behavior: contain;
-    flex-direction: column; gap: .72rem;
-    justify-content: flex-start; align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(.4rem, 1.2vh, .7rem);
+    justify-content: center; align-items: stretch;
     background: var(--page-bg);
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);
     border-bottom: none;
-    padding: 1rem clamp(.9rem, 4vw, 1.4rem) calc(1.25rem + env(safe-area-inset-bottom, 0px));
-    box-shadow: 0 26px 52px rgba(8, 30, 46, .12);
+    padding: calc(var(--nav-height) + clamp(.6rem, 1.4vh, 1rem)) clamp(.9rem, 4vw, 1.4rem) calc(clamp(.8rem, 2vh, 1.25rem) + env(safe-area-inset-bottom, 0px));
+    box-shadow: none;
     transform: translateY(-10px); opacity: 0; pointer-events: none;
-    transition: all .3s cubic-bezier(0.22, 1, 0.36, 1);
+    transition: opacity .3s cubic-bezier(0.22, 1, 0.36, 1), transform .3s cubic-bezier(0.22, 1, 0.36, 1);
+    z-index: 2;
   }
   .nav__menu--open { transform: translateY(0); opacity: 1; pointer-events: auto; }
+  .nav__item { display: flex; }
   .nav__item a {
+    flex: 1 1 auto;
     width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
     display: grid;
-    grid-template-columns: 42px minmax(0, 1fr);
-    gap: .82rem;
+    grid-template-columns: 40px minmax(0, 1fr);
+    column-gap: .85rem;
     align-items: center;
-    padding: .82rem .9rem;
+    padding: .7rem .9rem;
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 12px;
     background: var(--surface);
     box-shadow: 0 12px 28px -28px rgba(8, 30, 46, .55);
-    font-size: 1rem;
+    font-size: .98rem;
     font-weight: 700;
     line-height: 1.15;
   }
   .nav__item a::after { display: none; }
   .nav__link-icon {
-    width: 42px;
-    height: 42px;
+    width: 40px;
+    height: 40px;
     display: inline-grid;
     place-items: center;
-    border-radius: 8px;
+    border-radius: 10px;
     color: var(--dp-accent);
     background: color-mix(in srgb, var(--dp-accent) 10%, transparent);
     border: 1px solid color-mix(in srgb, var(--dp-accent) 22%, transparent);
@@ -105,7 +177,8 @@
   .nav__link-copy {
     min-width: 0;
     display: grid;
-    gap: .18rem;
+    gap: .12rem;
+    align-content: center;
   }
   .nav__link-label {
     color: currentColor;
@@ -114,9 +187,10 @@
     display: block;
     color: var(--text-muted);
     font-family: var(--dp-font-sans);
-    font-size: .73rem;
+    font-size: .7rem;
     font-weight: 600;
     letter-spacing: .02em;
+    line-height: 1.3;
   }
   .nav__item a[aria-current="page"] {
     color: var(--dp-accent);

--- a/src/styles/homepage/planner.css
+++ b/src/styles/homepage/planner.css
@@ -385,14 +385,14 @@
   height: 580px;
   max-height: 80vh;
 }
-[data-theme="dark"] .planner__chat { background: #0e2a3e; border-color: rgba(255,255,255,.08); }
+[data-theme="dark"] .planner__chat { background: #0e2a3e; border-color: rgba(255,255,255,.14); }
 .planner__header {
   display: flex; align-items: center; gap: .85rem;
   padding: 1rem 1.25rem;
   border-bottom: 1px solid var(--divider);
   background: linear-gradient(180deg, var(--surface-subtle), transparent);
 }
-[data-theme="dark"] .planner__header { border-bottom-color: rgba(255,255,255,.06); background: linear-gradient(180deg, rgba(255,255,255,.04), transparent); }
+[data-theme="dark"] .planner__header { border-bottom-color: rgba(255,255,255,.16); background: linear-gradient(180deg, rgba(255,255,255,.06), transparent); }
 .planner__avatar {
   width: 40px; height: 40px;
   border-radius: 12px;
@@ -530,10 +530,11 @@
   background: rgba(255,111,97,.055);
   box-shadow: inset 0 1px 0 rgba(255,111,97,.18);
 }
-[data-theme="dark"] .planner__form { border-top-color: rgba(255,255,255,.06); background: rgba(255,255,255,.02); }
+[data-theme="dark"] .planner__form { border-top-color: rgba(255,255,255,.16); background: rgba(255,255,255,.03); }
 [data-theme="dark"] .planner__form--active { background: rgba(255,111,97,.08); }
 .planner__input {
   flex: 1;
+  min-width: 0;
   border: none;
   background: transparent;
   font-family: inherit;
@@ -543,9 +544,12 @@
   outline: none;
   padding: .55rem 0;
   line-height: 1.4;
+  min-height: 2.8em;
   max-height: 140px;
 }
-.planner__input::placeholder { color: var(--text-muted); }
+.planner__input::placeholder { color: var(--text-muted); opacity: 1; }
+[data-theme="dark"] .planner__input { color: #f3f4f6; }
+[data-theme="dark"] .planner__input::placeholder { color: rgba(243, 244, 246, .55); }
 .planner__send {
   flex-shrink: 0;
   width: 40px; height: 40px;
@@ -569,10 +573,40 @@
   color: var(--text-muted);
   border-top: 1px solid var(--divider);
 }
-[data-theme="dark"] .planner__foot { border-top-color: rgba(255,255,255,.04); }
+[data-theme="dark"] .planner__foot { border-top-color: rgba(255,255,255,.16); }
 .planner__foot--simple {
   justify-content: center;
   text-align: center;
+}
+.planner__foot-note {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.planner__handoff {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .4rem;
+  padding: .55rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: #FF6F61;
+  color: #fff;
+  font-family: var(--dp-font-sans);
+  font-size: .85rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background .2s ease, transform .15s ease, opacity .2s ease;
+}
+.planner__handoff:hover:not(:disabled) {
+  background: #ff8678;
+  transform: translateY(-1px);
+}
+.planner__handoff:disabled {
+  opacity: .45;
+  cursor: not-allowed;
 }
 
 .planner__status {

--- a/src/styles/homepage/weather.css
+++ b/src/styles/homepage/weather.css
@@ -51,6 +51,71 @@
   flex-shrink: 0;
   margin-bottom: 1.2rem;
 }
+
+/* Weather icon animations */
+.wx-icon { overflow: visible; }
+.wx-sun-disc { transform-origin: center; animation: wx-sun-pulse 4s ease-in-out infinite; }
+.wx-sun-rays { transform-origin: 32px 32px; animation: wx-sun-spin 22s linear infinite; }
+.wx-icon--partly-day .wx-sun-rays { transform-origin: 22px 24px; animation: wx-sun-spin 26s linear infinite; }
+.wx-moon { transform-origin: center; animation: wx-moon-glow 4.5s ease-in-out infinite; }
+.wx-star { animation: wx-star-twinkle 2.6s ease-in-out infinite; }
+.wx-star--2 { animation-delay: .8s; }
+.wx-star--3 { animation-delay: 1.6s; }
+.wx-cloud { animation: wx-cloud-drift 6s ease-in-out infinite; }
+.wx-cloud--solo { animation: wx-cloud-bob 5s ease-in-out infinite; }
+.wx-drop { stroke-linecap: round; animation: wx-drop-fall 1.2s ease-in infinite; transform-origin: top; }
+.wx-drop--2 { animation-delay: .35s; }
+.wx-drop--3 { animation-delay: .7s; }
+.wx-fog-line { stroke-dasharray: 22 12; animation: wx-fog-drift 4s linear infinite; }
+.wx-fog-line--2 { animation-direction: reverse; animation-duration: 5s; }
+.wx-bolt {
+  stroke-linecap: round;
+  fill: var(--dp-accent);
+  stroke: var(--dp-accent);
+  animation: wx-bolt-flicker 2.4s ease-in-out infinite;
+  transform-origin: 32px 50px;
+}
+
+@keyframes wx-sun-spin { to { transform: rotate(360deg); } }
+@keyframes wx-sun-pulse {
+  0%, 100% { transform: scale(1); opacity: .95; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+@keyframes wx-moon-glow {
+  0%, 100% { filter: drop-shadow(0 0 0 rgba(207,225,238,0)); }
+  50% { filter: drop-shadow(0 0 6px rgba(207,225,238,.55)); }
+}
+@keyframes wx-star-twinkle {
+  0%, 100% { opacity: .35; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.4); }
+}
+@keyframes wx-cloud-drift {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(3px); }
+}
+@keyframes wx-cloud-bob {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-3px); }
+}
+@keyframes wx-drop-fall {
+  0% { transform: translateY(-4px); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translateY(6px); opacity: 0; }
+}
+@keyframes wx-fog-drift {
+  to { stroke-dashoffset: -34; }
+}
+@keyframes wx-bolt-flicker {
+  0%, 38%, 44%, 100% { opacity: 1; transform: translateY(0); }
+  40% { opacity: .25; }
+  42% { opacity: 1; }
+  60% { transform: translateY(1px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wx-sun-rays, .wx-sun-disc, .wx-moon, .wx-star,
+  .wx-cloud, .wx-drop, .wx-fog-line, .wx-bolt { animation: none; }
+}
 .weather__desc {
   font-family: var(--dp-font-display); font-size: 1.05rem; color: var(--text); line-height: 1.6; margin: 0; max-width: 32em;
 }

--- a/src/styles/safaris.css
+++ b/src/styles/safaris.css
@@ -546,9 +546,9 @@
 
   .saf-filter {
     max-width: none;
-    margin: 0 -1rem 1.25rem;
-    padding: .2rem 1rem .85rem;
-    justify-content: flex-start;
+    margin: 0 0 1.25rem;
+    padding: .2rem 0 0;
+    justify-content: center;
   }
 }
 .saf-route-grid {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,9 +1,18 @@
 export const THEME_STORAGE_KEY = 'dp_tweaks';
 
 const THEMES = new Set(['light', 'dark']);
+const THEME_MODES = new Set(['auto', 'light', 'dark']);
+const DAY_START_HOUR = 6;
+const NIGHT_START_HOUR = 18;
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+const LIGHT_QUERY = '(prefers-color-scheme: light)';
 
 export function normalizeTheme(theme) {
   return THEMES.has(theme) ? theme : 'light';
+}
+
+export function normalizeThemeMode(mode) {
+  return THEME_MODES.has(mode) ? mode : 'auto';
 }
 
 export function readStoredTweaks() {
@@ -15,21 +24,125 @@ export function readStoredTweaks() {
   }
 }
 
-export function readStoredTheme(fallback = 'light') {
+export function readStoredThemeMode() {
   const saved = readStoredTweaks();
-  if (saved?.theme) return normalizeTheme(saved.theme);
-  return normalizeTheme(document.documentElement.getAttribute('data-theme') || fallback);
+  return normalizeThemeMode(saved?.themeMode);
+}
+
+export function readStoredTheme(fallback = 'light') {
+  return resolveThemeForMode(readStoredThemeMode(), fallback);
 }
 
 export function persistTheme(theme) {
+  return persistThemeMode(normalizeTheme(theme), theme).theme;
+}
+
+export function persistThemeMode(mode, theme = resolveThemeForMode(mode)) {
+  const nextMode = normalizeThemeMode(mode);
   const nextTheme = normalizeTheme(theme);
+
   try {
     const saved = readStoredTweaks() || {};
-    localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify({ ...saved, theme: nextTheme }));
+    localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify({ ...saved, themeMode: nextMode, theme: nextTheme }));
   } catch (e) {
     /* noop */
   }
-  return nextTheme;
+
+  return { mode: nextMode, theme: nextTheme };
+}
+
+function getThemeQuery(query) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+  try {
+    return window.matchMedia(query);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function readSystemThemePreference() {
+  const darkQuery = getThemeQuery(DARK_QUERY);
+  if (darkQuery?.matches) return 'dark';
+
+  const lightQuery = getThemeQuery(LIGHT_QUERY);
+  if (lightQuery?.matches) return 'light';
+
+  return null;
+}
+
+export function resolveTimeTheme(date = new Date()) {
+  const hour = date.getHours();
+  return hour >= DAY_START_HOUR && hour < NIGHT_START_HOUR ? 'light' : 'dark';
+}
+
+export function resolveAutomaticTheme(fallback = 'light') {
+  return readSystemThemePreference() || resolveTimeTheme(new Date()) || normalizeTheme(fallback);
+}
+
+export function resolveThemeForMode(mode = 'auto', fallback = 'light') {
+  const nextMode = normalizeThemeMode(mode);
+  return nextMode === 'auto' ? resolveAutomaticTheme(fallback) : normalizeTheme(nextMode);
+}
+
+function getNextTimeThemeChangeDelay(now = new Date()) {
+  const next = new Date(now);
+  const hour = now.getHours();
+
+  if (hour < DAY_START_HOUR) {
+    next.setHours(DAY_START_HOUR, 0, 0, 0);
+  } else if (hour < NIGHT_START_HOUR) {
+    next.setHours(NIGHT_START_HOUR, 0, 0, 0);
+  } else {
+    next.setDate(next.getDate() + 1);
+    next.setHours(DAY_START_HOUR, 0, 0, 0);
+  }
+
+  return Math.max(1000, next.getTime() - now.getTime() + 1000);
+}
+
+function addThemeQueryListener(query, callback) {
+  if (!query) return () => {};
+  if (typeof query.addEventListener === 'function') {
+    query.addEventListener('change', callback);
+    return () => query.removeEventListener('change', callback);
+  }
+  if (typeof query.addListener === 'function') {
+    query.addListener(callback);
+    return () => query.removeListener(callback);
+  }
+  return () => {};
+}
+
+export function watchAutomaticTheme(onThemeChange) {
+  if (typeof window === 'undefined') return () => {};
+
+  let timeoutId = 0;
+  let disposed = false;
+
+  const scheduleTimeFallback = () => {
+    if (timeoutId) window.clearTimeout(timeoutId);
+    timeoutId = 0;
+
+    if (readSystemThemePreference()) return;
+    timeoutId = window.setTimeout(updateTheme, getNextTimeThemeChangeDelay());
+  };
+
+  const updateTheme = () => {
+    if (disposed) return;
+    onThemeChange(resolveAutomaticTheme());
+    scheduleTimeFallback();
+  };
+
+  const stopDarkListener = addThemeQueryListener(getThemeQuery(DARK_QUERY), updateTheme);
+  const stopLightListener = addThemeQueryListener(getThemeQuery(LIGHT_QUERY), updateTheme);
+  updateTheme();
+
+  return () => {
+    disposed = true;
+    if (timeoutId) window.clearTimeout(timeoutId);
+    stopDarkListener();
+    stopLightListener();
+  };
 }
 
 export function applyTheme(theme) {
@@ -39,6 +152,11 @@ export function applyTheme(theme) {
   return nextTheme;
 }
 
-export function announceTheme(theme) {
-  window.dispatchEvent(new CustomEvent('dp-theme-change', { detail: { theme: normalizeTheme(theme) } }));
+export function announceTheme(theme, mode = readStoredThemeMode()) {
+  window.dispatchEvent(new CustomEvent('dp-theme-change', {
+    detail: {
+      theme: normalizeTheme(theme),
+      mode: normalizeThemeMode(mode),
+    },
+  }));
 }


### PR DESCRIPTION
## Summary
- **Mobile nav** — full-screen overlay, animated burger morph, centered/aligned items, hidden duplicate Book CTA, backdrop + Escape to close
- **Planner chat** — manual "Send to team" button, shorter input placeholder, taller default input box, stronger dark-mode dividers between header/log/input/footer
- **Live weather** — wired to Open-Meteo (temp/humidity/sea temp/sunrise/sunset) with day-night-aware icons (sun/moon/cloud/rain/fog/storm) and subtle per-icon animations
- **Filter chips** — Safaris, Excursions, Packages now wrap to multiple rows on mobile instead of forcing horizontal scroll
- **Polish** — WhatsApp FAB pulse rings, hero "Find my route" jumps directly to the chat box, footer tagline types out on view with blinking cursor, mobile footer centering

## Test plan
- [ ] Open mobile menu (≤960px): items centered, all visible without scroll, X animates from burger, Escape + backdrop tap close it
- [ ] Hero search "Find my route" scrolls to the chat box, not the planner intro
- [ ] Planner: "Send to team" disabled until first user message; prompts for email if none in transcript; sends successfully when email is present
- [ ] Filter chips wrap on Safaris / Excursions / Packages at ≤720px
- [ ] Weather widget loads real values; icon changes between day and night; falls back gracefully if Open-Meteo errors
- [ ] Footer tagline types out when scrolled into view, copyright + policy links centered on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)