### PR TITLE
Make mobile hero intro full screen

### DIFF
--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -70,13 +70,15 @@ export default function HeroSection({ tweaks, handleHeroSearch }) {
         ))}
       </div>
       <div className="hero__content">
-  <span className="hero__eyebrow">15 packages · 29 safaris · 40+ excursions</span>
-        <h1 className="hero__title">Destination Paradise</h1>
-        <h2 className="hero__motto"><i>your next trip to paradise…</i></h2>
-  <p className="hero__desc">Plan Zanzibar and Tanzania in one place: complete safari-and-beach packages, island excursions, mainland safaris, and an AI planner that helps shape the right route.</p>
-        <div className="hero__cta-row">
-          <Link className="btn" to="/packages">Browse packages <ArrowIcon size={18} /></Link>
-          <Link className="btn btn--ghost" to="/explore">Explore Zanzibar &amp; Tanzania</Link>
+        <div className="hero__intro">
+          <span className="hero__eyebrow">15 packages · 29 safaris · 40+ excursions</span>
+          <h1 className="hero__title">Destination Paradise</h1>
+          <h2 className="hero__motto"><i>your next trip to paradise…</i></h2>
+          <p className="hero__desc">Plan Zanzibar and Tanzania in one place: complete safari-and-beach packages, island excursions, mainland safaris, and an AI planner that helps shape the right route.</p>
+          <div className="hero__cta-row">
+            <Link className="btn" to="/packages">Browse packages <ArrowIcon size={18} /></Link>
+            <Link className="btn btn--ghost" to="/explore">Explore Zanzibar &amp; Tanzania</Link>
+          </div>
         </div>
         <form className="hero__search" onSubmit={handleHeroSearch}>
           <div className="hero__search-field">

--- a/src/styles/homepage/mobile.css
+++ b/src/styles/homepage/mobile.css
@@ -42,10 +42,22 @@ html, body { max-width: 100%; }
 /* ---- Hero: tame display sizes & padding ---- */
 @media (max-width: 720px) {
   .hero--photo {
-    min-height: 100svh;
-    padding: clamp(5.2rem, 12vw, 6.2rem) clamp(1.25rem, 5vw, 6rem) clamp(2.25rem, 5vh, 3.5rem);
+    min-height: auto;
+    align-items: flex-start;
+    padding: 0 clamp(1.25rem, 5vw, 6rem) clamp(2.25rem, 5vh, 3.5rem);
   }
   .hero__content { transform: none; }
+  .hero__intro {
+    min-height: 100svh;
+    min-height: 100dvh;
+    width: 100%;
+    display: grid;
+    justify-items: center;
+    align-content: center;
+    gap: clamp(.6rem, 1.05vh, 1rem);
+    padding-top: calc(var(--nav-height) + max(1rem, env(safe-area-inset-top, 0px)));
+    padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  }
   .hero__eyebrow { font-size: 10px; padding: .4rem .8rem; margin-bottom: 0; letter-spacing: .18em; }
   .hero__title { font-size: clamp(2.75rem, 13vw, 4.25rem); line-height: 1.02; }
   .hero__motto { font-size: clamp(1.15rem, 5.5vw, 1.6rem); margin: 0; }
@@ -59,15 +71,20 @@ html, body { max-width: 100%; }
 
 @media (max-width: 480px) {
   .hero--photo {
-    min-height: auto;
     align-items: flex-start;
-    padding: calc(var(--nav-height) + 1.3rem) 1rem calc(4.25rem + env(safe-area-inset-bottom, 0px));
+    padding: 0 1rem calc(4.25rem + env(safe-area-inset-bottom, 0px));
   }
 
   .hero__content {
     width: 100%;
     max-width: 24rem;
     gap: .48rem;
+  }
+
+  .hero__intro {
+    gap: .48rem;
+    padding-top: calc(var(--nav-height) + max(1rem, env(safe-area-inset-top, 0px)));
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   }
 
   .hero__eyebrow {
@@ -113,11 +130,14 @@ html, body { max-width: 100%; }
 
 @media (max-width: 380px) {
   .hero--photo {
-    min-height: 100svh;
     padding-inline: .85rem;
   }
 
   .hero__content {
+    gap: .42rem;
+  }
+
+  .hero__intro {
     gap: .42rem;
   }
 
@@ -148,25 +168,31 @@ html, body { max-width: 100%; }
   }
 
   .hero__search {
-    display: none;
+    margin-top: 0;
   }
 }
 
 @media (max-width: 480px) and (max-height: 700px) {
-  .hero--photo {
-    padding-top: calc(var(--nav-height) + .85rem);
+  .hero__intro {
+    padding-top: calc(var(--nav-height) + .75rem);
+    padding-bottom: .75rem;
   }
 }
 
 @media (max-width: 360px) and (max-height: 640px) {
   .hero--photo {
-    min-height: 100svh;
-    padding: calc(var(--nav-height) + .75rem) .85rem calc(3.25rem + env(safe-area-inset-bottom, 0px));
+    padding: 0 .85rem calc(3.25rem + env(safe-area-inset-bottom, 0px));
   }
 
   .hero__content {
     max-width: 18rem;
     gap: .34rem;
+  }
+
+  .hero__intro {
+    gap: .34rem;
+    padding-top: calc(var(--nav-height) + .6rem);
+    padding-bottom: .6rem;
   }
 
   .hero__eyebrow {
@@ -205,7 +231,7 @@ html, body { max-width: 100%; }
   }
 
   .hero__search {
-    display: none;
+    margin-top: 0;
   }
 }
 

--- a/src/styles/homepage/nav-stand.css
+++ b/src/styles/homepage/nav-stand.css
@@ -191,6 +191,9 @@
   gap: clamp(.6rem, 1.05vh, 1rem);
   transform: none;
 }
+.hero__intro {
+  display: contents;
+}
 .hero__eyebrow {
   display: inline-flex; align-items: center; gap: .55rem;
   font-family: var(--dp-font-sans);


### PR DESCRIPTION
## Summary
- Makes the mobile homepage hero intro fill the first viewport.
- Moves the route search form below the first mobile screen.
- Keeps desktop hero behavior unchanged.

## Verification
- `npm run build`
- `npm run lint` (passes with the existing SiteLayout hook dependency warning)
- Mobile viewport check at 390x844 confirmed the intro fills the viewport and the search form starts below it.
