### PR TITLE
A11y: fix three Lighthouse score-zero audits

### DIFF
--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -209,8 +209,8 @@ function TypedTagline() {
     <p
       ref={elRef}
       className={`footer__script footer__script--typed${done ? ' is-done' : ''}`}
-      aria-label={TYPED_TAGLINE}
     >
+      <span className="visually-hidden">{TYPED_TAGLINE}</span>
       <span aria-hidden="true">{typed}</span>
       <span className="footer__script-cursor" aria-hidden="true" />
     </p>

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -179,7 +179,7 @@ export default function SiteNav() {
         role="dialog"
         aria-modal="true"
         aria-label="Site navigation"
-        aria-hidden={!navOpen}
+        {...(navOpen ? {} : { inert: '' })}
       >
         <div className="mm-menu__bg" style={{ backgroundImage: `url('${MM_BGS[bgIndex]}')` }} />
         <div className="mm-menu__scrim" />

--- a/src/styles/homepage/footer.css
+++ b/src/styles/homepage/footer.css
@@ -94,12 +94,12 @@
 }
 .footer__theme-option:hover,
 .footer__theme-option:focus-visible {
-  color: var(--dp-accent);
-  background: color-mix(in srgb, var(--dp-accent) 8%, var(--surface-raised));
+  color: var(--text);
+  background: color-mix(in srgb, var(--dp-accent) 10%, var(--surface-raised));
 }
 .footer__theme-option.is-active {
-  color: var(--dp-accent);
-  background: color-mix(in srgb, var(--dp-accent) 14%, var(--surface-raised));
+  color: var(--text);
+  background: color-mix(in srgb, var(--dp-accent) 18%, var(--surface-raised));
 }
 .footer__theme-option:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--dp-accent) 22%, transparent);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -97,3 +97,16 @@
   --dp-container-lg:  1200px;
   --dp-container-xl:  1400px;
 }
+
+/* Visually hidden — accessible to screen readers, invisible on screen */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
## Summary
Closes three score-zero accessibility audits flagged in the latest Lighthouse run on the Netlify preview, lifting the Accessibility category from 89 toward 100.

### Mobile menu — `aria-hidden-focus`
The V2A overlay sets `aria-hidden="true"` when closed, but the close button and brand link inside it remain in the tab order — assistive tech and keyboard users can land on offscreen, supposedly-hidden controls. Swapping to the `inert` attribute disables the whole subtree (focus + interaction + assistive tech) in one stroke, the modern recommended pattern.

### Footer typed tagline — `aria-allowed-attr`
\`aria-label\` is not allowed on a generic \`<p>\` (no implicit role that accepts it), so the tagline's accessible name was being dropped. Removed the attribute and exposed the full sentence via a visually-hidden span; the partial typing animation stays \`aria-hidden\` so screen readers don't read half-words.

Adds a \`.visually-hidden\` utility class to \`tokens.css\` for reuse.

### Footer theme toggle — `color-contrast` (WCAG 1.4.3)
The active and hover states used \`#FF6F61\` accent text on white surface — 2.72:1, well under the 4.5:1 AA threshold. Text color now uses \`var(--text)\` while the accent shifts to the background tint, keeping the visual emphasis without sacrificing readability.

## Out of scope
Lighthouse also flagged \`uses-responsive-images\` (-126 KiB potential savings) — portrait images are declared as \`1200w\` in srcset when the actual file width is 800px. Fixing it cleanly needs per-image width metadata, so it's a separate PR.

## Test plan
- [ ] Tab through the page on a mobile viewport with the menu closed — no focus lands inside the off-screen menu.
- [ ] Open the menu, tab through — focus is trapped inside the dialog as before; Escape and the close button both work.
- [ ] Screen reader on the footer announces the full "your next trip to paradise..." sentence once, not the half-typed string.
- [ ] Footer theme toggle: hover and selected states are legible in both light and dark themes.
- [ ] Re-run Lighthouse on the preview — \`aria-hidden-focus\`, \`aria-allowed-attr\`, and \`color-contrast\` all pass; Accessibility ≥ 95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)