### PR TITLE
Mobile menu: tie italic emphasis to active row only

### DIFF
--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -58,7 +58,7 @@ const WhatsAppIcon = () => (
 const MM_ITEMS = [
   { label: 'Home',         to: '/',             end: true, sub: 'Start at the island hub' },
   { label: 'Excursions',   to: '/excursions',   sub: 'Stone Town · Reefs · Spice farms' },
-  { label: 'Safaris',      to: '/safaris',      sub: 'Serengeti · Ngorongoro · Selous', italic: true },
+  { label: 'Safaris',      to: '/safaris',      sub: 'Serengeti · Ngorongoro · Selous' },
   { label: 'Packages',     to: '/packages',     sub: 'Bush & Beach · 7–14 nights' },
   { label: 'Trip Planner', to: '/trip-planner', sub: 'Hand-built · 90 sec', badge: 'AI' },
   { label: 'Explore',      to: '/explore',      sub: 'Compare places & styles' },
@@ -216,7 +216,7 @@ export default function SiteNav() {
                 >
                   <span className="mm-menu__row-main">
                     <span className="mm-menu__lbl">
-                      {item.italic ? <em>{item.label}</em> : item.label}
+                      {active ? <em>{item.label}</em> : item.label}
                       {item.badge && <span className="mm-menu__pill-inline">{item.badge}</span>}
                     </span>
                     {item.sub && <span className="mm-menu__sub">{item.sub}</span>}


### PR DESCRIPTION
## Summary
- Previously the Safaris row was always rendered italic in the accent orange because the V2A mockup demonstrated the active state on that row.
- The italic-em treatment is now driven by `aria-current`, so it follows whichever row matches the current route (and pairs with the existing orange active background).
- On pages like `/` or `/excursions`, Safaris no longer looks like it's the selected item.

## Test plan
- [ ] On `/`, open the mobile menu — Home is highlighted with italic emphasis; Safaris is regular.
- [ ] On `/safaris`, Safaris shows the active state with italic emphasis.
- [ ] On any other route, the matching row is the only one styled italic; all others render in the default serif weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)