### PR TITLE
Perf: accurate srcset widths from a build-time image manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/build-image-manifest.mjs && vite build",
+    "build:manifest": "node scripts/build-image-manifest.mjs",
     "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",

--- a/scripts/build-image-manifest.mjs
+++ b/scripts/build-image-manifest.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Scans every .webp under public/assets/images, reads intrinsic dimensions
+ * from the WebP header (no third-party deps), and writes a manifest of
+ *   { "/assets/images/.../foo.webp": { w, h, has600w } }
+ * to src/data/imageManifest.json.
+ *
+ * Used by <ResponsiveImage> to declare accurate srcset widths and explicit
+ * width/height attributes — fixes the Lighthouse "Properly size images"
+ * audit and reduces CLS.
+ */
+
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const IMAGES_ROOT = join(REPO_ROOT, 'public', 'assets', 'images');
+const OUTPUT = join(REPO_ROOT, 'src', 'data', 'imageManifest.json');
+
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(path);
+    else if (entry.isFile() && entry.name.endsWith('.webp')) yield path;
+  }
+}
+
+function readWebpDimensions(buf, path) {
+  if (buf.toString('ascii', 0, 4) !== 'RIFF' || buf.toString('ascii', 8, 12) !== 'WEBP') {
+    throw new Error(`Not a WebP: ${path}`);
+  }
+  const chunk = buf.toString('ascii', 12, 16);
+  if (chunk === 'VP8X') {
+    const w = (buf[24] | (buf[25] << 8) | (buf[26] << 16)) + 1;
+    const h = (buf[27] | (buf[28] << 8) | (buf[29] << 16)) + 1;
+    return { w, h };
+  }
+  if (chunk === 'VP8 ') {
+    const w = ((buf[27] << 8) | buf[26]) & 0x3fff;
+    const h = ((buf[29] << 8) | buf[28]) & 0x3fff;
+    return { w, h };
+  }
+  if (chunk === 'VP8L') {
+    const b0 = buf[21], b1 = buf[22], b2 = buf[23], b3 = buf[24];
+    const w = (b0 | ((b1 & 0x3f) << 8)) + 1;
+    const h = (((b1 >> 6) | (b2 << 2) | ((b3 & 0xf) << 10))) + 1;
+    return { w, h };
+  }
+  throw new Error(`Unknown WebP chunk "${chunk}" in ${path}`);
+}
+
+const exists = (p) => stat(p).then(() => true, () => false);
+
+const manifest = {};
+for await (const file of walk(IMAGES_ROOT)) {
+  const rel = '/' + relative(join(REPO_ROOT, 'public'), file).split(sep).join('/');
+  if (rel.endsWith('-600w.webp')) continue;
+  const buf = await readFile(file);
+  const { w, h } = readWebpDimensions(buf, file);
+  const variantPath = file.replace(/\.webp$/, '-600w.webp');
+  let smallW = 0;
+  if (await exists(variantPath)) {
+    const smallBuf = await readFile(variantPath);
+    smallW = readWebpDimensions(smallBuf, variantPath).w;
+  }
+  manifest[rel] = smallW ? { w, h, smallW } : { w, h };
+}
+
+const sorted = Object.fromEntries(
+  Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b))
+);
+
+await writeFile(OUTPUT, JSON.stringify(sorted, null, 2) + '\n');
+console.log(`Wrote ${Object.keys(sorted).length} entries → ${relative(REPO_ROOT, OUTPUT)}`);

--- a/src/components/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import imageManifest from '../data/imageManifest.json';
 
 /**
  * @param {React.ImgHTMLAttributes<HTMLImageElement> & {
@@ -7,22 +8,35 @@ import React from 'react';
  *   fetchpriority?: string;
  * }} props
  */
