### PR TITLE
Add i18n foundation (react-i18next) with EN/PL switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "destination-paradise",
       "version": "0.1.0",
       "dependencies": {
+        "i18next": "^23.16.8",
+        "i18next-browser-languagedetector": "^8.2.1",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^14.1.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.27.0"
       },
@@ -1515,7 +1518,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4748,6 +4750,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4756,6 +4767,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/idb": {
@@ -6853,6 +6896,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -8408,6 +8473,15 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "i18next": "^23.16.8",
+    "i18next-browser-languagedetector": "^8.2.1",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^14.1.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.27.0"
   },

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { SUPPORTED_LANGUAGES } from '../i18n/index.js';
+
+const LABELS = {
+  en: { short: 'EN', long: 'English' },
+  pl: { short: 'PL', long: 'Polski' },
+};
+
+export default function LanguageSwitcher({ className = '' }) {
+  const { i18n, t } = useTranslation();
+  const active = SUPPORTED_LANGUAGES.includes(i18n.resolvedLanguage)
+    ? i18n.resolvedLanguage
+    : 'en';
+
+  const choose = (lang) => {
+    if (lang === active) return;
+    i18n.changeLanguage(lang);
+  };
+
+  return (
+    <div
+      className={`lang-switcher${className ? ` ${className}` : ''}`}
+      role="group"
+      aria-label={t('language.switcher_label')}
+    >
+      {SUPPORTED_LANGUAGES.map((lang) => {
+        const isActive = lang === active;
+        return (
+          <button
+            key={lang}
+            type="button"
+            className={`lang-switcher__btn${isActive ? ' is-active' : ''}`}
+            onClick={() => choose(lang)}
+            aria-pressed={isActive}
+            aria-label={t(lang === 'en' ? 'language.switch_to_english' : 'language.switch_to_polish')}
+            lang={lang}
+          >
+            {LABELS[lang].short}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import { CONTACT_INFO } from '../constants/contactInfo';
 import SiteSearch, { SearchButton } from './SiteSearch.jsx';
+import LanguageSwitcher from './LanguageSwitcher.jsx';
 
 const NAV_ITEMS = [
   { label: 'Home', to: '/', end: true, icon: 'home', hint: 'Start at the island hub' },
@@ -175,6 +176,7 @@ export default function SiteNav() {
           ))}
         </ul>
         <div className="nav__right">
+          <LanguageSwitcher className="nav__lang" />
           <SearchButton className="nav__search" onClick={() => setSearchOpen(true)} label="Search" />
           <Link className="btn nav__cta" to="/booking" aria-label="Book now">
             <span className="nav__cta-text">Book Now</span> <BookingIcon size={16} />

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,44 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import enCommon from '../locales/en/common.json';
+import plCommon from '../locales/pl/common.json';
+
+export const SUPPORTED_LANGUAGES = ['en', 'pl'];
+export const DEFAULT_LANGUAGE = 'en';
+export const STORAGE_KEY = 'dp_lang';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { common: enCommon },
+      pl: { common: plCommon },
+    },
+    fallbackLng: DEFAULT_LANGUAGE,
+    supportedLngs: SUPPORTED_LANGUAGES,
+    ns: ['common'],
+    defaultNS: 'common',
+    detection: {
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: STORAGE_KEY,
+      caches: ['localStorage'],
+    },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+    returnNull: false,
+  });
+
+i18n.on('languageChanged', (lng) => {
+  if (typeof document !== 'undefined' && SUPPORTED_LANGUAGES.includes(lng)) {
+    document.documentElement.lang = lng;
+  }
+});
+
+if (typeof document !== 'undefined') {
+  document.documentElement.lang = i18n.resolvedLanguage || DEFAULT_LANGUAGE;
+}
+
+export default i18n;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,0 +1,9 @@
+{
+  "language": {
+    "switcher_label": "Language",
+    "english": "English",
+    "polish": "Polski",
+    "switch_to_english": "Switch language to English",
+    "switch_to_polish": "Switch language to Polish"
+  }
+}

--- a/src/locales/pl/common.json
+++ b/src/locales/pl/common.json
@@ -1,0 +1,9 @@
+{
+  "language": {
+    "switcher_label": "Język",
+    "english": "English",
+    "polish": "Polski",
+    "switch_to_english": "Zmień język na angielski",
+    "switch_to_polish": "Zmień język na polski"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,8 +4,10 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
 import { applyTheme, readStoredTheme } from './utils/theme.js';
+import './i18n/index.js';
 import './styles/tokens.css';
 import './styles/site-shell.css';
+import './styles/components/lang-switcher.css';
 
 applyTheme(readStoredTheme());
 

--- a/src/styles/components/lang-switcher.css
+++ b/src/styles/components/lang-switcher.css
@@ -1,0 +1,46 @@
+.lang-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-raised) 92%, transparent);
+  font-family: var(--dp-font-sans);
+}
+
+.lang-switcher__btn {
+  min-width: 34px;
+  min-height: 30px;
+  padding: 0 .55rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-soft);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  cursor: pointer;
+  transition: color .2s ease, background .2s ease;
+}
+
+.lang-switcher__btn:hover,
+.lang-switcher__btn:focus-visible {
+  color: var(--text);
+  background: color-mix(in srgb, var(--dp-accent) 10%, var(--surface-raised));
+}
+
+.lang-switcher__btn:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--dp-accent) 50%, transparent);
+  outline-offset: 1px;
+}
+
+.lang-switcher__btn.is-active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--dp-accent) 20%, var(--surface-raised));
+}
+
+@media (max-width: 720px) {
+  .lang-switcher { display: none; }
+}


