### PR TITLE
Fix hidden breadcrumb and wrapped category on detail pages

### DIFF
--- a/src/styles/excursions/block.css
+++ b/src/styles/excursions/block.css
@@ -109,9 +109,11 @@
 .exc-block__facts dd {
   margin: 0;
   font-family: var(--dp-font-display, 'Playfair Display', Georgia, serif);
-  font-size: 1.15rem;
+  font-size: clamp(.95rem, 1.05vw, 1.1rem);
   font-weight: 500;
   color: var(--text, #1a4d6e);
+  line-height: 1.2;
+  text-wrap: balance;
 }
 .exc-block__facts dd small {
   display: block;

--- a/src/styles/excursions/detail.css
+++ b/src/styles/excursions/detail.css
@@ -1,7 +1,7 @@
 /* ============ DETAIL PAGE ============ */
 .exc-detail__crumbs {
   display: flex; align-items: center; gap: .5rem; flex-wrap: wrap;
-  padding: clamp(1.5rem, 3vw, 2.25rem) clamp(1.25rem, 5vw, 6rem) 0;
+  padding: clamp(5.5rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem) 0;
   font-family: var(--dp-font-sans);
   font-size: 12px;
   letter-spacing: .04em;
@@ -13,4 +13,8 @@
 .exc-detail .exc-block--detail {
   margin-top: clamp(1.75rem, 4vw, 3rem);
   margin-bottom: clamp(3rem, 6vw, 5rem);
+}
+.exc-detail .exc-block--detail .exc-block__facts {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .85rem 1.25rem;
 }


### PR DESCRIPTION
## Summary
- Breadcrumb on excursion / safari / package detail pages was hidden behind the fixed top nav at scrollY=0 (text sat at y=0-60px, nav covers y=0-66px). Increased the breadcrumb container's top padding so its content clears the header.
- Long category values like "Luxury Experiences" wrapped mid-text in the CATEGORY fact column because the 4-column grid inside the detail body gave each column only ~92px. Switched detail-page facts to a 2x2 grid (~210px columns) and tightened the dd type with `text-wrap: balance`.

## Test plan
- [ ] Visit `/packages/twelve-day-serengeti-zanzibar` — breadcrumb visible below header, "Luxury Experiences" on one line.
- [ ] Visit `/safaris/ngorongoro-tarangire` — same checks; "Premium Mid-Range" fits cleanly.
- [ ] Spot-check an excursion detail page for layout regressions on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)