### PR TITLE
Launch prep: About rewrite, mobile menu, perf/a11y, Resend emails

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -112,6 +112,58 @@ export default function About() {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const root = pageRef.current;
+    if (!root) return undefined;
+    const timeline = root.querySelector('.ab-timeline');
+    const wrap = root.querySelector('.ab-timeline__photo-wrap');
+    const photo = wrap?.querySelector('.ab-timeline__photo');
+    if (!timeline || !wrap || !photo) return undefined;
+
+    const desktopMQ = window.matchMedia('(min-width: 981px)');
+    const reduceMQ = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let raf = 0;
+
+    function tick() {
+      raf = 0;
+      if (!desktopMQ.matches || reduceMQ.matches) {
+        wrap.classList.remove('js-pin');
+        wrap.style.removeProperty('--pin-y');
+        return;
+      }
+      wrap.classList.add('js-pin');
+      const rect = timeline.getBoundingClientRect();
+      const navH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-height')) || 66;
+      const offset = navH + 24;
+      const maxY = Math.max(0, wrap.offsetHeight - photo.offsetHeight);
+      const y = Math.max(0, Math.min(offset - rect.top, maxY));
+      wrap.style.setProperty('--pin-y', `${y}px`);
+    }
+
+    function schedule() {
+      if (raf) return;
+      raf = requestAnimationFrame(tick);
+    }
+
+    tick();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+    const onMQ = () => schedule();
+    desktopMQ.addEventListener?.('change', onMQ);
+    reduceMQ.addEventListener?.('change', onMQ);
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      desktopMQ.removeEventListener?.('change', onMQ);
+      reduceMQ.removeEventListener?.('change', onMQ);
+      wrap.classList.remove('js-pin');
+      wrap.style.removeProperty('--pin-y');
+    };
+  }, []);
+
   return (
     <main className="about-page" ref={pageRef}>
       {/* HERO */}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -155,9 +155,11 @@ export default function About() {
               </div>
             ))}
           </div>
-          <div className="ab-timeline__photo">
-            <ResponsiveImage src={STORY_IMAGE} alt="A traditional dhow on the Zanzibar coast" loading="lazy" />
-            <div className="ab-timeline__caption">From an idea on paper to a real company — Zanzibar, where it all began.</div>
+          <div className="ab-timeline__photo-wrap">
+            <div className="ab-timeline__photo">
+              <ResponsiveImage src={STORY_IMAGE} alt="A traditional dhow on the Zanzibar coast" loading="lazy" />
+              <div className="ab-timeline__caption">From an idea on paper to a real company — Zanzibar, where it all began.</div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -260,12 +260,19 @@
   background: #2a1a10;
 }
 @media (min-width: 981px) {
-  .ab-timeline__photo-wrap { align-self: stretch; }
+  .ab-timeline__photo-wrap { align-self: stretch; position: relative; }
   .ab-timeline__photo-wrap .ab-timeline__photo {
     position: sticky;
     top: calc(var(--nav-height, 66px) + 1.5rem);
     aspect-ratio: auto;
-    height: min(45vh, 380px);
+    height: min(64vh, 560px);
+  }
+  .ab-timeline__photo-wrap.js-pin .ab-timeline__photo {
+    position: relative;
+    top: auto;
+    transform: translate3d(0, var(--pin-y, 0px), 0);
+    will-change: transform;
+    transition: none;
   }
 }
 .ab-timeline__photo img { width: 100%; height: 100%; object-fit: cover; display: block; }

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -259,6 +259,15 @@
   aspect-ratio: 4/5;
   background: #2a1a10;
 }
+@media (min-width: 981px) {
+  .ab-timeline__photo-wrap { align-self: stretch; }
+  .ab-timeline__photo-wrap .ab-timeline__photo {
+    position: sticky;
+    top: calc(var(--nav-height, 66px) + 1.5rem);
+    aspect-ratio: auto;
+    height: min(45vh, 380px);
+  }
+}
 .ab-timeline__photo img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .ab-timeline__caption {
   position: absolute; left: 1.25rem; bottom: 1.25rem; right: 1.25rem; z-index: 2;


### PR DESCRIPTION
## Summary

Large pre-launch branch consolidating several feature/polish lines on top of `main`.

**About page**
- Launch-aligned rewrite (hero, story, mission, community, destinations, CTA) wired into nav and footer
- Brand-aligned polish on color, image and casing
- Sticky → JS transform-based scrollytelling pin on the Our Story timeline photo

**Mobile menu (V2A)**
- Photo-takeover overlay matching design handoff
- 7-item spacing fits without scroll
- Hero photo rotates on each open
- Italic-em emphasis tied to active row only

**Performance**
- Built srcset manifest with accurate widths + intrinsic dims (`scripts/build-image-manifest.mjs`)
- `DeferredMount` triggers on user interaction with a 6s fallback
- Heavy homepage sections (planner, map) deferred
- Lighthouse: contrast fixes and image sizing

**Accessibility**
- Three Lighthouse score-zero audit fixes

**Email + planner (Netlify Functions via Resend)**
- `booking-send`, `contact-send`, `planner-send` functions
- Booking form migrated off mailto to `/api/booking-send`
- Distinct team vs guest emails for planner / contact / booking
- Planner: Claude Haiku 4.5, guest update support after handoff, structured (non-markdown) summaries, bot echoes contact info for reliable server values
- Planner conversation and handoff button refined

**Mobile UX pass**
- Nav, planner, weather, filters and footer polish

**Hardening**
- `ErrorBoundary` component + page, plus form hardening for production deploy

## Test plan

- [ ] About page: hero, timeline scroll-pin tracks photo through to "Today" (desktop), reduced-motion + mobile fall back cleanly
- [ ] Mobile menu: opens, rotates hero photo, active row italic emphasis, all 7 items visible without scroll
- [ ] Booking, contact and planner forms deliver to both team and guest mailboxes via Resend
- [ ] Planner: handoff flow, guest updates after handoff, no markdown in delivered emails
- [ ] Homepage: deferred planner and map mount on interaction
- [ ] Responsive images load correct srcset widths; no CLS regression
- [ ] Lighthouse perf/a11y scores stable or improved
- [ ] ErrorBoundary catches a thrown render error in a child without breaking the rest of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)