### PR DESCRIPTION
## Summary
Phase 1 of the i18n plan agreed in chat: wires up `react-i18next` with English as the source language and Polish as the second supported locale. **No visible English strings are migrated in this PR** — this is the plumbing so follow-up PRs can extract strings namespace by namespace without changing visible output.

## What's in here
- Adds dependencies: `i18next`, `react-i18next`, `i18next-browser-languagedetector`
- `src/i18n/index.js` initializes with namespaces, `localStorage` detection (key: `dp_lang`), and syncs `<html lang>` on `languageChanged`
- Minimal `locales/en/common.json` + `locales/pl/common.json` containing only the switcher's own strings (the only UI text this PR introduces)
- `LanguageSwitcher` component — EN | PL pill toggle, mounted in `SiteNav` between menu links and search icon
- `lang-switcher.css` styles matching the existing pill/rounded button language in the design system
- Hidden below 720px viewport; mobile menu gets its own treatment when per-page translations land

## What's *not* in here
- Any string extraction (deliberate — keeps this PR small and verifiable)
- Mobile menu language switcher (deferred to Phase 2)
- URL-prefix routing (`/pl/*`) — kept simple; `hreflang` SEO tags can come later if needed
- Suspense / lazy-loading per namespace — config supports it but namespaces are bundled eagerly while there's only one tiny one

## Verification done
- Switcher renders, EN active by default, no console errors introduced
- Clicking PL: persists `localStorage.dp_lang = 'pl'`, updates `<html lang="pl">`, switcher aria-labels switch to Polish, hero H1 still shows "Destination Paradise" (proving no English strings were translated)
- Switching back to EN: persists, updates, reverts

## Follow-up plan
- **Phase 2 (one PR per namespace):** Migrate `nav` + `footer` first (visible everywhere), then `home`, then leaf pages. Each PR adds keys to both `en/<ns>.json` and `pl/<ns>.json`, replaces hardcoded strings in components with `t('key')`, and verifies English output is identical.
- The Polish copy on the `i18n/polish-translation` branch (now closed PR #55) will be mined for `pl/*` entries.

## Test plan
- [ ] Default load shows English; switcher in nav reads EN | PL
- [ ] Clicking PL persists in localStorage and `<html lang>` updates
- [ ] Reloading the page keeps the chosen language
- [ ] No visible English text changes anywhere on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)