### PR TITLE
feat(i18n): default to German in DE and Polish in PL via geo

### DIFF
--- a/netlify/edge-functions/geo.js
+++ b/netlify/edge-functions/geo.js
@@ -1,0 +1,11 @@
+export default async (_request, context) => {
+  const country = context?.geo?.country?.code || null;
+  return new Response(JSON.stringify({ country }), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  });
+};
+
+export const config = { path: '/api/geo' };

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -86,4 +86,28 @@ if (typeof document !== 'undefined') {
   document.documentElement.lang = i18n.resolvedLanguage || DEFAULT_LANGUAGE;
 }
 
+const COUNTRY_TO_LANG = { DE: 'de', PL: 'pl' };
+
+async function applyGeoLanguage() {
+  if (typeof window === 'undefined') return;
+  try {
+    if (window.localStorage.getItem(STORAGE_KEY)) return;
+  } catch {
+    return;
+  }
+  try {
+    const res = await fetch('/api/geo', { credentials: 'omit' });
+    if (!res.ok) return;
+    const { country } = await res.json();
+    const lang = COUNTRY_TO_LANG[country];
+    if (lang && lang !== i18n.resolvedLanguage) {
+      await i18n.changeLanguage(lang);
+    }
+  } catch {
+    // ignore – fall back to whatever the detector chose
+  }
+}
+
+applyGeoLanguage();
+
 export default i18n;

--- a/src/locales/de/booking.json
+++ b/src/locales/de/booking.json
@@ -129,7 +129,7 @@
     "product_label_transfer": "Transferroute",
     "product_label_default": "Konkretes Produkt",
     "product_placeholder_transfer": "Transferroute wählen oder flexibel lassen",
-    "product_placeholder_default": "Produkt ({{serviceType}}) wählen oder flexibel lassen",
+    "product_placeholder_default": "{{serviceType}} wählen oder flexibel lassen",
     "product_placeholder_generic": "Produkt wählen oder flexibel lassen",
     "name": "Name",
     "email": "E-Mail",

--- a/src/locales/de/booking.json
+++ b/src/locales/de/booking.json
@@ -129,7 +129,7 @@
     "product_label_transfer": "Transferroute",
     "product_label_default": "Konkretes Produkt",
     "product_placeholder_transfer": "Transferroute wählen oder flexibel lassen",
-    "product_placeholder_default": "Produkt wählen oder flexibel lassen",
+    "product_placeholder_default": "Produkt ({{serviceType}}) wählen oder flexibel lassen",
     "product_placeholder_generic": "Produkt wählen oder flexibel lassen",
     "name": "Name",
     "email": "E-Mail",

--- a/src/locales/en/booking.json
+++ b/src/locales/en/booking.json
@@ -129,7 +129,7 @@
     "product_label_transfer": "Transfer route",
     "product_label_default": "Specific product",
     "product_placeholder_transfer": "Choose a transfer route or leave flexible",
-    "product_placeholder_default": "Choose from {{serviceType}}s or leave flexible",
+    "product_placeholder_default": "Choose {{serviceType}} or leave flexible",
     "product_placeholder_generic": "Choose a product or leave flexible",
     "name": "Name",
     "email": "Email",

--- a/src/locales/pl/booking.json
+++ b/src/locales/pl/booking.json
@@ -129,7 +129,7 @@
     "product_label_transfer": "Trasa transferu",
     "product_label_default": "Konkretny produkt",
     "product_placeholder_transfer": "Wybierz trasę transferu albo zostaw elastycznie",
-    "product_placeholder_default": "Wybierz produkt z kategorii {{serviceType}} albo zostaw elastycznie",
+    "product_placeholder_default": "Wybierz {{serviceType}} albo elastycznie",
     "product_placeholder_generic": "Wybierz produkt albo zostaw elastycznie",
     "name": "Imię i nazwisko",
     "email": "Email",

--- a/src/locales/pl/booking.json
+++ b/src/locales/pl/booking.json
@@ -129,7 +129,7 @@
     "product_label_transfer": "Trasa transferu",
     "product_label_default": "Konkretny produkt",
     "product_placeholder_transfer": "Wybierz trasę transferu albo zostaw elastycznie",
-    "product_placeholder_default": "Wybierz produkt albo zostaw elastycznie",
+    "product_placeholder_default": "Wybierz produkt z kategorii {{serviceType}} albo zostaw elastycznie",
     "product_placeholder_generic": "Wybierz produkt albo zostaw elastycznie",
     "name": "Imię i nazwisko",
     "email": "Email",

--- a/src/styles/booking/hero.css
+++ b/src/styles/booking/hero.css
@@ -159,3 +159,13 @@
   }
 }
 
+@media (max-width: 400px) {
+  .booking-hero__actions {
+    flex-direction: column;
+    width: 100%;
+  }
+  .booking-hero__actions .btn {
+    width: 100%;
+  }
+}
+

--- a/src/styles/homepage/mobile.css
+++ b/src/styles/homepage/mobile.css
@@ -457,7 +457,7 @@ html, body { max-width: 100%; }
 @media (max-width: 720px) {
   .map-section { padding: 0 1rem; }
   .map-stage { min-height: 360px; border-radius: 22px; }
-  .map-list__button { padding: .6rem .65rem; font-size: 13px; gap: .65rem; }
+  .map-list__button { padding: .6rem 3rem .6rem .65rem; font-size: 13px; gap: .65rem; }
   .map-list__button > span:last-child { font-size: 11px !important; }
   .map-list .num { width: 24px; height: 24px; font-size: 10px; }
   .map-list-label { font-size: 9px; }


### PR DESCRIPTION
## Summary
- New Netlify Edge Function at `/api/geo` returns the visitor's country code from `context.geo`.
- On first visit (no `dp_lang` in localStorage), `src/i18n/index.js` calls `/api/geo` and switches to `de` for `DE` or `pl` for `PL`. Any other country falls back to the existing detector (localStorage → navigator → `en`).
- An explicit choice from the language switcher writes `dp_lang` to localStorage, so geo never overrides a user's pick on subsequent visits.

## Why
German visitors should land in German and Polish visitors in Polish without needing to flip the switcher, regardless of their browser's accept-language header.

## Notes for reviewer
- Edge functions auto-register via the exported `config.path`, so no `netlify.toml` change was needed.
- Geo data is only populated in Netlify's runtime — locally (`vite dev`) the fetch will simply fail silently and the existing detector wins. To smoke test pre-deploy, use `netlify dev`.
- The override only fires when localStorage has no `dp_lang` entry, so returning visitors and anyone who has used the switcher are unaffected.

## Test plan
- [ ] Deploy preview from DE IP loads German on first visit
- [ ] Deploy preview from PL IP loads Polish on first visit
- [ ] Deploy preview from elsewhere falls back to navigator/English
- [ ] After picking a different language via the switcher, reloading keeps that choice (geo does not override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)