### PR TITLE
About Us: brand-aligned polish (color, image, casing)

### DIFF
--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -247,11 +247,11 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
             <li><Link to="/packages"><FooterIcon name="suitcase" />Packages</Link></li>
             <li><Link to="/trip-planner"><FooterIcon name="route" />Trip Planner</Link></li>
             <li><Link to="/explore"><FooterIcon name="map" />Explore</Link></li>
-            <li><Link to="/aboutus"><FooterIcon name="book" />About us</Link></li>
+            <li><Link to="/aboutus"><FooterIcon name="book" />About Us</Link></li>
           </ul>
         </div>
         <div className="footer__col">
-          <h4>About us</h4>
+          <h4>About Us</h4>
           <ul>
             <li><Link to="/aboutus#story"><FooterIcon name="book" />Our story</Link></li>
             <li><Link to="/aboutus#mission"><FooterIcon name="target" />Our mission</Link></li>

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -9,7 +9,7 @@ const NAV_ITEMS = [
   { label: 'Packages', to: '/packages', icon: 'suitcase', hint: 'Safari, beach, honeymoon' },
   { label: 'Trip Planner', to: '/trip-planner', icon: 'route', hint: 'Shape a custom route' },
   { label: 'Explore', to: '/explore', icon: 'map', hint: 'Compare places and styles' },
-  { label: 'About', to: '/aboutus', icon: 'info', hint: 'Our story and mission' },
+  { label: 'About Us', to: '/aboutus', icon: 'info', hint: 'Our story and mission' },
   { label: 'Book Now', to: '/booking', icon: 'bag', hint: 'Send a booking request', mobileOnly: true },
 ];
 
