### PR TITLE
Translate policy pages

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -8,18 +8,21 @@ import enFooter from '../locales/en/footer.json';
 import enHome from '../locales/en/home.json';
 import enExcursions from '../locales/en/excursions.json';
 import enSafaris from '../locales/en/safaris.json';
+import enPolicy from '../locales/en/policy.json';
 import plCommon from '../locales/pl/common.json';
 import plNav from '../locales/pl/nav.json';
 import plFooter from '../locales/pl/footer.json';
 import plHome from '../locales/pl/home.json';
 import plExcursions from '../locales/pl/excursions.json';
 import plSafaris from '../locales/pl/safaris.json';
+import plPolicy from '../locales/pl/policy.json';
 import deCommon from '../locales/de/common.json';
 import deNav from '../locales/de/nav.json';
 import deFooter from '../locales/de/footer.json';
 import deHome from '../locales/de/home.json';
 import deExcursions from '../locales/de/excursions.json';
 import deSafaris from '../locales/de/safaris.json';
+import dePolicy from '../locales/de/policy.json';
 
 export const SUPPORTED_LANGUAGES = ['en', 'pl', 'de'];
 export const DEFAULT_LANGUAGE = 'en';
@@ -57,14 +60,14 @@ i18n
   .use(initReactI18next)
   .init({
     resources: {
-      en: { common: enCommon, nav: enNav, footer: enFooter, home: enHome, excursions: enExcursions, safaris: enSafaris },
-      pl: { common: plCommon, nav: plNav, footer: plFooter, home: plHome, excursions: plExcursions, safaris: plSafaris },
-      de: { common: deCommon, nav: deNav, footer: deFooter, home: deHome, excursions: deExcursions, safaris: deSafaris },
+      en: { common: enCommon, nav: enNav, footer: enFooter, home: enHome, excursions: enExcursions, safaris: enSafaris, policy: enPolicy },
+      pl: { common: plCommon, nav: plNav, footer: plFooter, home: plHome, excursions: plExcursions, safaris: plSafaris, policy: plPolicy },
+      de: { common: deCommon, nav: deNav, footer: deFooter, home: deHome, excursions: deExcursions, safaris: deSafaris, policy: dePolicy },
     },
     partialBundledLanguages: true,
     fallbackLng: DEFAULT_LANGUAGE,
     supportedLngs: SUPPORTED_LANGUAGES,
-    ns: ['common', 'nav', 'footer', 'home', 'excursions', 'safaris'],
+    ns: ['common', 'nav', 'footer', 'home', 'excursions', 'safaris', 'policy'],
     defaultNS: 'common',
     detection: {
       order: ['localStorage', 'navigator'],

--- a/src/locales/de/policy.json
+++ b/src/locales/de/policy.json
@@ -1,0 +1,137 @@
+{
+  "page_title": "{{title}} · Destination Paradise",
+  "meta": {
+    "aria_label": "Richtliniendetails",
+    "last_updated": "Zuletzt aktualisiert",
+    "last_updated_value": "13. Mai 2026",
+    "contact": "Kontakt"
+  },
+  "policies": {
+    "privacy": {
+      "eyebrow": "Datenschutz",
+      "title": "Datenschutzerklärung",
+      "intro": "Diese Datenschutzerklärung erklärt, wie Destination Paradise mit den Angaben umgeht, die du teilst, wenn du Reisen anfragst, Erlebnisse buchst oder unser Team kontaktierst.",
+      "sections": [
+        {
+          "title": "Welche Informationen Wir Erheben",
+          "items": [
+            "Kontaktdaten wie Name, E-Mail-Adresse, Telefonnummer, WhatsApp-Kontakt und Land.",
+            "Reisedetails wie Wunschdaten, Gruppengröße, Budget, Interessen, Hotel oder Abholort und besondere Wünsche.",
+            "Nachrichten, die du über unsere Formulare, WhatsApp, E-Mail oder Social-Media-Kanäle sendest.",
+            "Grundlegende technische Informationen wie Browsertyp, Geräteinformationen, besuchte Seiten und ungefährer Standort aus Analyse-Tools."
+          ]
+        },
+        {
+          "title": "Wie Wir Deine Informationen Nutzen",
+          "items": [
+            "Um Anfragen zu beantworten und Reisevorschläge, Angebote, Buchungen und Reisepläne vorzubereiten.",
+            "Um Guides, Fahrer, Unterkunftspartner, Bootsbetreiber, Safari-Anbieter und andere Partner zu koordinieren, die für deine Reise gebraucht werden.",
+            "Um unsere Website, den Kundenservice, Pakete, Ausflüge und die Safari-Planung zu verbessern.",
+            "Um Buchungsupdates, Service-Nachrichten und Folgeinformationen zu deiner Anfrage zu senden."
+          ]
+        },
+        {
+          "title": "Weitergabe Deiner Informationen",
+          "items": [
+            "Wir teilen nur die Angaben, die nötig sind, um deine Reise mit vertrauenswürdigen lokalen Partnern, Zahlungsanbietern oder Dienstleistern zu organisieren.",
+            "Wir können Informationen weitergeben, wenn dies durch Gesetze, Sicherheitsanforderungen, Grenzbestimmungen oder offizielle Reiseverfahren erforderlich ist.",
+            "Wir verkaufen deine persönlichen Informationen nicht."
+          ]
+        },
+        {
+          "title": "Deine Wahlmöglichkeiten",
+          "items": [
+            "Du kannst uns bitten, deine persönlichen Angaben zu korrigieren, zu aktualisieren oder zu löschen, wenn wir sie nicht mehr für Buchung, Buchhaltung, Sicherheit oder rechtliche Gründe benötigen.",
+            "Du kannst optionale Angaben weglassen, auch wenn dies einschränken kann, wie genau wir deine Reise planen können.",
+            "Du kannst Marketing-Nachrichten jederzeit abbestellen, indem du uns kontaktierst."
+          ]
+        }
+      ]
+    },
+    "terms": {
+      "eyebrow": "AGB",
+      "title": "Allgemeine Geschäftsbedingungen",
+      "intro": "Diese Bedingungen beschreiben, wie Anfragen, Buchungen, Zahlungen, Änderungen und Reiseverantwortung funktionieren, wenn du Leistungen von Destination Paradise nutzt.",
+      "sections": [
+        {
+          "title": "Nutzung Unserer Website",
+          "items": [
+            "Die Website hilft dir, Reisen in Sansibar und Tansania zu entdecken, Angebote anzufragen und unser Team zu kontaktieren.",
+            "Inhalte, Preise, Routen, Verfügbarkeit und Leistungen können sich ändern, wenn sich Partner, Saisons, Parkregeln, Treibstoffkosten oder Wetterbedingungen ändern.",
+            "Du stimmst zu, die Website nicht zu missbrauchen, keine falschen Anfragen zu senden und den normalen Betrieb der Website nicht zu stören."
+          ]
+        },
+        {
+          "title": "Angebote Und Buchungen",
+          "items": [
+            "Eine Buchung ist erst bestätigt, nachdem wir die Verfügbarkeit bestätigt, den finalen Reiseplan mit dir abgestimmt und die erforderliche Zahlung oder Anzahlung erhalten haben.",
+            "Dein Angebot erklärt, was enthalten ist, was nicht enthalten ist, wann Zahlungen fällig sind, welche Stornoregeln gelten und welche wichtigen Partnerbedingungen zu beachten sind.",
+            "Du bist dafür verantwortlich, Namen, Daten, Abholdetails, Passinformationen, Ernährungswünsche, medizinische Hinweise und Reisedokumente vor der Bestätigung zu prüfen."
+          ]
+        },
+        {
+          "title": "Änderungen, Stornierungen Und Rückerstattungen",
+          "items": [
+            "Änderungs- und Stornoregeln hängen vom jeweiligen Hotel, Park, der Airline, dem Boot, Guide oder Drittanbieter in deinem Reiseplan ab.",
+            "Rückerstattungen, Teilrückerstattungen oder Gutschriften richten sich nach den schriftlichen Bedingungen, die du mit deiner Buchungsbestätigung erhältst.",
+            "Wetter, Seegang, Parkzugang, Straßenzustand, staatliche Regeln oder Sicherheitsbedenken können Änderungen bei Uhrzeit, Route, Anbieter oder Reihenfolge der Aktivitäten erforderlich machen."
+          ]
+        },
+        {
+          "title": "Reiseverantwortung",
+          "items": [
+            "Reisen sind immer mit gewissen Risiken verbunden. Du bist verantwortlich für passende Reiseversicherung, Gesundheitsberatung, Visa, Reisepässe und persönliche Gegenstände.",
+            "Wir arbeiten sorgfältig mit lokalen Partnern, sind jedoch nicht verantwortlich für Verzögerungen oder Verluste durch Ereignisse außerhalb unseres angemessenen Einflussbereichs.",
+            "Wenn während deiner Reise etwas schiefläuft, kontaktiere uns schnell, damit wir helfen können, solange noch Zeit zum Handeln ist."
+          ]
+        }
+      ]
+    },
+    "cookies": {
+      "eyebrow": "Cookies",
+      "title": "Cookie-Richtlinie",
+      "intro": "Diese Richtlinie erklärt, wie Cookies und ähnliche Technologien genutzt werden können, damit die Website funktioniert, Besuche verstanden werden und die Reiseplanung verbessert wird.",
+      "sections": [
+        {
+          "title": "Was Cookies Sind",
+          "items": [
+            "Cookies sind kleine Dateien, die auf deinem Gerät gespeichert werden, wenn du eine Website besuchst.",
+            "Ähnliche Technologien wie lokaler Speicher, Pixel und Analyse-Tags können helfen, Einstellungen zu merken oder zu messen, wie Seiten genutzt werden."
+          ]
+        },
+        {
+          "title": "Wie Wir Cookies Nutzen",
+          "items": [
+            "Notwendige Cookies und Speicher helfen der Website beim Laden, merken Design-Einstellungen, unterstützen Formulare und halten die Nutzung stabil.",
+            "Analyse-Cookies können uns helfen zu verstehen, welche Seiten nützlich sind, wo Besucher uns finden und wie wir die Website verbessern können.",
+            "Marketing- oder Social-Plattform-Tools können genutzt werden, wenn du mit eingebetteten Inhalten, Social Links oder Kampagnenlinks interagierst."
+          ]
+        },
+        {
+          "title": "Cookies Verwalten",
+          "items": [
+            "Du kannst Cookies in deinen Browser-Einstellungen blockieren, löschen oder einschränken.",
+            "Einige Funktionen funktionieren eventuell nicht wie erwartet, wenn notwendige Cookies oder lokaler Speicher deaktiviert sind.",
+            "Drittanbieter können eigene Datenschutz- und Cookie-Einstellungen über ihre Websites oder Kontoeinstellungen anbieten."
+          ]
+        },
+        {
+          "title": "Aktualisierungen",
+          "items": [
+            "Wir können diese Richtlinie aktualisieren, wenn sich Website-Tools, Analyse-Einstellungen oder Buchungsabläufe ändern.",
+            "Die aktuelle Version wird mit dem aktualisierten Datum auf dieser Seite veröffentlicht."
+          ]
+        }
+      ]
+    }
+  },
+  "contact": {
+    "title": "Kontakt",
+    "copy_prefix": "Bei Fragen zu dieser Richtlinie oder zu deinen Buchungsdetails kontaktiere Destination Paradise unter",
+    "copy_suffix": "oder schreibe uns auf WhatsApp.",
+    "actions": {
+      "email": "E-Mail senden",
+      "plan": "Reise planen"
+    }
+  }
+}

--- a/src/locales/en/policy.json
+++ b/src/locales/en/policy.json
@@ -1,0 +1,137 @@
+{
+  "page_title": "{{title}} · Destination Paradise",
+  "meta": {
+    "aria_label": "Policy details",
+    "last_updated": "Last updated",
+    "last_updated_value": "May 13, 2026",
+    "contact": "Contact"
+  },
+  "policies": {
+    "privacy": {
+      "eyebrow": "Privacy",
+      "title": "Privacy Policy",
+      "intro": "This policy explains how Destination Paradise handles the details you share when you ask about trips, book experiences, or contact our team.",
+      "sections": [
+        {
+          "title": "Information We Collect",
+          "items": [
+            "Contact details such as your name, email address, phone number, WhatsApp contact, and country.",
+            "Trip details such as preferred dates, group size, budget, interests, hotel or pickup location, and special requests.",
+            "Messages you send through our forms, WhatsApp, email, or social channels.",
+            "Basic technical information such as browser type, device information, pages visited, and approximate location from analytics tools."
+          ]
+        },
+        {
+          "title": "How We Use Your Information",
+          "items": [
+            "To respond to enquiries and prepare trip suggestions, quotes, bookings, and itineraries.",
+            "To coordinate guides, drivers, accommodation partners, boat operators, safari providers, and other suppliers needed for your trip.",
+            "To improve our website, customer service, packages, excursions, and safari planning experience.",
+            "To send booking updates, service messages, and follow-up information connected to your request."
+          ]
+        },
+        {
+          "title": "Sharing Your Information",
+          "items": [
+            "We share only the details needed to arrange your trip with trusted local partners, payment providers, or service providers.",
+            "We may share information when required by law, safety requirements, border rules, or official travel procedures.",
+            "We do not sell your personal information."
+          ]
+        },
+        {
+          "title": "Your Choices",
+          "items": [
+            "You can ask us to correct, update, or delete your personal details when we no longer need them for booking, accounting, safety, or legal reasons.",
+            "You can choose not to provide optional details, although this may limit how accurately we can plan your trip.",
+            "You can unsubscribe from marketing messages at any time by contacting us."
+          ]
+        }
+      ]
+    },
+    "terms": {
+      "eyebrow": "Terms",
+      "title": "Terms of Service",
+      "intro": "These terms describe how enquiries, bookings, payments, changes, and travel responsibilities work when you use Destination Paradise services.",
+      "sections": [
+        {
+          "title": "Using Our Website",
+          "items": [
+            "The website helps you explore Zanzibar and Tanzania trips, request quotes, and contact our team.",
+            "Content, prices, routes, availability, and inclusions may change as suppliers, seasons, park rules, fuel costs, and weather conditions change.",
+            "You agree not to misuse the website, submit false requests, or interfere with normal site operation."
+          ]
+        },
+        {
+          "title": "Quotes And Bookings",
+          "items": [
+            "A booking is confirmed only after we confirm availability, agree the final itinerary with you, and receive the required payment or deposit.",
+            "Your quote will explain what is included, what is excluded, payment timing, cancellation rules, and any important supplier conditions.",
+            "You are responsible for checking names, dates, pickup details, passport information, dietary needs, medical considerations, and travel documents before confirmation."
+          ]
+        },
+        {
+          "title": "Changes, Cancellations, And Refunds",
+          "items": [
+            "Change and cancellation rules depend on the specific hotel, park, airline, boat, guide, or third-party supplier used in your itinerary.",
+            "Refunds, partial refunds, or credits are handled according to the written terms shared with your booking confirmation.",
+            "Weather, sea conditions, park access, road conditions, government rules, or safety concerns may require changes to timing, route, supplier, or activity order."
+          ]
+        },
+        {
+          "title": "Travel Responsibility",
+          "items": [
+            "Travel always carries some risk. You are responsible for suitable travel insurance, health advice, visas, passports, and personal belongings.",
+            "We work carefully with local partners, but we are not responsible for delays or losses caused by events outside our reasonable control.",
+            "If something goes wrong during your trip, contact us quickly so we can help while there is still time to act."
+          ]
+        }
+      ]
+    },
+    "cookies": {
+      "eyebrow": "Cookies",
+      "title": "Cookies Policy",
+      "intro": "This policy explains how cookies and similar technologies may be used to keep the website working, understand visits, and improve the planning experience.",
+      "sections": [
+        {
+          "title": "What Cookies Are",
+          "items": [
+            "Cookies are small files stored on your device when you visit a website.",
+            "Similar technologies such as local storage, pixels, and analytics tags can help remember settings or measure how pages are used."
+          ]
+        },
+        {
+          "title": "How We Use Cookies",
+          "items": [
+            "Essential cookies and storage help the website load, remember theme preferences, support forms, and keep the experience stable.",
+            "Analytics cookies may help us understand which pages are useful, where visitors find us, and how we can improve the site.",
+            "Marketing or social platform tools may be used when you interact with embedded content, social links, or campaign links."
+          ]
+        },
+        {
+          "title": "Managing Cookies",
+          "items": [
+            "You can block, delete, or limit cookies in your browser settings.",
+            "Some features may not work as expected if essential cookies or local storage are disabled.",
+            "Third-party services may provide their own privacy and cookie controls through their websites or account settings."
+          ]
+        },
+        {
+          "title": "Updates",
+          "items": [
+            "We may update this policy when our website tools, analytics setup, or booking workflows change.",
+            "The latest version will be posted on this page with the updated date."
+          ]
+        }
+      ]
+    }
+  },
+  "contact": {
+    "title": "Contact Us",
+    "copy_prefix": "For questions about this policy or your booking details, contact Destination Paradise at",
+    "copy_suffix": "or message us on WhatsApp.",
+    "actions": {
+      "email": "Email us",
+      "plan": "Plan a trip"
+    }
+  }
+}

--- a/src/locales/pl/policy.json
+++ b/src/locales/pl/policy.json
@@ -1,0 +1,137 @@
+{
+  "page_title": "{{title}} · Destination Paradise",
+  "meta": {
+    "aria_label": "Szczegoly zasad",
+    "last_updated": "Ostatnia aktualizacja",
+    "last_updated_value": "13 maja 2026",
+    "contact": "Kontakt"
+  },
+  "policies": {
+    "privacy": {
+      "eyebrow": "Prywatnosc",
+      "title": "Polityka prywatnosci",
+      "intro": "Ta polityka wyjasnia, jak Destination Paradise obchodzi sie z danymi, ktore przekazujesz, gdy pytasz o wyjazdy, rezerwujesz atrakcje lub kontaktujesz sie z naszym zespolem.",
+      "sections": [
+        {
+          "title": "Jakie Informacje Zbieramy",
+          "items": [
+            "Dane kontaktowe, takie jak imie i nazwisko, adres e-mail, numer telefonu, kontakt WhatsApp i kraj.",
+            "Szczegoly podrozy, takie jak preferowane daty, wielkosc grupy, budzet, zainteresowania, hotel lub miejsce odbioru oraz specjalne prosby.",
+            "Wiadomosci wysylane przez formularze, WhatsApp, e-mail lub kanaly spolecznosciowe.",
+            "Podstawowe informacje techniczne, takie jak typ przegladarki, informacje o urzadzeniu, odwiedzone strony i przyblizona lokalizacja z narzedzi analitycznych."
+          ]
+        },
+        {
+          "title": "Jak Wykorzystujemy Twoje Informacje",
+          "items": [
+            "Aby odpowiadac na zapytania oraz przygotowywac propozycje podrozy, wyceny, rezerwacje i plany wyjazdu.",
+            "Aby koordynowac przewodnikow, kierowcow, partnerow noclegowych, operatorow lodzi, dostawcow safari i innych partnerow potrzebnych do realizacji wyjazdu.",
+            "Aby ulepszac nasza strone, obsluge klienta, pakiety, wycieczki i planowanie safari.",
+            "Aby wysylac aktualizacje rezerwacji, wiadomosci serwisowe i informacje powiazane z Twoja prosba."
+          ]
+        },
+        {
+          "title": "Udostepnianie Informacji",
+          "items": [
+            "Udostepniamy tylko te dane, ktore sa potrzebne do zorganizowania podrozy z zaufanymi lokalnymi partnerami, dostawcami platnosci lub uslug.",
+            "Mozemy udostepnic informacje, gdy wymagaja tego przepisy, zasady bezpieczenstwa, procedury graniczne lub oficjalne procedury podrozne.",
+            "Nie sprzedajemy Twoich danych osobowych."
+          ]
+        },
+        {
+          "title": "Twoje Mozliwosci",
+          "items": [
+            "Mozesz poprosic nas o poprawienie, zaktualizowanie lub usuniecie danych osobowych, gdy nie sa juz potrzebne do rezerwacji, ksiegowosci, bezpieczenstwa lub z powodow prawnych.",
+            "Mozesz nie podawac opcjonalnych danych, chociaz moze to ograniczyc dokladnosc planowania Twojej podrozy.",
+            "Mozesz w kazdej chwili zrezygnowac z wiadomosci marketingowych, kontaktujac sie z nami."
+          ]
+        }
+      ]
+    },
+    "terms": {
+      "eyebrow": "Regulamin",
+      "title": "Regulamin uslug",
+      "intro": "Ten regulamin opisuje, jak dzialaja zapytania, rezerwacje, platnosci, zmiany i odpowiedzialnosc za podroz podczas korzystania z uslug Destination Paradise.",
+      "sections": [
+        {
+          "title": "Korzystanie Z Naszej Strony",
+          "items": [
+            "Strona pomaga odkrywac wyjazdy na Zanzibar i do Tanzanii, prosic o wyceny i kontaktowac sie z naszym zespolem.",
+            "Tresci, ceny, trasy, dostepnosc i elementy oferty moga sie zmieniac wraz ze zmianami u dostawcow, sezonow, zasad parkow, kosztow paliwa i warunkow pogodowych.",
+            "Zgadzasz sie nie naduzywac strony, nie wysylac falszywych zapytan i nie zaklocac normalnego dzialania strony."
+          ]
+        },
+        {
+          "title": "Wyceny I Rezerwacje",
+          "items": [
+            "Rezerwacja jest potwierdzona dopiero po potwierdzeniu dostepnosci, uzgodnieniu finalnego planu wyjazdu i otrzymaniu wymaganej platnosci lub zaliczki.",
+            "Wycena wyjasni, co jest wliczone, co nie jest wliczone, terminy platnosci, zasady anulowania i wazne warunki dostawcow.",
+            "Odpowiadasz za sprawdzenie nazwisk, dat, szczegolow odbioru, informacji paszportowych, potrzeb dietetycznych, kwestii medycznych i dokumentow podroznych przed potwierdzeniem."
+          ]
+        },
+        {
+          "title": "Zmiany, Anulacje I Zwroty",
+          "items": [
+            "Zasady zmian i anulacji zaleza od konkretnego hotelu, parku, linii lotniczej, lodzi, przewodnika lub zewnetrznego dostawcy w Twoim planie.",
+            "Zwroty, czesciowe zwroty lub kredyty sa obslugiwane zgodnie z pisemnymi warunkami przekazanymi wraz z potwierdzeniem rezerwacji.",
+            "Pogoda, warunki na morzu, dostep do parku, stan drog, przepisy rzadowe lub wzgledy bezpieczenstwa moga wymagac zmian czasu, trasy, dostawcy lub kolejnosci atrakcji."
+          ]
+        },
+        {
+          "title": "Odpowiedzialnosc Za Podroz",
+          "items": [
+            "Podroz zawsze wiaze sie z pewnym ryzykiem. Odpowiadasz za odpowiednie ubezpieczenie, porady zdrowotne, wizy, paszporty i rzeczy osobiste.",
+            "Starannie wspolpracujemy z lokalnymi partnerami, ale nie odpowiadamy za opoznienia lub straty spowodowane zdarzeniami poza nasza rozsadna kontrola.",
+            "Jesli cos pojdzie nie tak podczas wyjazdu, skontaktuj sie z nami szybko, abysmy mogli pomoc, gdy jest jeszcze czas na dzialanie."
+          ]
+        }
+      ]
+    },
+    "cookies": {
+      "eyebrow": "Cookies",
+      "title": "Polityka cookies",
+      "intro": "Ta polityka wyjasnia, jak cookies i podobne technologie moga byc uzywane, aby strona dzialala, aby rozumiec wizyty i ulepszac planowanie podrozy.",
+      "sections": [
+        {
+          "title": "Czym Sa Cookies",
+          "items": [
+            "Cookies to male pliki zapisywane na Twoim urzadzeniu podczas odwiedzania strony internetowej.",
+            "Podobne technologie, takie jak pamiec lokalna, piksele i tagi analityczne, moga pomagac zapamietywac ustawienia lub mierzyc sposob korzystania ze stron."
+          ]
+        },
+        {
+          "title": "Jak Uzywamy Cookies",
+          "items": [
+            "Niezbedne cookies i pamiec pomagaja stronie sie ladowac, zapamietywac preferencje motywu, obslugiwac formularze i utrzymywac stabilne dzialanie.",
+            "Cookies analityczne moga pomoc nam zrozumiec, ktore strony sa przydatne, skad trafiaja odwiedzajacy i jak mozemy ulepszyc strone.",
+            "Narzedzia marketingowe lub platform spolecznosciowych moga byc uzywane, gdy korzystasz z tresci osadzonych, linkow spolecznosciowych lub linkow kampanii."
+          ]
+        },
+        {
+          "title": "Zarzadzanie Cookies",
+          "items": [
+            "Mozesz blokowac, usuwac lub ograniczac cookies w ustawieniach przegladarki.",
+            "Niektore funkcje moga nie dzialac zgodnie z oczekiwaniami, jesli niezbedne cookies lub pamiec lokalna sa wylaczone.",
+            "Uslugi zewnetrzne moga udostepniac wlasne ustawienia prywatnosci i cookies na swoich stronach lub w ustawieniach konta."
+          ]
+        },
+        {
+          "title": "Aktualizacje",
+          "items": [
+            "Mozemy aktualizowac te polityke, gdy zmieniaja sie narzedzia strony, konfiguracja analityki lub procesy rezerwacji.",
+            "Najnowsza wersja bedzie opublikowana na tej stronie z data aktualizacji."
+          ]
+        }
+      ]
+    }
+  },
+  "contact": {
+    "title": "Kontakt",
+    "copy_prefix": "W sprawach dotyczacych tej polityki lub szczegolow rezerwacji skontaktuj sie z Destination Paradise pod adresem",
+    "copy_suffix": "albo napisz do nas na WhatsApp.",
+    "actions": {
+      "email": "Napisz e-mail",
+      "plan": "Zaplanuj podroz"
+    }
+  }
+}

--- a/src/pages/Policy.jsx
+++ b/src/pages/Policy.jsx
@@ -1,133 +1,10 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { CONTACT_INFO } from '../constants/contactInfo.js';
+import { usePageMeta } from '../hooks/usePageMeta.js';
 import '../styles/homepage.css';
 import '../styles/policy.css';
-
-const LAST_UPDATED = 'May 13, 2026';
-
-const POLICIES = {
-  privacy: {
-    eyebrow: 'Privacy',
-    title: 'Privacy Policy',
-    intro:
-      'This policy explains how Destination Paradise handles the details you share when you ask about trips, book experiences, or contact our team.',
-    sections: [
-      {
-        title: 'Information We Collect',
-        items: [
-          'Contact details such as your name, email address, phone number, WhatsApp contact, and country.',
-          'Trip details such as preferred dates, group size, budget, interests, hotel or pickup location, and special requests.',
-          'Messages you send through our forms, WhatsApp, email, or social channels.',
-          'Basic technical information such as browser type, device information, pages visited, and approximate location from analytics tools.',
-        ],
-      },
-      {
-        title: 'How We Use Your Information',
-        items: [
-          'To respond to enquiries and prepare trip suggestions, quotes, bookings, and itineraries.',
-          'To coordinate guides, drivers, accommodation partners, boat operators, safari providers, and other suppliers needed for your trip.',
-          'To improve our website, customer service, packages, excursions, and safari planning experience.',
-          'To send booking updates, service messages, and follow-up information connected to your request.',
-        ],
-      },
-      {
-        title: 'Sharing Your Information',
-        items: [
-          'We share only the details needed to arrange your trip with trusted local partners, payment providers, or service providers.',
-          'We may share information when required by law, safety requirements, border rules, or official travel procedures.',
-          'We do not sell your personal information.',
-        ],
-      },
-      {
-        title: 'Your Choices',
-        items: [
-          'You can ask us to correct, update, or delete your personal details when we no longer need them for booking, accounting, safety, or legal reasons.',
-          'You can choose not to provide optional details, although this may limit how accurately we can plan your trip.',
-          'You can unsubscribe from marketing messages at any time by contacting us.',
-        ],
-      },
-    ],
-  },
-  terms: {
-    eyebrow: 'Terms',
-    title: 'Terms of Service',
-    intro:
-      'These terms describe how enquiries, bookings, payments, changes, and travel responsibilities work when you use Destination Paradise services.',
-    sections: [
-      {
-        title: 'Using Our Website',
-        items: [
-          'The website helps you explore Zanzibar and Tanzania trips, request quotes, and contact our team.',
-          'Content, prices, routes, availability, and inclusions may change as suppliers, seasons, park rules, fuel costs, and weather conditions change.',
-          'You agree not to misuse the website, submit false requests, or interfere with normal site operation.',
-        ],
-      },
-      {
-        title: 'Quotes And Bookings',
-        items: [
-          'A booking is confirmed only after we confirm availability, agree the final itinerary with you, and receive the required payment or deposit.',
-          'Your quote will explain what is included, what is excluded, payment timing, cancellation rules, and any important supplier conditions.',
-          'You are responsible for checking names, dates, pickup details, passport information, dietary needs, medical considerations, and travel documents before confirmation.',
-        ],
-      },
-      {
-        title: 'Changes, Cancellations, And Refunds',
-        items: [
-          'Change and cancellation rules depend on the specific hotel, park, airline, boat, guide, or third-party supplier used in your itinerary.',
-          'Refunds, partial refunds, or credits are handled according to the written terms shared with your booking confirmation.',
-          'Weather, sea conditions, park access, road conditions, government rules, or safety concerns may require changes to timing, route, supplier, or activity order.',
-        ],
-      },
-      {
-        title: 'Travel Responsibility',
-        items: [
-          'Travel always carries some risk. You are responsible for suitable travel insurance, health advice, visas, passports, and personal belongings.',
-          'We work carefully with local partners, but we are not responsible for delays or losses caused by events outside our reasonable control.',
-          'If something goes wrong during your trip, contact us quickly so we can help while there is still time to act.',
-        ],
-      },
-    ],
-  },
-  cookies: {
-    eyebrow: 'Cookies',
-    title: 'Cookies Policy',
-    intro:
-      'This policy explains how cookies and similar technologies may be used to keep the website working, understand visits, and improve the planning experience.',
-    sections: [
-      {
-        title: 'What Cookies Are',
-        items: [
-          'Cookies are small files stored on your device when you visit a website.',
-          'Similar technologies such as local storage, pixels, and analytics tags can help remember settings or measure how pages are used.',
-        ],
-      },
-      {
-        title: 'How We Use Cookies',
-        items: [
-          'Essential cookies and storage help the website load, remember theme preferences, support forms, and keep the experience stable.',
-          'Analytics cookies may help us understand which pages are useful, where visitors find us, and how we can improve the site.',
-          'Marketing or social platform tools may be used when you interact with embedded content, social links, or campaign links.',
-        ],
-      },
-      {
-        title: 'Managing Cookies',
-        items: [
-          'You can block, delete, or limit cookies in your browser settings.',
-          'Some features may not work as expected if essential cookies or local storage are disabled.',
-          'Third-party services may provide their own privacy and cookie controls through their websites or account settings.',
-        ],
-      },
-      {
-        title: 'Updates',
-        items: [
-          'We may update this policy when our website tools, analytics setup, or booking workflows change.',
-          'The latest version will be posted on this page with the updated date.',
-        ],
-      },
-    ],
-  },
-};
 
 function PolicySection({ title, items }) {
   return (
@@ -143,11 +20,19 @@ function PolicySection({ title, items }) {
 }
 
 export default function Policy({ section = 'privacy' }) {
-  const policy = POLICIES[section] || POLICIES.privacy;
+  const { t } = useTranslation('policy');
+  const policies = t('policies', { returnObjects: true });
+  const policy = policies?.[section] || policies?.privacy;
+  const actions = t('contact.actions', { returnObjects: true });
+  const meta = t('meta', { returnObjects: true });
+  const contact = t('contact', { returnObjects: true });
 
-  useEffect(() => {
-    document.title = `${policy.title} · Destination Paradise`;
-  }, [policy.title]);
+  const pageTitle = useMemo(
+    () => t('page_title', { title: policy.title }),
+    [policy.title, t],
+  );
+
+  usePageMeta(pageTitle, policy.intro);
 
   return (
     <main className="policy-page">
@@ -156,13 +41,13 @@ export default function Policy({ section = 'privacy' }) {
           <span className="section-eyebrow">{policy.eyebrow}</span>
           <h1>{policy.title}</h1>
           <p>{policy.intro}</p>
-          <dl className="policy-meta" aria-label="Policy details">
+          <dl className="policy-meta" aria-label={meta.aria_label}>
             <div>
-              <dt>Last updated</dt>
-              <dd>{LAST_UPDATED}</dd>
+              <dt>{meta.last_updated}</dt>
+              <dd>{meta.last_updated_value}</dd>
             </div>
             <div>
-              <dt>Contact</dt>
+              <dt>{meta.contact}</dt>
               <dd><a href={`mailto:${CONTACT_INFO.email}`}>{CONTACT_INFO.email}</a></dd>
             </div>
           </dl>
@@ -175,14 +60,15 @@ export default function Policy({ section = 'privacy' }) {
         ))}
 
         <section className="policy-section policy-section--contact">
-          <h2>Contact Us</h2>
+          <h2>{contact.title}</h2>
           <p>
-            For questions about this policy or your booking details, contact Destination Paradise at{' '}
-            <a href={`mailto:${CONTACT_INFO.email}`}>{CONTACT_INFO.email}</a> or message us on WhatsApp.
+            {contact.copy_prefix}{' '}
+            <a href={`mailto:${CONTACT_INFO.email}`}>{CONTACT_INFO.email}</a>
+            {' '}{contact.copy_suffix}
           </p>
           <div className="policy-actions">
-            <a className="btn" href={`mailto:${CONTACT_INFO.email}`}>Email us</a>
-            <Link className="btn btn--ghost" to="/trip-planner">Plan a trip</Link>
+            <a className="btn" href={`mailto:${CONTACT_INFO.email}`}>{actions.email}</a>
+            <Link className="btn btn--ghost" to="/trip-planner">{actions.plan}</Link>
           </div>
         </section>
       </section>


### PR DESCRIPTION
## Summary\n- Move Datenschutz, AGB, and Cookies policy page copy into the i18n policy namespace\n- Add English, German, and Polish policy translations\n- Keep policy page metadata and contact actions localized\n\n## Validation\n- npm run lint\n- npm run build