### PR TITLE
Mobile menu V2A: photo-takeover overlay

### DIFF
--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useLocation } from 'react-router-dom';
+import { CONTACT_INFO } from '../constants/contactInfo';
 
 const NAV_ITEMS = [
   { label: 'Home', to: '/', end: true, icon: 'home', hint: 'Start at the island hub' },
@@ -35,16 +36,53 @@ const BookingIcon = (p) => (
   </svg>
 );
 
+const CloseIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M6 6l12 12M18 6L6 18" />
+  </svg>
+);
+
+const ChevronRight = ({ size = 16 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M9 6l6 6-6 6" />
+  </svg>
+);
+
+const WhatsAppIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 32 32" fill="currentColor" aria-hidden="true">
+    <path d="M19.11 17.205c-.372 0-1.088 1.39-1.518 1.39a.63.63 0 0 1-.315-.1c-.802-.402-1.504-.817-2.163-1.447-.545-.516-1.146-1.29-1.46-1.963a.426.426 0 0 1-.073-.215c0-.33.99-.945.99-1.49 0-.143-.73-2.09-.832-2.335-.143-.372-.214-.487-.6-.487-.187 0-.36-.043-.53-.043-.302 0-.53.115-.746.315-.688.645-1.032 1.318-1.06 2.264v.114c-.015.99.472 1.977 1.017 2.78 1.23 1.82 2.506 3.41 4.554 4.34.616.287 2.035.888 2.722.888.817 0 2.15-.515 2.478-1.318.13-.33.143-.745.143-1.103 0-.272-.058-.387-.215-.515-.158-.143-1.532-.745-1.762-.745zM16.207 4.992c-6.06.058-10.973 5.013-10.973 11.08 0 2.05.572 3.97 1.575 5.63L5.001 27.16l5.658-1.805a11.04 11.04 0 0 0 5.21 1.318c6.103 0 11.073-4.97 11.073-11.072 0-6.045-4.926-10.987-10.987-11.087h-.107v.476h.36zm0 20.13a9.06 9.06 0 0 1-4.624-1.262l-.33-.2-3.466 1.117 1.132-3.398-.215-.345A9.073 9.073 0 0 1 7.18 16.16c0-5 4.067-9.066 9.066-9.066 5 0 9.066 4.066 9.066 9.066s-4.066 9.066-9.066 9.066h-.043z"/>
+  </svg>
+);
+
+// V2 mobile menu rows — richer copy + per-item flourish (italic Safaris, AI badge, etc.)
+const MM_ITEMS = [
+  { label: 'Home',         to: '/',             end: true, sub: 'Start at the island hub' },
+  { label: 'Excursions',   to: '/excursions',   sub: 'Stone Town · Reefs · Spice farms' },
+  { label: 'Safaris',      to: '/safaris',      sub: 'Serengeti · Ngorongoro · Selous', italic: true },
+  { label: 'Packages',     to: '/packages',     sub: 'Bush & Beach · 7–14 nights' },
+  { label: 'Trip Planner', to: '/trip-planner', sub: 'Hand-built · 90 sec', badge: 'AI' },
+  { label: 'Explore',      to: '/explore',      sub: 'Compare places & styles' },
+  { label: 'About',        to: '/aboutus',      sub: 'Our story · Guides · Press' },
+];
+
+const MM_BG = '/assets/images/safaris/male-lion-in-grass.webp';
+
 export default function SiteNav() {
   const [navOpen, setNavOpen] = useState(false);
   const navRef = useRef(null);
+  const mmRef = useRef(null);
+  const location = useLocation();
+
+  // Close on route change
+  useEffect(() => { setNavOpen(false); }, [location.pathname]);
 
   useEffect(() => {
     if (navOpen) {
       document.body.style.overflow = 'hidden';
-      const focusable = navRef.current.querySelectorAll(
+      const scope = mmRef.current || navRef.current;
+      const focusable = scope ? scope.querySelectorAll(
         'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select'
-      );
+      ) : [];
 
       const handleKey = (e) => {
         if (e.key === 'Escape') {
@@ -74,11 +112,7 @@ export default function SiteNav() {
     return () => { document.body.style.overflow = ''; };
   }, [navOpen]);
 
-  const closeMenuFromLink = (event) => {
-    if (event.target instanceof Element && event.target.closest('a')) {
-      setNavOpen(false);
-    }
-  };
+  const isCurrent = (to, end) => (end ? location.pathname === to : location.pathname.startsWith(to));
 
   return (
     <nav className="nav" id="top" ref={navRef}>
@@ -87,16 +121,7 @@ export default function SiteNav() {
           <img src="/assets/brand/destination-paradise-logo-96.webp" alt="Destination Paradise" width="48" height="48" decoding="async" />
           <span className="nav__logo-text">Destination Paradise<small>Zanzibar &amp; Tanzania</small></span>
         </Link>
-        {navOpen && (
-          <button
-            type="button"
-            className="nav__backdrop"
-            aria-label="Close menu"
-            tabIndex={-1}
-            onClick={() => setNavOpen(false)}
-          />
-        )}
-        <ul className={`nav__menu${navOpen ? ' nav__menu--open' : ''}`} id="navMenu" onClick={closeMenuFromLink}>
+        <ul className="nav__menu" id="navMenu">
           {NAV_ITEMS.map((item) => (
             <li className={`nav__item${item.mobileOnly ? ' nav__item--mobile-only' : ''}`} key={item.to}>
               <NavLink to={item.to} end={item.end}>
@@ -118,7 +143,7 @@ export default function SiteNav() {
             type="button"
             aria-label={navOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={navOpen}
-            aria-controls="navMenu"
+            aria-controls="mobileMenu"
             onClick={() => setNavOpen((v) => !v)}
           >
             <span className="nav__burger-box" aria-hidden="true">
@@ -127,6 +152,78 @@ export default function SiteNav() {
               <span className="nav__burger-line" />
             </span>
           </button>
+        </div>
+      </div>
+
+      <div
+        id="mobileMenu"
+        ref={mmRef}
+        className={`mm-menu${navOpen ? ' is-open' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+        aria-hidden={!navOpen}
+      >
+        <div className="mm-menu__bg" style={{ backgroundImage: `url('${MM_BG}')` }} />
+        <div className="mm-menu__scrim" />
+
+        <div className="mm-menu__bar">
+          <Link to="/" className="mm-menu__brand">
+            <img src="/assets/brand/destination-paradise-logo-96.webp" alt="" width="38" height="38" decoding="async" />
+            <span className="mm-menu__brand-text">Destination Paradise<small>Zanzibar &amp; Tanzania</small></span>
+          </Link>
+          <button
+            type="button"
+            className="mm-menu__close"
+            aria-label="Close menu"
+            onClick={() => setNavOpen(false)}
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <div className="mm-menu__hero">
+          <span className="mm-menu__eyebrow">Karibu Tanzania</span>
+          <p className="mm-menu__head">Where would you like to <em>wander</em>?</p>
+        </div>
+
+        <ul className="mm-menu__list">
+          {MM_ITEMS.map((item) => {
+            const active = isCurrent(item.to, item.end);
+            return (
+              <li key={item.to}>
+                <Link
+                  to={item.to}
+                  className="mm-menu__row"
+                  aria-current={active ? 'page' : undefined}
+                >
+                  <span className="mm-menu__row-main">
+                    <span className="mm-menu__lbl">
+                      {item.italic ? <em>{item.label}</em> : item.label}
+                      {item.badge && <span className="mm-menu__pill-inline">{item.badge}</span>}
+                    </span>
+                    {item.sub && <span className="mm-menu__sub">{item.sub}</span>}
+                  </span>
+                  <span className="mm-menu__arr"><ChevronRight /></span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="mm-menu__foot">
+          <Link to="/booking" className="mm-menu__cta">
+            Book a trip <ChevronRight />
+          </Link>
+          <a
+            className="mm-menu__wa"
+            href={CONTACT_INFO.whatsappUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="Chat on WhatsApp"
+          >
+            <WhatsAppIcon />
+          </a>
         </div>
       </div>
     </nav>

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -65,16 +65,33 @@ const MM_ITEMS = [
   { label: 'About',        to: '/aboutus',      sub: 'Our story · Guides · Press' },
 ];
 
-const MM_BG = '/assets/images/safaris/male-lion-in-grass.webp';
+const MM_BGS = [
+  '/assets/images/excursions/dream-dhow-sunset.webp',
+  '/assets/images/excursions/safari-blue-sandbank.webp',
+  '/assets/images/home/aerial-boats-turquoise-water.webp',
+  '/assets/images/home/stone-town-waterfront.webp',
+  '/assets/images/safaris/zebra-herd-on-track.webp',
+];
 
 export default function SiteNav() {
   const [navOpen, setNavOpen] = useState(false);
+  const [bgIndex, setBgIndex] = useState(() => Math.floor(Math.random() * MM_BGS.length));
   const navRef = useRef(null);
   const mmRef = useRef(null);
   const location = useLocation();
 
   // Close on route change
   useEffect(() => { setNavOpen(false); }, [location.pathname]);
+
+  // Rotate background each time the menu opens — pick a different image than last time
+  useEffect(() => {
+    if (!navOpen || MM_BGS.length < 2) return;
+    setBgIndex((prev) => {
+      let next = prev;
+      while (next === prev) next = Math.floor(Math.random() * MM_BGS.length);
+      return next;
+    });
+  }, [navOpen]);
 
   useEffect(() => {
     if (navOpen) {
@@ -164,7 +181,7 @@ export default function SiteNav() {
         aria-label="Site navigation"
         aria-hidden={!navOpen}
       >
-        <div className="mm-menu__bg" style={{ backgroundImage: `url('${MM_BG}')` }} />
+        <div className="mm-menu__bg" style={{ backgroundImage: `url('${MM_BGS[bgIndex]}')` }} />
         <div className="mm-menu__scrim" />
 
         <div className="mm-menu__bar">

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -1,4 +1,5 @@
 @import "./homepage/nav.css";
+@import "./homepage/nav-mm.css";
 @import "./homepage/hero.css";
 @import "./homepage/nav-stand.css";
 @import "./homepage/buttons.css";

--- a/src/styles/homepage/nav-mm.css
+++ b/src/styles/homepage/nav-mm.css
@@ -40,7 +40,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: calc(env(safe-area-inset-top, 0px) + 14px) 18px 12px;
+  padding: calc(env(safe-area-inset-top, 0px) + 10px) 18px 8px;
   flex-shrink: 0;
 }
 .mm-menu__brand {
@@ -70,7 +70,7 @@
 }
 
 /* Hero */
-.mm-menu__hero { padding: 4px 22px 14px; }
+.mm-menu__hero { padding: 2px 22px 10px; }
 .mm-menu__eyebrow {
   display: inline-flex; align-items: center; gap: 8px;
   font-size: 9px; letter-spacing: .24em; text-transform: uppercase;
@@ -83,28 +83,29 @@
 .mm-menu__head {
   font-family: var(--dp-font-display);
   font-style: italic; font-weight: 400;
-  font-size: 24px; line-height: 1.18;
-  margin: 10px 0 0; color: rgba(245,241,232,.92);
+  font-size: 20px; line-height: 1.18;
+  margin: 6px 0 0; color: rgba(245,241,232,.92);
   max-width: 17ch;
 }
 .mm-menu__head em { font-style: italic; color: var(--dp-accent); }
 
 /* Menu list */
 .mm-menu__list {
-  padding: 4px 16px;
+  padding: 2px 16px;
   flex: 1;
   display: flex; flex-direction: column;
-  gap: 6px;
+  justify-content: center;
+  gap: 4px;
   margin: 0; list-style: none;
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  overflow: hidden;
+  min-height: 0;
 }
 .mm-menu__row {
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  padding: 14px 16px;
-  border-radius: 14px;
+  padding: 9px 14px;
+  border-radius: 12px;
   background: rgba(255,255,255,.06);
   border: 1px solid rgba(255,255,255,.09);
   -webkit-backdrop-filter: blur(8px);
@@ -120,18 +121,18 @@
   color: #fff;
 }
 .mm-menu__row-main {
-  display: flex; flex-direction: column; gap: 3px; min-width: 0;
+  display: flex; flex-direction: column; gap: 2px; min-width: 0;
 }
 .mm-menu__lbl {
   font-family: var(--dp-font-display);
-  font-size: 22px; line-height: 1.05; font-weight: 500;
+  font-size: 17px; line-height: 1.05; font-weight: 500;
   letter-spacing: -.005em;
 }
 .mm-menu__lbl em { font-style: italic; color: var(--dp-accent); }
 .mm-menu__row[aria-current="page"] .mm-menu__lbl em { color: #fff; }
 .mm-menu__sub {
   font-family: var(--dp-font-sans);
-  font-size: 10px; letter-spacing: .14em; text-transform: uppercase;
+  font-size: 9px; letter-spacing: .12em; text-transform: uppercase;
   font-weight: 600; color: rgba(245,241,232,.55);
 }
 .mm-menu__row[aria-current="page"] .mm-menu__sub { color: rgba(255,255,255,.85); }
@@ -153,13 +154,13 @@
 
 /* Footer */
 .mm-menu__foot {
-  padding: 12px 16px calc(20px + env(safe-area-inset-bottom, 0px));
+  padding: 10px 16px calc(14px + env(safe-area-inset-bottom, 0px));
   display: flex; gap: 10px;
 }
 .mm-menu__cta {
   flex: 1;
   display: flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 15px; border-radius: 13px;
+  padding: 13px; border-radius: 13px;
   background: var(--dp-accent); color: #fff;
   font-family: var(--dp-font-sans);
   font-size: 12px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
@@ -168,7 +169,7 @@
 }
 .mm-menu__cta:hover { background: var(--dp-hover); }
 .mm-menu__wa {
-  width: 48px; height: 48px; border-radius: 13px;
+  width: 44px; height: 44px; border-radius: 13px;
   background: #25D366; color: #fff;
   display: inline-flex; align-items: center; justify-content: center;
   text-decoration: none;

--- a/src/styles/homepage/nav-mm.css
+++ b/src/styles/homepage/nav-mm.css
@@ -1,0 +1,195 @@
+/* ------------ MOBILE MENU V2 — photo takeover overlay ------------ */
+
+.mm-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  isolation: isolate;
+  color: #F5F1E8;
+  font-family: var(--dp-font-sans);
+  transform: translateY(-6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s var(--dp-ease-out), transform .3s var(--dp-ease-out);
+}
+.mm-menu.is-open {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mm-menu__bg {
+  position: absolute; inset: 0; z-index: 0;
+  background-position: center; background-size: cover;
+}
+.mm-menu__scrim {
+  position: absolute; inset: 0; z-index: 1;
+  background: linear-gradient(180deg, rgba(20,12,8,.5) 0%, rgba(20,12,8,.62) 45%, rgba(20,12,8,.95) 100%);
+}
+.mm-menu__bar,
+.mm-menu__hero,
+.mm-menu__list,
+.mm-menu__foot { position: relative; z-index: 2; }
+
+/* Top bar */
+.mm-menu__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: calc(env(safe-area-inset-top, 0px) + 14px) 18px 12px;
+  flex-shrink: 0;
+}
+.mm-menu__brand {
+  display: flex; align-items: center; gap: 10px;
+  color: #fff; text-decoration: none;
+}
+.mm-menu__brand img { width: 38px; height: 38px; }
+.mm-menu__brand-text {
+  font-family: var(--dp-font-script);
+  font-size: 18px; line-height: 1;
+}
+.mm-menu__brand-text small {
+  display: block;
+  font-family: var(--dp-font-sans);
+  font-size: 7px; letter-spacing: .22em; text-transform: uppercase;
+  font-weight: 700; opacity: .78; margin-top: 3px;
+}
+.mm-menu__close {
+  width: 40px; height: 40px; border-radius: 999px;
+  background: rgba(255,255,255,.1);
+  border: 1px solid rgba(255,255,255,.22);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  color: #fff; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Hero */
+.mm-menu__hero { padding: 4px 22px 14px; }
+.mm-menu__eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 9px; letter-spacing: .24em; text-transform: uppercase;
+  font-weight: 700; color: var(--dp-accent);
+}
+.mm-menu__eyebrow::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor; box-shadow: 0 0 12px currentColor;
+}
+.mm-menu__head {
+  font-family: var(--dp-font-display);
+  font-style: italic; font-weight: 400;
+  font-size: 24px; line-height: 1.18;
+  margin: 10px 0 0; color: rgba(245,241,232,.92);
+  max-width: 17ch;
+}
+.mm-menu__head em { font-style: italic; color: var(--dp-accent); }
+
+/* Menu list */
+.mm-menu__list {
+  padding: 4px 16px;
+  flex: 1;
+  display: flex; flex-direction: column;
+  gap: 6px;
+  margin: 0; list-style: none;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.mm-menu__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(255,255,255,.09);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  text-decoration: none;
+  color: inherit;
+  transition: background .2s ease, border-color .2s ease;
+}
+.mm-menu__row:hover { background: rgba(255,255,255,.1); }
+.mm-menu__row[aria-current="page"] {
+  background: rgba(184,84,26,.88);
+  border-color: transparent;
+  color: #fff;
+}
+.mm-menu__row-main {
+  display: flex; flex-direction: column; gap: 3px; min-width: 0;
+}
+.mm-menu__lbl {
+  font-family: var(--dp-font-display);
+  font-size: 22px; line-height: 1.05; font-weight: 500;
+  letter-spacing: -.005em;
+}
+.mm-menu__lbl em { font-style: italic; color: var(--dp-accent); }
+.mm-menu__row[aria-current="page"] .mm-menu__lbl em { color: #fff; }
+.mm-menu__sub {
+  font-family: var(--dp-font-sans);
+  font-size: 10px; letter-spacing: .14em; text-transform: uppercase;
+  font-weight: 600; color: rgba(245,241,232,.55);
+}
+.mm-menu__row[aria-current="page"] .mm-menu__sub { color: rgba(255,255,255,.85); }
+
+.mm-menu__arr {
+  color: rgba(245,241,232,.4);
+  display: inline-flex;
+  transition: transform .25s ease, color .25s ease;
+}
+.mm-menu__row:hover .mm-menu__arr { transform: translateX(3px); color: rgba(245,241,232,.85); }
+.mm-menu__row[aria-current="page"] .mm-menu__arr { color: #fff; }
+
+.mm-menu__pill-inline {
+  font-size: 8px; letter-spacing: .14em; padding: 3px 7px;
+  background: var(--dp-accent); color: #fff; border-radius: 999px;
+  font-weight: 700; margin-left: 8px; vertical-align: middle;
+  text-transform: uppercase;
+}
+
+/* Footer */
+.mm-menu__foot {
+  padding: 12px 16px calc(20px + env(safe-area-inset-bottom, 0px));
+  display: flex; gap: 10px;
+}
+.mm-menu__cta {
+  flex: 1;
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 15px; border-radius: 13px;
+  background: var(--dp-accent); color: #fff;
+  font-family: var(--dp-font-sans);
+  font-size: 12px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: 0 8px 22px rgba(255,111,97,.35);
+}
+.mm-menu__cta:hover { background: var(--dp-hover); }
+.mm-menu__wa {
+  width: 48px; height: 48px; border-radius: 13px;
+  background: #25D366; color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  text-decoration: none;
+  flex-shrink: 0;
+  box-shadow: 0 8px 22px rgba(37, 211, 102, .35);
+}
+.mm-menu__wa:hover { background: #1ebe5d; }
+
+/* Mobile-only — desktop suppresses the V2 overlay; the existing inline nav__menu remains */
+@media (min-width: 961px) {
+  .mm-menu { display: none; }
+}
+
+/* Hide the legacy fullscreen ul/backdrop on mobile so V2 overlay is the only menu */
+@media (max-width: 960px) {
+  .nav__menu { display: none; }
+  .nav__backdrop { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mm-menu { transition: none; }
+  .mm-menu__arr,
+  .mm-menu__row { transition: none; }
+}


### PR DESCRIPTION
## Summary
- Replaces the legacy mobile nav with the V2A direction from the Claude Design handoff: full-bleed photo, dark scrim, glass row cards, Playfair labels with an italic accent on Safaris, AI badge on Trip Planner, and a Book a trip CTA paired with a real WhatsApp button.
- Brand and route list stay aligned with the live site (Home, Excursions, Safaris, Packages, Trip Planner, Explore, About → `/aboutus`).
- Tightened spacing so the seven-item menu fits without scrolling on small viewports.
- Hero photo rotates each time the menu opens through five atmospheric backgrounds (dhow sunset, sandbank, aerial boats, Stone Town waterfront, zebra herd), always picking a different image than the previous open.

## Test plan
- [ ] Open the burger menu on a mobile viewport — full-screen photo overlay slides in with the expected hero copy ("Where would you like to *wander*?").
- [ ] All seven rows fit within the viewport without vertical scrolling.
- [ ] Active row highlights when on the matching route (e.g. on `/safaris`, the Safaris row is the orange active state).
- [ ] Book a trip CTA navigates to `/booking`; WhatsApp button opens the configured WhatsApp URL in a new tab.
- [ ] Escape key, close button, and tapping a menu item all close the overlay; route changes auto-close it.
- [ ] Repeated opens cycle through the five background photos without immediate repeats.
- [ ] Desktop nav (≥ 961px) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)