### PR TITLE
Mobile error-boundary fix + About Us polish + perf/a11y

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,21 +2,39 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import SiteLayout from './components/SiteLayout.jsx';
 
-const Homepage = lazy(() => import('./pages/Homepage.jsx'));
-const Excursions = lazy(() => import('./pages/Excursions.jsx'));
-const ExcursionCombinationDetail = lazy(() => import('./pages/ExcursionCombinationDetail.jsx'));
-const ExcursionDetail = lazy(() => import('./pages/ExcursionDetail.jsx'));
-const Safaris = lazy(() => import('./pages/Safaris.jsx'));
-const SafariDetail = lazy(() => import('./pages/SafariDetail.jsx'));
-const SafariTypeDetail = lazy(() => import('./pages/SafariTypeDetail.jsx'));
-const Packages = lazy(() => import('./pages/Packages.jsx'));
-const PackageDetail = lazy(() => import('./pages/PackageDetail.jsx'));
-const TripPlannerPage = lazy(() => import('./pages/TripPlannerPage.jsx'));
-const Explore = lazy(() => import('./pages/Explore.jsx'));
-const About = lazy(() => import('./pages/About.jsx'));
-const Booking = lazy(() => import('./pages/Booking.jsx'));
-const Policy = lazy(() => import('./pages/Policy.jsx'));
-const NotFound = lazy(() => import('./pages/NotFound.jsx'));
+function lazyWithRetry(factory) {
+  return lazy(async () => {
+    try {
+      return await factory();
+    } catch (error) {
+      const message = error?.message || '';
+      const isChunkError =
+        error?.name === 'ChunkLoadError' ||
+        /Loading chunk [\w-]+ failed|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module/i.test(
+          message,
+        );
+      if (!isChunkError) throw error;
+      await new Promise((r) => setTimeout(r, 250));
+      return factory();
+    }
+  });
+}
+
+const Homepage = lazyWithRetry(() => import('./pages/Homepage.jsx'));
+const Excursions = lazyWithRetry(() => import('./pages/Excursions.jsx'));
+const ExcursionCombinationDetail = lazyWithRetry(() => import('./pages/ExcursionCombinationDetail.jsx'));
+const ExcursionDetail = lazyWithRetry(() => import('./pages/ExcursionDetail.jsx'));
+const Safaris = lazyWithRetry(() => import('./pages/Safaris.jsx'));
+const SafariDetail = lazyWithRetry(() => import('./pages/SafariDetail.jsx'));
+const SafariTypeDetail = lazyWithRetry(() => import('./pages/SafariTypeDetail.jsx'));
+const Packages = lazyWithRetry(() => import('./pages/Packages.jsx'));
+const PackageDetail = lazyWithRetry(() => import('./pages/PackageDetail.jsx'));
+const TripPlannerPage = lazyWithRetry(() => import('./pages/TripPlannerPage.jsx'));
+const Explore = lazyWithRetry(() => import('./pages/Explore.jsx'));
+const About = lazyWithRetry(() => import('./pages/About.jsx'));
+const Booking = lazyWithRetry(() => import('./pages/Booking.jsx'));
+const Policy = lazyWithRetry(() => import('./pages/Policy.jsx'));
+const NotFound = lazyWithRetry(() => import('./pages/NotFound.jsx'));
 
 export default function App() {
   return (

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -2,6 +2,39 @@ import { Component } from 'react';
 import { useLocation } from 'react-router-dom';
 import ErrorBoundaryPage from '../pages/ErrorBoundaryPage.jsx';
 
+const RELOAD_FLAG = 'dp-chunk-reload';
+
+function isChunkLoadError(error) {
+  if (!error) return false;
+  const name = error.name || '';
+  const message = error.message || '';
+  if (name === 'ChunkLoadError') return true;
+  return /Loading chunk [\w-]+ failed|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module/i.test(
+    message,
+  );
+}
+
+function tryAutoRecover(error) {
+  if (typeof window === 'undefined') return false;
+  if (!isChunkLoadError(error)) return false;
+  try {
+    if (sessionStorage.getItem(RELOAD_FLAG)) return false;
+    sessionStorage.setItem(RELOAD_FLAG, '1');
+  } catch {
+    // sessionStorage unavailable (private mode etc.) — fall through to a one-shot reload.
+  }
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations?.().then((regs) => {
+      regs.forEach((r) => r.unregister());
+    }).catch(() => {});
+  }
+  if (typeof caches !== 'undefined' && caches?.keys) {
+    caches.keys().then((keys) => Promise.all(keys.map((k) => caches.delete(k)))).catch(() => {});
+  }
+  window.location.reload();
+  return true;
+}
+
 class ErrorBoundaryFrame extends Component {
   state = { error: null };
 
@@ -11,6 +44,7 @@ class ErrorBoundaryFrame extends Component {
 
   componentDidCatch(error, errorInfo) {
     console.error('Destination Paradise error boundary caught an error:', error, errorInfo);
+    tryAutoRecover(error);
   }
 
   componentDidUpdate(previousProps) {
@@ -20,11 +54,19 @@ class ErrorBoundaryFrame extends Component {
   }
 
   reset = () => {
+    try {
+      sessionStorage.removeItem(RELOAD_FLAG);
+    } catch {
+      // ignore
+    }
     this.setState({ error: null });
   };
 
   render() {
     if (this.state.error) {
+      if (isChunkLoadError(this.state.error)) {
+        return null;
+      }
       return <ErrorBoundaryPage error={this.state.error} onReset={this.reset} />;
     }
 


### PR DESCRIPTION
## Summary
- **Mobile auto-recovery from stale PWA chunks** (c3761170) — `lazy()` imports retry once on chunk-load failures, and the error boundary unregisters the SW, clears caches, and reloads once (guarded by sessionStorage) when a chunk-load error reaches it. Fixes the "We lost the route for a moment" screen returning visitors hit on Excursions / Safaris / Packages and detail pages after a redeploy.
- **About Us launch-aligned rewrite** plus sticky-photo timeline (later replaced by JS transform pin for fuller follow-through), founding-note expansion, founder portrait avatar, and brand-aligned polish.
- **Weather**: degree-symbol typography alignment.
- Carries forward earlier merged work: mobile menu V2A, Lighthouse a11y/perf fixes, responsive-image manifest, planner/booking Resend migration.

## Test plan
- [ ] Open homepage on a phone that previously visited the site; verify "View all excursions/safaris/packages" and trip-card links no longer hit the error boundary.
- [ ] First-load on a stale-SW device shows a brief blank flash then the working page (one-shot reload).
- [ ] Verify the reload happens at most once per session (no loops).
- [ ] Spot-check About Us scrollytelling on mobile + desktop.
- [ ] Run Lighthouse on a key page to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)