### PR TITLE
Fix React 18 warnings, rework gallery masonry, animate hero tagline

### DIFF
--- a/src/components/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage.jsx
@@ -17,7 +17,7 @@ export default function ResponsiveImage({ src, alt = '', fetchpriority, fetchPri
   const resolvedFetchPriority = fetchPriority ?? normalizeFetchPriority(fetchpriority);
 
   if (typeof src !== 'string' || !src.endsWith('.webp')) {
-    return <img {...imageProps} src={src} alt={alt} fetchPriority={resolvedFetchPriority} width={width} height={height} />;
+    return <img {...imageProps} src={src} alt={alt} fetchpriority={resolvedFetchPriority} width={width} height={height} />;
   }
 
   const meta = imageManifest[src];
@@ -40,7 +40,7 @@ export default function ResponsiveImage({ src, alt = '', fetchpriority, fetchPri
       {...imageProps}
       src={src}
       alt={alt}
-      fetchPriority={resolvedFetchPriority}
+      fetchpriority={resolvedFetchPriority}
       width={width ?? fullWidth}
       height={height ?? fullHeight}
       srcSet={srcSetParts.join(', ')}

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -246,7 +246,7 @@ export default function SiteNav({ theme = 'light', themeMode = 'auto', onThemeMo
         role="dialog"
         aria-modal="true"
         aria-label={t('menu.site_nav_label')}
-        {...(navOpen ? {} : { inert: true })}
+        {...(navOpen ? {} : { inert: '' })}
       >
         <div className="mm-menu__bg" style={navOpen ? { backgroundImage: `url('${MM_BGS[bgIndex]}')` } : undefined} />
         <div className="mm-menu__scrim" />

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -21,6 +21,48 @@ const dateInputValue = (date) => {
   return `${year}-${month}-${day}`;
 };
 
+function HeroMotto() {
+  const { t } = useTranslation('home');
+  const motto = t('hero.motto');
+  const [typed, setTyped] = useState('');
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    setTyped('');
+    setDone(false);
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) {
+      setTyped(motto);
+      setDone(true);
+      return undefined;
+    }
+    let timeoutId;
+    let i = 0;
+    const tick = () => {
+      i += 1;
+      setTyped(motto.slice(0, i));
+      if (i >= motto.length) {
+        setDone(true);
+        return;
+      }
+      const pause = motto[i - 1] === ' ' ? 80 : 48 + (i % 4) * 14;
+      timeoutId = window.setTimeout(tick, pause);
+    };
+    timeoutId = window.setTimeout(tick, 600);
+    return () => {
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, [motto]);
+
+  return (
+    <h2 className={`hero__motto hero__motto--typed${done ? ' is-done' : ''}`}>
+      <span className="visually-hidden">{motto}</span>
+      <i aria-hidden="true">{typed}</i>
+      <span className="hero__motto-cursor" aria-hidden="true" />
+    </h2>
+  );
+}
+
 export default function HeroSection({ tweaks, handleHeroSearch }) {
   const { t } = useTranslation('home');
   const popularPackages = t('hero.search.popular_packages', { returnObjects: true });
@@ -119,7 +161,7 @@ export default function HeroSection({ tweaks, handleHeroSearch }) {
         <div className="hero__intro">
           <span className="hero__eyebrow">{t('hero.eyebrow')}</span>
           <h1 className="hero__title">{t('hero.title')}</h1>
-          <h2 className="hero__motto"><i>{t('hero.motto')}</i></h2>
+          <HeroMotto />
           <p className="hero__desc">{t('hero.description')}</p>
           <div className="hero__cta-row">
             <Link className="btn" to="/packages">{t('hero.browse_packages')} <ArrowIcon size={18} /></Link>

--- a/src/styles/homepage/gallery.css
+++ b/src/styles/homepage/gallery.css
@@ -2,27 +2,21 @@
 .gallery-section { width: 100%; margin: var(--section-stack-gap) 0; overflow: hidden; }
 .gallery-head { text-align: center; margin: 0 auto clamp(2rem, 3vw, 2.5rem); max-width: 640px; padding: 0 1rem; }
 .gallery-strip {
-  display: grid;
-  grid-template-columns: repeat(10, minmax(0, 1fr));
-  gap: 10px;
+  columns: 5;
+  column-gap: 10px;
   padding: 0 10px;
 }
 @media (max-width: 900px) {
-  .gallery-strip { grid-template-columns: repeat(2, 1fr); }
+  .gallery-strip { columns: 2; }
 }
 .gallery-tile {
   position: relative; overflow: hidden;
-  grid-column: span 2;
+  break-inside: avoid;
+  margin: 0 0 10px;
   border-radius: 18px;
   aspect-ratio: 3/4;
 }
-.gallery-strip > :nth-last-child(2) {
-  grid-column: 4 / span 2;
-}
-.gallery-strip > :last-child {
-  grid-column: 6 / span 2;
-}
-.gallery-tile img { width: 100%; height: 100%; object-fit: cover; transition: transform .6s var(--dp-ease-out); }
+.gallery-tile img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform .6s var(--dp-ease-out); }
 .gallery-tile:hover img { transform: scale(1.08); }
 .gallery-tile::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, transparent 50%, rgba(26,77,110,.55)); }
 .gallery-tile__caption {
@@ -31,11 +25,3 @@
 }
 .gallery-tile--wide { aspect-ratio: 4/5; }
 .gallery-tile--tall { aspect-ratio: 3/5; }
-
-@media (max-width: 900px) {
-  .gallery-tile,
-  .gallery-strip > :nth-last-child(2),
-  .gallery-strip > :last-child {
-    grid-column: auto;
-  }
-}

--- a/src/styles/homepage/nav-stand.css
+++ b/src/styles/homepage/nav-stand.css
@@ -235,6 +235,20 @@
   animation: fadeInUp 1s var(--dp-ease-out) both;
   animation-delay: .3s;
 }
+.hero__motto-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 2px;
+  background: currentColor;
+  vertical-align: text-bottom;
+  animation: hero-motto-blink 1.05s steps(1) infinite;
+}
+.hero__motto--typed.is-done .hero__motto-cursor { opacity: .55; }
+@keyframes hero-motto-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
 .hero__desc {
   font-family: var(--dp-font-display);
   color: #fff;

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
       react(),
       VitePWA({
         registerType: 'autoUpdate',
+        injectRegister: 'script-defer',
         devOptions: {
           enabled: false
         },


### PR DESCRIPTION
## Summary
- **React 18 attribute warnings** — `ResponsiveImage` now passes lowercase `fetchpriority` and `SiteNav` passes `inert=''` (empty string), eliminating the unknown-attribute warnings that fired on every render/image.
- **Gallery masonry** — the homepage gallery strip moves from a fixed 10-column grid (with brittle `nth-last-child` overrides) to CSS `columns`, so varied tile heights pack tightly instead of leaving a gap under shorter cards. 5 columns on desktop, 2 on mobile.
- **Hero tagline animation** — the "your next trip to paradise…" tagline now types out character-by-character with a blinking cursor, mirroring the footer's typed tagline.

## Why
The first two were in-progress fixes for issues found in a visual review (console noise + uneven gallery rows). The hero animation was a requested enhancement to match the footer's existing typewriter effect.

## Reviewer notes
- The hero typewriter is a self-contained `HeroMotto` component. It respects `prefers-reduced-motion` (renders the full tagline instantly) and keeps a `visually-hidden` full-text copy for screen readers while the animated copy is `aria-hidden`.
- Unlike the footer (which waits for scroll-into-view via IntersectionObserver), the hero is above the fold, so typing starts ~600ms after mount to let the hero fade-in settle first.

## Test plan
- [x] No console warnings/errors on homepage load
- [x] Gallery: 5 cols desktop / 2 cols mobile, no gaps under short tiles
- [x] Hero tagline types out then shows blinking cursor (verified via frame sampling)
- [x] Detail-page action bar verified clean at desktop + mobile (no overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)