-export default function ResponsiveImage({ src, alt = '', fetchpriority, sizes, ...imageProps }) {
-  const commonProps = { ...imageProps, src, alt, fetchpriority };
-
+export default function ResponsiveImage({ src, alt = '', fetchpriority, sizes, width, height, ...imageProps }) {
   if (typeof src !== 'string' || !src.endsWith('.webp')) {
-    return (
-      <img {...commonProps} />
-    );
+    return <img {...imageProps} src={src} alt={alt} fetchpriority={fetchpriority} width={width} height={height} />;
   }
 
-  const srcSet = `${src.replace('.webp', '-600w.webp')} 600w, ${src} 1200w`;
+  const meta = imageManifest[src];
+  // Fall back to the old behavior for any unknown image so the build still works.
+  const fullWidth = meta?.w ?? 1200;
+  const fullHeight = meta?.h;
+  const smallWidth = meta?.smallW;
+
+  const srcSetParts = [];
+  if (smallWidth && smallWidth < fullWidth) {
+    const smallSrc = src.replace(/\.webp$/, '-600w.webp');
+    srcSetParts.push(`${smallSrc} ${smallWidth}w`);
+  }
+  srcSetParts.push(`${src} ${fullWidth}w`);
+
   const resolvedSizes = sizes || '(max-width: 600px) 100vw, 1200px';
 
   return (
     <img
-      {...commonProps}
-      srcSet={srcSet}
+      {...imageProps}
+      src={src}
+      alt={alt}
+      fetchpriority={fetchpriority}
+      width={width ?? fullWidth}
+      height={height ?? fullHeight}
+      srcSet={srcSetParts.join(', ')}
       sizes={resolvedSizes}
     />
   );

--- a/src/data/imageManifest.json
+++ b/src/data/imageManifest.json
@@ -1,0 +1,397 @@
+{
+  "/assets/images/excursions/dolphin-snorkeling.webp": {
+    "w": 640,
+    "h": 461
+  },
+  "/assets/images/excursions/dream-dhow-sunset.webp": {
+    "w": 810,
+    "h": 1080
+  },
+  "/assets/images/excursions/jozani-red-colobus.webp": {
+    "w": 535,
+    "h": 800
+  },
+  "/assets/images/excursions/prison-island-tortoise.webp": {
+    "w": 535,
+    "h": 800
+  },
+  "/assets/images/excursions/safari-blue-sandbank.webp": {
+    "w": 1200,
+    "h": 676
+  },
+  "/assets/images/excursions/spice-tour-nutmeg.webp": {
+    "w": 1195,
+    "h": 800
+  },
+  "/assets/images/excursions/stone-town-old-fort.webp": {
+    "w": 640,
+    "h": 427
+  },
+  "/assets/images/excursions/trips/advanced-diving.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/blue-lagoon-snorkeling.webp": {
+    "w": 960,
+    "h": 720,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/butterfly-nature-walk.webp": {
+    "w": 903,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/bwejuu-village.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/chumbe-coral-reef.webp": {
+    "w": 1200,
+    "h": 900,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/chwaka-mangrove-road.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/cooking-coffee-spices.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/dhow-building.webp": {
+    "w": 960,
+    "h": 540,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/dhow-heritage.webp": {
+    "w": 1200,
+    "h": 900,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/dolphin-swim.webp": {
+    "w": 640,
+    "h": 480,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/forodhani-street-food.webp": {
+    "w": 800,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/herbal-medicine.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/hidden-alleys.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/historical-ruins.webp": {
+    "w": 1200,
+    "h": 800,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/horse-riding-beach.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/jet-ski-water.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/jozani-red-colobus.webp": {
+    "w": 836,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/kitesurfing-beach.webp": {
+    "w": 960,
+    "h": 540,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/kizimkazi-fishing-boat.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/local-game-fishing.webp": {
+    "w": 640,
+    "h": 640,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/maalum-cave-stone.webp": {
+    "w": 1200,
+    "h": 800,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/mafia-whale-shark.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/mangapwani-cave.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/mangrove-kayak-dhow.webp": {
+    "w": 960,
+    "h": 540,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/mnemba-snorkeling.webp": {
+    "w": 960,
+    "h": 720,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/nakupenda-sandbank.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/nungwi-coast.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/ocean-sand-combo.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/organic-spice-farm.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/pange-sandbank.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/parasailing-coast.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/persian-baths-sultan.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/prison-island-tortoise.webp": {
+    "w": 1200,
+    "h": 817,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/private-sunset-dhow.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/private-vip-island.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/quad-bike-adventure.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/safari-blue-dhow.webp": {
+    "w": 800,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/sauti-busara-festival.webp": {
+    "w": 1200,
+    "h": 814,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/seaweed-cooperative.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/skydive-zanzibar-beach.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/spice-tour.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/stargazing-beach.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/stone-town-harbor.webp": {
+    "w": 1200,
+    "h": 800,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/the-rock-restaurant.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/transparent-kayak-sup.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/turtle-conservation.webp": {
+    "w": 1200,
+    "h": 817,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/turtle-nesting-beach.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/village-workshop.webp": {
+    "w": 803,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/water-sports-festival.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/wellness-yoga-beach.webp": {
+    "w": 1200,
+    "h": 803,
+    "smallW": 600
+  },
+  "/assets/images/excursions/trips/ziff-film-festival.webp": {
+    "w": 960,
+    "h": 540,
+    "smallW": 600
+  },
+  "/assets/images/home/aerial-boats-turquoise-water.webp": {
+    "w": 360,
+    "h": 640,
+    "smallW": 360
+  },
+  "/assets/images/home/mizingani-waterfront.webp": {
+    "w": 360,
+    "h": 640,
+    "smallW": 360
+  },
+  "/assets/images/home/stone-town-waterfront.webp": {
+    "w": 1195,
+    "h": 800,
+    "smallW": 600
+  },
+  "/assets/images/safaris/buffalo-and-egret.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/safaris/buffalo-herd-close.webp": {
+    "w": 1200,
+    "h": 676,
+    "smallW": 600
+  },
+  "/assets/images/safaris/crowned-crane-close.webp": {
+    "w": 1200,
+    "h": 676,
+    "smallW": 600
+  },
+  "/assets/images/safaris/crowned-cranes-in-grass.webp": {
+    "w": 1200,
+    "h": 676,
+    "smallW": 600
+  },
+  "/assets/images/safaris/eland-grazing.webp": {
+    "w": 1200,
+    "h": 676,
+    "smallW": 600
+  },
+  "/assets/images/safaris/eland-herd-plains.webp": {
+    "w": 1200,
+    "h": 677,
+    "smallW": 600
+  },
+  "/assets/images/safaris/lion-cub-in-grass.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/safaris/lioness-and-cub-resting.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/safaris/male-lion-in-grass.webp": {
+    "w": 1200,
+    "h": 676,
+    "smallW": 600
+  },
+  "/assets/images/safaris/raptor-on-log.webp": {
+    "w": 1200,
+    "h": 706,
+    "smallW": 600
+  },
+  "/assets/images/safaris/rhino-on-plains.webp": {
+    "w": 1200,
+    "h": 677,
+    "smallW": 600
+  },
+  "/assets/images/safaris/serval-in-grass.webp": {
+    "w": 1200,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/safaris/warthog-on-plains.webp": {
+    "w": 1200,
+    "h": 1200,
+    "smallW": 600
+  },
+  "/assets/images/safaris/wildebeest-grazing.webp": {
+    "w": 1200,
+    "h": 674,
+    "smallW": 600
+  },
+  "/assets/images/safaris/yellow-weaver-on-rail.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/safaris/zebra-herd-on-track.webp": {
+    "w": 1200,
+    "h": 675,
+    "smallW": 600
+  },
+  "/assets/images/safaris/zebra-mare-and-foal.webp": {
+    "w": 1200,
+    "h": 1202,
+    "smallW": 600
+  },
+  "/assets/images/testimonials/arturo.webp": {
+    "w": 100,
+    "h": 100
+  },
+  "/assets/images/testimonials/coleman.webp": {
+    "w": 100,
+    "h": 100
+  },
+  "/assets/images/testimonials/isa.webp": {
+    "w": 100,
+    "h": 100
+  }
+}


### PR DESCRIPTION
## Summary
Closes the **Properly size images** Lighthouse opportunity (~126 KiB potential savings) and helps **Cumulative Layout Shift** by emitting explicit `width`/`height`.

The root cause: `ResponsiveImage` declared every full-size WebP as `1200w` in `srcset`, regardless of its actual file width. Portrait images in the excursions library live at 800×1200, so the browser dutifully picked the 800-wide file on screens where the 600-wide variant would have sufficed (e.g. 322px display × DPR 3 = ~966 effective px).

### How
- **`scripts/build-image-manifest.mjs`** — walks `public/assets/images`, parses the WebP RIFF/VP8/VP8L/VP8X chunks directly (no third-party deps) and writes `src/data/imageManifest.json` with `{ w, h, smallW? }` keyed by public URL. Also detects the actual width of `-600w` companions, so when the suffix lies (some "600w" files are physically 360px) we still declare the correct descriptor.
- **`npm run build`** now runs the script before Vite. The manifest is committed so anyone working without a build still gets it.
- **`ResponsiveImage`** consumes the manifest: descriptors use the real file widths, the `-600w` entry is skipped when it isn't actually narrower, and `width`/`height` attributes are filled in from intrinsic dimensions.

Unknown sources fall back to the old `1200w` behaviour so the build never breaks if a new image is added before the manifest regenerates.

## Test plan
- [ ] Inspect any excursion card image in DevTools — `srcset` now reads e.g. `safari-blue-dhow-600w.webp 600w, safari-blue-dhow.webp 800w` (not `1200w`).
- [ ] On a phone-sized viewport with DPR ≥ 2, network tab shows the `-600w.webp` variant being loaded for excursion cards.
- [ ] `<img>` elements emit `width` and `height` attributes — Lighthouse CLS audit should improve.
- [ ] Lighthouse rerun on the preview: "Properly size images" passes (or savings drop ≪ 50 KiB), Performance score nudges up.
- [ ] Adding a new image and running `npm run build:manifest` regenerates the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)