### PR TITLE
Fix Lighthouse heading-order accessibility regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <link rel="icon" type="image/webp" href="/assets/brand/destination-paradise-logo-96.webp" />
     <link rel="apple-touch-icon" sizes="192x192" href="/assets/brand/destination-paradise-logo-192.png" />
     <link rel="preload" href="/assets/fonts/kaushan-script-regular.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/assets/fonts/playfair-display-variable.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/assets/fonts/montserrat-variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/assets/images/home/aerial-boats-turquoise-water.webp" as="image" fetchpriority="high" />
     <link rel="manifest" href="/manifest.json" />
     <title>Destination Paradise — your next trip to paradise</title>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,6 @@
     <link rel="icon" type="image/webp" href="/assets/brand/destination-paradise-logo-96.webp" />
     <link rel="apple-touch-icon" sizes="192x192" href="/assets/brand/destination-paradise-logo-192.png" />
     <link rel="preload" href="/assets/fonts/kaushan-script-regular.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="/assets/fonts/playfair-display-variable.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="/assets/fonts/montserrat-variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/assets/images/home/aerial-boats-turquoise-water.webp" as="image" fetchpriority="high" />
     <link rel="manifest" href="/manifest.json" />
     <title>Destination Paradise — your next trip to paradise</title>

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -237,7 +237,7 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
           </div>
         </div>
         <div className="footer__col">
-          <h4>Pages</h4>
+          <h3>Pages</h3>
           <ul>
             <li><Link to="/"><FooterIcon name="home" />Home</Link></li>
             <li><Link to="/excursions"><FooterIcon name="compass" />Excursions</Link></li>
@@ -249,7 +249,7 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
           </ul>
         </div>
         <div className="footer__col">
-          <h4>About Us</h4>
+          <h3>About Us</h3>
           <ul>
             <li><Link to="/aboutus#story"><FooterIcon name="book" />Our story</Link></li>
             <li><Link to="/aboutus#mission"><FooterIcon name="target" />Our mission</Link></li>
@@ -258,7 +258,7 @@ export default function SiteFooter({ theme = 'light', themeMode = 'auto', onThem
           </ul>
         </div>
         <div className="footer__col">
-          <h4>Get in touch</h4>
+          <h3>Get in touch</h3>
           <ul>
             <li><a href={`mailto:${CONTACT_INFO.email}`}><FooterIcon name="mail" />{CONTACT_INFO.email}</a></li>
             <li><a href={`tel:${CONTACT_INFO.phones[0]}`}><FooterIcon name="phone" />+255 768 779 517</a></li>

--- a/src/styles/homepage/footer.css
+++ b/src/styles/homepage/footer.css
@@ -109,7 +109,7 @@
   display: flex;
   justify-content: center;
 }
-.footer__col h4 { font-family: var(--dp-font-sans); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; color: var(--text-soft); margin: 0 0 1rem; font-weight: 700; }
+.footer__col h3 { font-family: var(--dp-font-sans); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; color: var(--text-soft); margin: 0 0 1rem; font-weight: 700; }
 .footer__col ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: .6rem; }
 .footer__col a {
   width: fit-content;

--- a/src/styles/homepage/mobile.css
+++ b/src/styles/homepage/mobile.css
@@ -533,7 +533,7 @@ html, body { max-width: 100%; }
 @media (max-width: 720px) {
   .footer { padding: 2.25rem 1.25rem 1.25rem; }
   .footer__inner { gap: 1.5rem; }
-  .footer__col h4 { margin-bottom: .65rem; }
+  .footer__col h3 { margin-bottom: .65rem; }
   .footer__col ul { gap: .5rem; }
   .footer__theme-row { margin-top: 1.5rem; justify-content: center; }
   .footer__bottom {


### PR DESCRIPTION
## Summary
Promotes the heading-order accessibility fix from `development` to `main`. Brings in [#53](https://github.com/louisclarencepeter/destinationparadise/pull/53).

- Footer rendered three `<h4>` headings (Pages / About Us / Get in touch) with no preceding `<h3>`, breaking sequential heading order across the homepage.
- Promoted them to `<h3>` in `SiteFooter.jsx` and updated the matching selectors in `footer.css` and `mobile.css`.

An earlier commit on the merged branch experimented with extra font preloads to reduce hero CLS — those were reverted in the same PR after the Netlify deploy preview showed Performance dropping 11 points (the preloads competed with the LCP image at Highest priority). CLS remains at its ~0.134 baseline; a follow-up using `@font-face` metric overrides would be the right fix.

## Test plan
- [ ] Lighthouse Accessibility on homepage returns to 100 (heading-order audit passes)
- [ ] Lighthouse Performance unchanged from prior production (~94)
- [ ] Visual spot-check: footer columns still render with the same uppercase-eyebrow style

🤖 Generated with [Claude Code](https://claude.com/claude-code)