@@ -64,7 +64,7 @@ const MM_ITEMS = [
   { label: 'Packages',     to: '/packages',     sub: 'Bush & Beach · 7–14 nights' },
   { label: 'Trip Planner', to: '/trip-planner', sub: 'Hand-built · 90 sec', badge: 'AI' },
   { label: 'Explore',      to: '/explore',      sub: 'Compare places & styles' },
-  { label: 'About',        to: '/aboutus',      sub: 'Our story · Mission · Destinations' },
+  { label: 'About Us',     to: '/aboutus',      sub: 'Our story · Mission · Destinations' },
 ];
 
 const MM_BGS = [

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -6,6 +6,7 @@ import '../styles/about.css';
 
 const HERO_IMAGE = '/assets/images/safaris/crowned-cranes-in-grass.webp';
 const STORY_IMAGE = '/assets/images/excursions/trips/dhow-heritage.webp';
+const CTA_IMAGE = '/assets/images/excursions/dream-dhow-sunset.webp';
 
 const TIMELINE = [
   {
@@ -229,6 +230,7 @@ export default function About() {
 
       {/* CTA */}
       <section className="ab-cta">
+        <div className="ab-cta__bg"><ResponsiveImage src={CTA_IMAGE} alt="" loading="lazy" /></div>
         <div className="ab-cta__inner">
           <span className="ab-story__eyebrow ab-cta__eyebrow">Karibu</span>
           <h2>Welcome to <em>Destination Paradise</em>.</h2>

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -486,7 +486,7 @@
 
 /* ============ SUSTAINABILITY ============ */
 .ab-sus {
-  background: linear-gradient(180deg, rgba(74,107,58,.06) 0%, transparent 100%);
+  background: linear-gradient(180deg, rgba(184,84,26,.06) 0%, transparent 100%);
   padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
 }
 .ab-sus__inner { max-width: 1240px; margin: 0 auto; }
@@ -497,8 +497,8 @@
   margin-bottom: clamp(2.5rem, 5vw, 4rem);
 }
 @media (max-width: 880px) { .ab-sus__head { grid-template-columns: 1fr; align-items: start; } }
-.ab-sus__eyebrow { color: #4a6b3a !important; }
-.ab-sus__eyebrow::before { background: #4a6b3a !important; }
+.ab-sus__eyebrow { color: #b8541a !important; }
+.ab-sus__eyebrow::before { background: #b8541a !important; }
 .ab-sus__head h2 {
   font-family: 'Playfair Display', Georgia, serif;
   font-size: clamp(2.2rem, 4.5vw, 3.6rem);
@@ -506,7 +506,7 @@
   margin: .5rem 0 0; color: var(--text-soft, #1a4d6e);
   max-width: 14ch;
 }
-.ab-sus__head h2 em { font-style: italic; color: #4a6b3a; }
+.ab-sus__head h2 em { font-style: italic; color: #b8541a; }
 .ab-sus__head p { margin: 0; font-size: 1.05rem; line-height: 1.7; color: var(--text, #2a3942); max-width: 54ch; }
 
 .ab-sus__grid {
@@ -527,8 +527,8 @@
 .ab-pillar__icon {
   width: 44px; height: 44px;
   border-radius: 12px;
-  background: rgba(74,107,58,.12);
-  color: #4a6b3a;
+  background: rgba(184,84,26,.12);
+  color: #b8541a;
   display: inline-flex; align-items: center; justify-content: center;
   margin-bottom: .35rem;
 }
@@ -546,11 +546,11 @@
 .ab-pillar__stat {
   margin-top: auto;
   padding-top: .85rem;
-  border-top: 1px dashed rgba(74,107,58,.3);
+  border-top: 1px dashed rgba(184,84,26,.3);
   font-family: 'Playfair Display', Georgia, serif;
   font-style: italic;
   font-size: 1.05rem;
-  color: #4a6b3a;
+  color: #b8541a;
 }
 .ab-pillar__stat strong { font-style: normal; font-weight: 500; font-size: 1.4rem; margin-right: .3rem; }
 
@@ -570,7 +570,7 @@
   font-style: italic;
   font-size: 8rem;
   line-height: 1;
-  color: rgba(74,107,58,.18);
+  color: rgba(184,84,26,.18);
 }
 .ab-sus__quote-text {
   font-family: 'Playfair Display', Georgia, serif;
@@ -631,7 +631,7 @@
 }
 [data-theme="dark"] .ab-sus__badge { color: rgba(245,241,232,.7); }
 .ab-sus__badge::before {
-  content: ''; width: 6px; height: 6px; border-radius: 50%; background: #4a6b3a;
+  content: ''; width: 6px; height: 6px; border-radius: 50%; background: #b8541a;
 }
 
 /* ============ PRESS ============ */
@@ -853,26 +853,33 @@
 
 /* ============ CTA ============ */
 .ab-cta {
-  padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
-  background:
-    radial-gradient(circle at 20% 30%, rgba(184,84,26,.12), transparent 50%),
-    radial-gradient(circle at 80% 70%, rgba(26,77,110,.1), transparent 50%),
-    var(--page-bg, #FFFCF5);
+  position: relative;
+  padding: clamp(5rem, 9vw, 8rem) clamp(1.25rem, 5vw, 6rem);
+  overflow: hidden;
+  isolation: isolate;
+  color: #F5F1E8;
   text-align: center;
 }
-.ab-cta__inner { max-width: 700px; margin: 0 auto; }
-.ab-cta__eyebrow { display: inline-flex; justify-content: center; }
+.ab-cta__bg { position: absolute; inset: 0; z-index: -2; }
+.ab-cta__bg img { width: 100%; height: 100%; object-fit: cover; }
+.ab-cta__bg::after {
+  content: ''; position: absolute; inset: 0;
+  background: linear-gradient(180deg, rgba(8,30,46,.55) 0%, rgba(8,30,46,.85) 100%);
+}
+.ab-cta__inner { max-width: 720px; margin: 0 auto; position: relative; }
+.ab-cta__eyebrow { display: inline-flex; justify-content: center; color: #FF6F61 !important; }
+.ab-cta__eyebrow::before { background: #FF6F61 !important; }
 .ab-cta h2 {
   font-family: 'Playfair Display', Georgia, serif;
-  font-size: clamp(2.2rem, 4.5vw, 3.4rem);
+  font-size: clamp(2.25rem, 4.5vw, 3.5rem);
   font-weight: 500; line-height: 1.05; letter-spacing: -.015em;
   margin: 1rem 0;
-  color: var(--text-soft, #1a4d6e);
+  color: #F5F1E8;
 }
-.ab-cta h2 em { font-style: italic; color: #b8541a; }
+.ab-cta h2 em { font-style: italic; color: #FF6F61; }
 .ab-cta p {
-  font-size: 1.05rem; line-height: 1.7;
-  color: var(--text, #2a3942);
+  font-size: 1.05rem; line-height: 1.65;
+  color: rgba(245,241,232,.85);
   margin: 0 auto 2rem;
   max-width: 52ch;
 }
@@ -889,12 +896,10 @@
 [data-theme="dark"] .ab-press__quote-text,
 [data-theme="dark"] .ab-pillar h4,
 [data-theme="dark"] .ab-guide__name,
-[data-theme="dark"] .ab-cta h2,
 [data-theme="dark"] .ab-sus__quote-text { color: #F5F1E8; }
 [data-theme="dark"] .ab-tl-item p,
 [data-theme="dark"] .ab-guide__bio,
-[data-theme="dark"] .ab-pillar p,
-[data-theme="dark"] .ab-cta p { color: rgba(245,241,232,.82); }
+[data-theme="dark"] .ab-pillar p { color: rgba(245,241,232,.82); }
 [data-theme="dark"] .ab-guide,
 [data-theme="dark"] .ab-pillar,
 [data-theme="dark"] .ab-press__quote,


### PR DESCRIPTION
## Summary
- Recolors the **Community** section from olive-green (#4a6b3a) to the page's orange accent (#b8541a) — the eyebrow, italic "network", pillar icons, soft section tint, and giant quote mark all now rhyme with the rest of the About page palette.
- Adds an image-backed background to the closing **Karibu** CTA (`dream-dhow-sunset.webp`) with the same navy gradient scrim pattern used on Excursions/Safaris/Packages CTAs. Eyebrow, headline and body switched to cream/coral for the dark scrim.
- Renames the navigation label from "About" to **"About Us"** in the desktop navbar, mobile menu, and footer (Pages list + column heading).

## Test plan
- [ ] `/aboutus` Community section eyebrow, italic "network", and pillar icons render in orange (no green)
- [ ] Closing CTA shows the sunset dhow image with a dark gradient and cream/coral text
- [ ] Desktop navbar shows "About Us" between Explore and Book Now
- [ ] Footer Pages column shows "About Us" at the bottom; column heading reads "About Us"
- [ ] Mobile menu row shows "About Us" with subhead "Our story · Mission · Destinations"
- [ ] Build succeeds (`npx vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)