### PR TITLE
Add global site search

### DIFF
--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -24,7 +24,6 @@ const ThemeIcon = ({ theme }) => (
 );
 
 const THEME_MODES = [
-  { mode: 'auto', label: 'Auto' },
   { mode: 'light', label: 'Light' },
   { mode: 'dark', label: 'Dark' },
 ];
@@ -273,9 +272,7 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
       <div className="footer__theme-row">
         <div className="footer__theme-toggle" role="radiogroup" aria-label="Theme preference">
           {THEME_MODES.map((option) => {
-            const isActive = themeMode === option.mode;
-            const iconTheme = option.mode === 'auto' ? theme : option.mode;
-            const label = option.mode === 'auto' ? `Auto ${theme}` : option.label;
+            const isActive = themeMode === 'auto' ? theme === option.mode : themeMode === option.mode;
 
             return (
               <button
@@ -284,11 +281,11 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
                 type="button"
                 role="radio"
                 aria-checked={isActive}
-                aria-label={`${label} mode`}
+                aria-label={`${option.label} mode`}
                 onClick={() => onThemeModeChange?.(option.mode)}
               >
-                <ThemeIcon theme={iconTheme} />
-                <span>{label}</span>
+                <ThemeIcon theme={option.mode} />
+                <span>{option.label}</span>
               </button>
             );
           })}

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import { CONTACT_INFO } from '../constants/contactInfo';
+import SiteSearch, { SearchButton } from './SiteSearch.jsx';
 
 const NAV_ITEMS = [
   { label: 'Home', to: '/', end: true, icon: 'home', hint: 'Start at the island hub' },
@@ -79,13 +80,17 @@ const MOBILE_NAV_QUERY = '(max-width: 960px)';
 
 export default function SiteNav() {
   const [navOpen, setNavOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [bgIndex, setBgIndex] = useState(() => Math.floor(Math.random() * MM_BGS.length));
   const navRef = useRef(null);
   const mmRef = useRef(null);
   const location = useLocation();
 
   // Close on route change
-  useEffect(() => { setNavOpen(false); }, [location.pathname]);
+  useEffect(() => {
+    setNavOpen(false);
+    setSearchOpen(false);
+  }, [location.pathname, location.search, location.hash]);
 
   // Rotate background each time the menu opens — pick a different image than last time
   useEffect(() => {
@@ -170,6 +175,7 @@ export default function SiteNav() {
           ))}
         </ul>
         <div className="nav__right">
+          <SearchButton className="nav__search" onClick={() => setSearchOpen(true)} label="Search" />
           <Link className="btn nav__cta" to="/booking" aria-label="Book now">
             <span className="nav__cta-text">Book Now</span> <BookingIcon size={16} />
           </Link>
@@ -247,6 +253,14 @@ export default function SiteNav() {
         </ul>
 
         <div className="mm-menu__foot">
+          <SearchButton
+            className="mm-menu__search"
+            onClick={() => {
+              setNavOpen(false);
+              setSearchOpen(true);
+            }}
+            label="Search the site"
+          />
           <Link to="/booking" className="mm-menu__cta">
             Book a trip <ChevronRight />
           </Link>
@@ -261,6 +275,7 @@ export default function SiteNav() {
           </a>
         </div>
       </div>
+      <SiteSearch open={searchOpen} onClose={() => setSearchOpen(false)} />
     </nav>
   );
 }

--- a/src/components/SiteSearch.jsx
+++ b/src/components/SiteSearch.jsx
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const MAX_RESULTS = 8;
+const FALLBACK_POPULAR = [
+  'Airport transfer',
+  'Safari Blue',
+  'Honeymoon package',
+  'Serengeti',
+  'Stone Town',
+  'Paje',
+];
+
+const tokenize = (query) => query
+  .toLowerCase()
+  .trim()
+  .split(/\s+/)
+  .filter(Boolean);
+
+const scoreResult = (item, terms) => {
+  if (!terms.length) return 0;
+
+  const title = item.title.toLowerCase();
+  const category = item.category.toLowerCase();
+  let score = 0;
+
+  terms.forEach((term) => {
+    if (title === term) score += 90;
+    if (title.startsWith(term)) score += 45;
+    if (title.includes(term)) score += 28;
+    if (category.includes(term)) score += 18;
+    if (item.searchText.includes(term)) score += 8;
+  });
+
+  if (terms.every((term) => item.searchText.includes(term))) score += 30;
+  return score;
+};
+
+const SearchIcon = ({ size = 20 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" />
+    <path d="m20 20-3.5-3.5" />
+  </svg>
+);
+
+const ArrowIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+);
+
+export function SearchButton({ className = '', onClick, label = 'Search' }) {
+  return (
+    <button className={className} type="button" aria-label="Search the website" onClick={onClick}>
+      <SearchIcon />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export default function SiteSearch({ open, onClose }) {
+  const [query, setQuery] = useState('');
+  const [searchIndex, setSearchIndex] = useState([]);
+  const [popularSearches, setPopularSearches] = useState(FALLBACK_POPULAR);
+  const inputRef = useRef(null);
+
+  const results = useMemo(() => {
+    if (!searchIndex.length) return [];
+
+    const terms = tokenize(query);
+    if (!terms.length) {
+      return searchIndex.filter((item) => (
+        ['Transfers', 'Packages', 'Safaris', 'Excursions', 'Booking', 'Trip Planner'].includes(item.title)
+      ));
+    }
+
+    return searchIndex
+      .map((item) => ({ item, score: scoreResult(item, terms) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score || a.item.title.localeCompare(b.item.title))
+      .slice(0, MAX_RESULTS)
+      .map((entry) => entry.item);
+  }, [query, searchIndex]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    window.setTimeout(() => inputRef.current?.focus(), 30);
+
+    const handleKey = (event) => {
+      if (event.key === 'Escape') onClose?.();
+    };
+
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (open) setQuery('');
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || searchIndex.length) return undefined;
+
+    let disposed = false;
+    import('../data/siteSearchIndex.js').then((module) => {
+      if (disposed) return;
+      setSearchIndex(module.SITE_SEARCH_INDEX || []);
+      setPopularSearches(module.SITE_SEARCH_POPULAR || FALLBACK_POPULAR);
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [open, searchIndex.length]);
+
+  if (!open) return null;
+
+  return (
+    <div className="site-search" role="dialog" aria-modal="true" aria-label="Search the website">
+      <button className="site-search__backdrop" type="button" aria-label="Close search" onClick={onClose} />
+      <div className="site-search__panel">
+        <div className="site-search__field">
+          <SearchIcon size={22} />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            type="search"
+            placeholder="Search safaris, transfers, packages, Stone Town..."
+            aria-label="Search query"
+          />
+          <button type="button" className="site-search__close" onClick={onClose}>Close</button>
+        </div>
+
+        {!query.trim() && (
+          <div className="site-search__chips" aria-label="Popular searches">
+            {popularSearches.map((term) => (
+              <button type="button" key={term} onClick={() => setQuery(term)}>{term}</button>
+            ))}
+          </div>
+        )}
+
+        <div className="site-search__results" role="list">
+          {!searchIndex.length && (
+            <div className="site-search__loading">Preparing the site index...</div>
+          )}
+
+          {results.map((item) => (
+            <Link className="site-search__result" to={item.to} key={item.id} onClick={onClose} role="listitem">
+              <span className="site-search__result-main">
+                <span className="site-search__category">{item.category}</span>
+                <strong>{item.title}</strong>
+                <span>{item.description}</span>
+              </span>
+              <ArrowIcon />
+            </Link>
+          ))}
+
+          {query.trim() && results.length === 0 && (
+            <div className="site-search__empty">
+              <strong>No exact match yet.</strong>
+              <span>Try a destination, activity, package style, safari park, transfer route, or send us a custom request.</span>
+              <Link className="btn" to="/trip-planner" onClick={onClose}>Open trip planner</Link>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/siteSearchIndex.js
+++ b/src/data/siteSearchIndex.js
@@ -1,0 +1,184 @@
+import { EXCURSIONS } from './excursionsData.js';
+import { EXCURSION_COMBINATIONS } from './excursionCombinations.js';
+import { destinationParadisePackages } from './destinationParadisePackages.js';
+import { ALL_SAFARI_PRODUCTS, SAFARI_TYPES } from './safariPageData.js';
+import { TRANSFER_PRODUCTS } from './transferProducts.js';
+
+const pageItems = [
+  {
+    title: 'Home',
+    category: 'Page',
+    description: 'Start here for Zanzibar trips, safaris, packages, transfers, weather, gallery, and trip planning.',
+    to: '/',
+    keywords: ['destination paradise', 'zanzibar', 'tanzania', 'home', 'main page'],
+  },
+  {
+    title: 'Excursions',
+    category: 'Page',
+    description: 'Browse Zanzibar day trips, dhow sailing, Stone Town, spice farms, snorkeling, dolphins, and nature tours.',
+    to: '/excursions',
+    keywords: ['day trips', 'activities', 'tours', 'dhow', 'stone town', 'spice', 'mnemba', 'jozani'],
+  },
+  {
+    title: 'Safaris',
+    category: 'Page',
+    description: 'Mainland wildlife routes across Serengeti, Ngorongoro, Tarangire, Nyerere, Ruaha, and more.',
+    to: '/safaris',
+    keywords: ['wildlife', 'big five', 'serengeti', 'ngorongoro', 'tarangire', 'migration', 'game drive'],
+  },
+  {
+    title: 'Packages',
+    category: 'Page',
+    description: 'Safari and Zanzibar packages for honeymoon, family, luxury, culture, migration, and beach holidays.',
+    to: '/packages',
+    keywords: ['holiday package', 'honeymoon', 'family', 'bush and beach', 'safari zanzibar'],
+  },
+  {
+    title: 'Transfers',
+    category: 'Page',
+    description: 'Private airport transfers, hotel transfers, group transport, and VIP airport concierge service.',
+    to: '/transfers',
+    keywords: ['airport pickup', 'taxi', 'private car', 'paje', 'nungwi', 'kendwa', 'stone town'],
+  },
+  {
+    title: 'Trip Planner',
+    category: 'Page',
+    description: 'Build a custom itinerary around pace, dates, budget, beach time, safaris, and excursions.',
+    to: '/trip-planner',
+    keywords: ['custom trip', 'itinerary', 'planner', 'ai planner', 'route'],
+  },
+  {
+    title: 'Booking',
+    category: 'Page',
+    description: 'Send a booking request for a package, excursion, safari, transfer, or custom plan.',
+    to: '/booking',
+    keywords: ['book now', 'request', 'payment', 'reserve', 'availability'],
+  },
+  {
+    title: 'About Us',
+    category: 'Page',
+    description: 'Learn about Destination Paradise, our mission, story, community, and local travel approach.',
+    to: '/aboutus',
+    keywords: ['company', 'team', 'mission', 'story', 'community', 'contact'],
+  },
+];
+
+const compactList = (items = []) => items.filter(Boolean).join(' · ');
+
+const priceLabel = (pricing) => {
+  if (!pricing?.from) return '';
+  return `From $${pricing.from}${pricing.unit ? ` ${pricing.unit.toLowerCase()}` : ''}`;
+};
+
+const packageItems = destinationParadisePackages.map((item) => ({
+  title: item.title,
+  category: 'Package',
+  description: compactList([item.duration, item.category, item.split, priceLabel(item.pricing)]),
+  to: `/packages/${item.slug}`,
+  keywords: [
+    item.category,
+    item.duration,
+    item.split,
+    ...(item.idealFor || []),
+    ...(item.includes || []),
+    ...(item.route || []),
+  ],
+}));
+
+const safariItems = ALL_SAFARI_PRODUCTS.map((item) => ({
+  title: item.title,
+  category: item.productType || 'Safari',
+  description: compactList([item.duration, item.category || item.positioning, item.rib || (item.price ? `From $${item.price} ${item.priceSub || 'pp'}` : '')]),
+  to: `/safaris/${item.id}`,
+  keywords: [
+    item.category,
+    item.positioning,
+    item.duration,
+    item.from,
+    item.intro,
+    ...(item.highlights || []),
+    ...(item.idealFor || []),
+    ...(item.days || []).flatMap((day) => [day.h, day.p]),
+  ],
+}));
+
+const safariTypeItems = SAFARI_TYPES.map((item) => ({
+  title: item.title,
+  category: 'Safari style',
+  description: compactList([item.bestFor, item.desc]),
+  to: `/safaris/types/${item.id}`,
+  keywords: [item.bestFor, item.desc, ...(item.highlights || [])],
+}));
+
+const excursionItems = EXCURSIONS.map((item) => ({
+  title: item.title,
+  category: 'Excursion',
+  description: compactList([item.duration, item.category, item.price ? `From $${item.price} ${item.priceSub || 'pp'}` : '', item.description]),
+  to: `/excursions/${item.id}`,
+  keywords: [
+    item.category,
+    item.eyebrow,
+    item.duration,
+    item.from,
+    item.group,
+    item.description,
+    ...(item.highlights || []),
+    ...(item.facts || []).flat(),
+  ],
+}));
+
+const combinationItems = EXCURSION_COMBINATIONS.map((item) => ({
+  title: item.title,
+  category: 'Excursion combo',
+  description: compactList([item.length, item.combo?.join(' + '), item.desc]),
+  to: `/excursions/combinations/${item.id}`,
+  keywords: [item.length, item.desc, ...(item.combo || []), ...(item.idealFor || [])],
+}));
+
+const transferItems = TRANSFER_PRODUCTS.map((item) => ({
+  title: item.title,
+  category: item.category || 'Transfer',
+  description: compactList([item.duration, item.priceSummary, item.description]),
+  to: `/booking?type=transfer&item=${item.slug}#booking-details`,
+  keywords: [
+    item.duration,
+    item.description,
+    item.priceSummary,
+    ...(item.pricing || []),
+    ...(item.details || []),
+  ],
+}));
+
+const normalizeSearchItem = (item, index) => {
+  const text = [
+    item.title,
+    item.category,
+    item.description,
+    ...(item.keywords || []),
+  ].filter(Boolean).join(' ');
+
+  return {
+    ...item,
+    id: `${item.category}-${index}-${item.to}`,
+    searchText: text.toLowerCase(),
+  };
+};
+
+export const SITE_SEARCH_INDEX = [
+  ...pageItems,
+  ...transferItems,
+  ...packageItems,
+  ...safariItems,
+  ...safariTypeItems,
+  ...excursionItems,
+  ...combinationItems,
+].map(normalizeSearchItem);
+
+export const SITE_SEARCH_POPULAR = [
+  'Airport transfer',
+  'Safari Blue',
+  'Honeymoon package',
+  'Serengeti',
+  'Stone Town',
+  'Paje',
+];

--- a/src/styles/homepage/nav-mm.css
+++ b/src/styles/homepage/nav-mm.css
@@ -161,7 +161,7 @@
 /* Footer */
 .mm-menu__foot {
   padding: 10px 16px calc(14px + env(safe-area-inset-bottom, 0px));
-  display: flex; gap: 10px;
+  display: flex; flex-wrap: wrap; gap: 10px;
 }
 .mm-menu__cta {
   flex: 1;

--- a/src/styles/homepage/nav.css
+++ b/src/styles/homepage/nav.css
@@ -64,6 +64,31 @@
 
 .nav__right { display: flex; align-items: center; gap: 1rem; }
 
+.nav__search {
+  width: 42px;
+  height: 42px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-raised) 88%, transparent);
+  color: var(--text);
+  cursor: pointer;
+  transition: color .25s ease, border-color .25s ease, background .25s ease, transform .25s ease;
+}
+.nav__search span { display: none; }
+.nav__search:hover,
+.nav__search:focus-visible {
+  color: var(--dp-accent);
+  border-color: color-mix(in srgb, var(--dp-accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--dp-accent) 10%, var(--surface-raised));
+  transform: translateY(-1px);
+}
+.nav__search:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--dp-accent) 24%, transparent);
+  outline-offset: 2px;
+}
+
 .nav__cta {
   padding: .55rem 1.1rem;
   font-size: 13px;
@@ -179,6 +204,12 @@
   .nav__right {
     flex: 0 0 auto;
     gap: .5rem;
+  }
+
+  .nav__search {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
   }
 
   .nav__cta {

--- a/src/styles/homepage/site-search.css
+++ b/src/styles/homepage/site-search.css
@@ -1,0 +1,247 @@
+.site-search {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: grid;
+  place-items: start center;
+  padding: calc(var(--nav-height) + clamp(1rem, 4vh, 2.5rem)) clamp(1rem, 4vw, 2rem) 2rem;
+}
+
+.site-search__backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(8, 30, 46, .48);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  cursor: default;
+}
+
+.site-search__panel {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 760px);
+  max-height: min(760px, calc(100svh - var(--nav-height) - 3rem));
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--surface-raised) 96%, transparent);
+  box-shadow: 0 30px 80px -42px rgba(8, 30, 46, .8);
+}
+
+.site-search__field {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .75rem;
+  padding: .85rem .9rem .85rem 1rem;
+  border-bottom: 1px solid var(--divider);
+  color: var(--text-soft);
+}
+
+.site-search__field input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font: 700 clamp(1rem, 2vw, 1.2rem)/1.2 var(--dp-font-sans);
+}
+
+.site-search__field input::placeholder {
+  color: var(--text-muted);
+  font-weight: 650;
+}
+
+.site-search__close {
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: .35rem .75rem;
+  background: var(--surface);
+  color: var(--text-soft);
+  font-family: var(--dp-font-sans);
+  font-size: .78rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.site-search__close:hover,
+.site-search__close:focus-visible {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--dp-accent) 32%, var(--border));
+}
+
+.site-search__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  padding: .85rem 1rem;
+  border-bottom: 1px solid var(--divider);
+}
+
+.site-search__chips button {
+  min-height: 34px;
+  border: 1px solid color-mix(in srgb, var(--dp-accent) 26%, var(--border));
+  border-radius: 999px;
+  padding: .35rem .75rem;
+  background: color-mix(in srgb, var(--dp-accent) 8%, var(--surface));
+  color: var(--text);
+  font-family: var(--dp-font-sans);
+  font-size: .78rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.site-search__chips button:hover,
+.site-search__chips button:focus-visible {
+  background: var(--dp-accent);
+  border-color: var(--dp-accent);
+  color: #fff;
+}
+
+.site-search__results {
+  min-height: 0;
+  overflow: auto;
+  padding: .55rem;
+}
+
+.site-search__result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  padding: .95rem 1rem;
+  border-radius: 16px;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.site-search__result:hover,
+.site-search__result:focus-visible {
+  background: color-mix(in srgb, var(--dp-accent) 9%, var(--surface));
+  outline: none;
+}
+
+.site-search__result-main {
+  min-width: 0;
+  display: grid;
+  gap: .25rem;
+}
+
+.site-search__category {
+  color: var(--dp-accent);
+  font-family: var(--dp-font-sans);
+  font-size: .68rem;
+  font-weight: 900;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+
+.site-search__result strong {
+  color: var(--text);
+  font-family: var(--dp-font-sans);
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.site-search__result span:last-child {
+  color: var(--text-muted);
+  font-family: var(--dp-font-display);
+  font-size: .92rem;
+  line-height: 1.45;
+}
+
+.site-search__result > svg {
+  color: var(--text-muted);
+  transition: transform .25s ease, color .25s ease;
+}
+
+.site-search__result:hover > svg,
+.site-search__result:focus-visible > svg {
+  color: var(--dp-accent);
+  transform: translateX(3px);
+}
+
+.site-search__empty {
+  display: grid;
+  justify-items: start;
+  gap: .65rem;
+  padding: 1.3rem;
+  color: var(--text-muted);
+}
+
+.site-search__empty strong {
+  color: var(--text);
+  font-family: var(--dp-font-sans);
+}
+
+.site-search__empty span {
+  font-family: var(--dp-font-display);
+  line-height: 1.55;
+}
+
+.site-search__loading {
+  padding: 1rem;
+  color: var(--text-muted);
+  font-family: var(--dp-font-sans);
+  font-size: .85rem;
+  font-weight: 800;
+}
+
+.mm-menu__search {
+  flex: 0 0 100%;
+  width: 100%;
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .55rem;
+  border: 1px solid rgba(255,255,255,.2);
+  border-radius: 14px;
+  background: rgba(255,255,255,.12);
+  color: #fff;
+  font-family: var(--dp-font-sans);
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.mm-menu__search:hover,
+.mm-menu__search:focus-visible {
+  background: rgba(255,255,255,.2);
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .site-search {
+    align-items: start;
+    padding: calc(var(--nav-height) + .75rem) .75rem .75rem;
+  }
+
+  .site-search__panel {
+    max-height: calc(100svh - var(--nav-height) - 1.5rem);
+    border-radius: 18px;
+  }
+
+  .site-search__field {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: .8rem;
+  }
+
+  .site-search__close {
+    grid-column: 1 / -1;
+    justify-self: end;
+  }
+
+  .site-search__result {
+    padding: .85rem;
+  }
+}
+
+html[data-theme="dark"] .site-search__close,
+html[data-theme="dark"] .site-search__chips button {
+  background: color-mix(in srgb, var(--surface-2) 88%, white 4%);
+}

--- a/src/styles/site-shell.css
+++ b/src/styles/site-shell.css
@@ -1,6 +1,7 @@
 @import "./homepage/buttons.css";
 @import "./homepage/nav.css";
 @import "./homepage/nav-mm.css";
+@import "./homepage/site-search.css";
 @import "./homepage/footer.css";
 @import "./homepage/floating-chat.css";
 @import "./cookie-banner.css";


### PR DESCRIPTION
## Summary
- Add a global nav search overlay for pages, packages, safaris, safari styles, excursions, combinations, and transfers
- Lazy-load the search index so the main bundle stays light
- Simplify the footer theme toggle to show only Light and Dark while reflecting automatic system theme

## Validation
- npm run lint
- npm run build
- Browser-tested search queries for paje and honeymoon