### PR TITLE
Apply site-wide scroll-animation system to all pages

### DIFF
--- a/src/components/about/AboutCommunity.jsx
+++ b/src/components/about/AboutCommunity.jsx
@@ -29,20 +29,20 @@ export default function AboutCommunity() {
   });
 
   return (
-    <section className="ab-sus reveal" id="community">
+    <section className="ab-sus" id="community">
       <div className="ab-sus__inner">
         <div className="ab-sus__head">
           <div>
-            <span className="ab-story__eyebrow ab-sus__eyebrow">{t('community.eyebrow', { defaultValue: 'Community' })}</span>
-            <h2>{t('community.title_prefix', { defaultValue: 'Built as a' })} <em>{t('community.title_em', { defaultValue: 'network' })}</em>, {t('community.title_suffix', { defaultValue: 'not a closed system.' })}</h2>
+            <span className="ab-story__eyebrow ab-sus__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('community.eyebrow', { defaultValue: 'Community' })}</span>
+            <h2 className="reveal" style={{ '--reveal-index': 1 }}>{t('community.title_prefix', { defaultValue: 'Built as a' })} <em>{t('community.title_em', { defaultValue: 'network' })}</em>, {t('community.title_suffix', { defaultValue: 'not a closed system.' })}</h2>
           </div>
-          <p>{t('community.lead', { defaultValue: 'Destination Paradise is not only about travel. We believe tourism should also create real opportunities for the people who host you. From day one we are working hand-in-hand with local drivers, guides, hotels, restaurants and service providers — building something the wider community grows with, not around.' })}</p>
+          <p className="reveal" style={{ '--reveal-index': 2 }}>{t('community.lead', { defaultValue: 'Destination Paradise is not only about travel. We believe tourism should also create real opportunities for the people who host you. From day one we are working hand-in-hand with local drivers, guides, hotels, restaurants and service providers — building something the wider community grows with, not around.' })}</p>
         </div>
 
         <div className="ab-sus__grid">
           <div className="ab-sus__pillars">
             {Array.isArray(pillars) && pillars.map((pillar, index) => (
-              <div className="ab-pillar reveal" key={pillar.icon || `pillar-${index}`} style={{ transitionDelay: `${index * 90}ms` }}>
+              <div className="ab-pillar reveal" key={pillar.icon || `pillar-${index}`} style={{ '--reveal-index': index }}>
                 <div className="ab-pillar__icon">{pillarIcons[pillar.icon]}</div>
                 <h4>{pillar.title}</h4>
                 <p>{pillar.body}</p>
@@ -50,7 +50,7 @@ export default function AboutCommunity() {
             ))}
           </div>
 
-          <aside className="ab-sus__quote">
+          <aside className="ab-sus__quote reveal" style={{ '--reveal-index': 0 }}>
             {Array.isArray(quote) && quote.map((paragraph) => (
               <p className="ab-sus__quote-text" key={paragraph}>{paragraph}</p>
             ))}

--- a/src/components/about/AboutCta.jsx
+++ b/src/components/about/AboutCta.jsx
@@ -10,10 +10,10 @@ export default function AboutCta() {
     <section className="ab-cta">
       <div className="ab-cta__bg"><ResponsiveImage src={ABOUT_CTA_IMAGE} alt="" loading="lazy" /></div>
       <div className="ab-cta__inner">
-        <span className="ab-story__eyebrow ab-cta__eyebrow">{t('cta.eyebrow', { defaultValue: 'Karibu' })}</span>
-        <h2>{t('cta.title_prefix', { defaultValue: 'Welcome to' })} <em>{t('cta.title_em', { defaultValue: 'Destination Paradise' })}</em>{t('cta.title_suffix', { defaultValue: '.' })}</h2>
-        <p>{t('cta.text', { defaultValue: 'To everyone who supported this journey from the beginning — thank you. And to everyone joining us now: the vision is big, the journey is long, and we are so glad you are here at the start.' })}</p>
-        <div className="ab-cta__btns">
+        <span className="ab-story__eyebrow ab-cta__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('cta.eyebrow', { defaultValue: 'Karibu' })}</span>
+        <h2 className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.title_prefix', { defaultValue: 'Welcome to' })} <em>{t('cta.title_em', { defaultValue: 'Destination Paradise' })}</em>{t('cta.title_suffix', { defaultValue: '.' })}</h2>
+        <p className="reveal" style={{ '--reveal-index': 2 }}>{t('cta.text', { defaultValue: 'To everyone who supported this journey from the beginning — thank you. And to everyone joining us now: the vision is big, the journey is long, and we are so glad you are here at the start.' })}</p>
+        <div className="ab-cta__btns reveal" style={{ '--reveal-index': 3 }}>
           <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.booking', { defaultValue: 'Plan your journey →' })}</Link>
           <Link className="btn btn--ghost-light btn--lg" to="/excursions">{t('cta.excursions', { defaultValue: 'See our excursions' })}</Link>
         </div>

--- a/src/components/about/AboutDestinations.jsx
+++ b/src/components/about/AboutDestinations.jsx
@@ -6,18 +6,18 @@ export default function AboutDestinations() {
   const destinations = t('destinations.items', { returnObjects: true, defaultValue: aboutDestinations });
 
   return (
-    <section className="ab-press reveal" id="destinations">
+    <section className="ab-press" id="destinations">
       <div className="ab-press__head">
         <div>
-          <span className="ab-story__eyebrow">{t('destinations.eyebrow', { defaultValue: 'Where we go' })}</span>
-          <h2>{t('destinations.title_prefix', { defaultValue: 'From Unguja,' })} <em>{t('destinations.title_em', { defaultValue: 'outward' })}</em>{t('destinations.title_suffix', { defaultValue: '.' })}</h2>
+          <span className="ab-story__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('destinations.eyebrow', { defaultValue: 'Where we go' })}</span>
+          <h2 className="reveal" style={{ '--reveal-index': 1 }}>{t('destinations.title_prefix', { defaultValue: 'From Unguja,' })} <em>{t('destinations.title_em', { defaultValue: 'outward' })}</em>{t('destinations.title_suffix', { defaultValue: '.' })}</h2>
         </div>
-        <p>{t('destinations.lead', { defaultValue: 'We begin in Unguja, Zanzibar — the place this journey started — and across mainland Tanzania, where the wider story unfolds. Pemba and Mafia Island will follow, each in the time it deserves.' })}</p>
+        <p className="reveal" style={{ '--reveal-index': 2 }}>{t('destinations.lead', { defaultValue: 'We begin in Unguja, Zanzibar — the place this journey started — and across mainland Tanzania, where the wider story unfolds. Pemba and Mafia Island will follow, each in the time it deserves.' })}</p>
       </div>
 
       <div className="ab-dest__grid">
         {Array.isArray(destinations) && destinations.map((destination, index) => (
-          <article className="ab-dest reveal" key={`destination-${index}`} style={{ transitionDelay: `${index * 90}ms` }}>
+          <article className="ab-dest reveal" key={`destination-${index}`} style={{ '--reveal-index': index }}>
             <span className="ab-dest__tag">{destination.tag}</span>
             <h3 className="ab-dest__name">{destination.name}</h3>
             <p className="ab-dest__body">{destination.body}</p>

--- a/src/components/about/AboutMission.jsx
+++ b/src/components/about/AboutMission.jsx
@@ -7,9 +7,9 @@ export default function AboutMission() {
   return (
     <section className="ab-numbers ab-mission" id="mission">
       <div className="ab-mission__inner">
-        <span className="ab-mission__eyebrow">{t('mission.eyebrow', { defaultValue: 'Our Mission' })}</span>
-        <h2 className="ab-mission__statement">{t('mission.title_prefix', { defaultValue: 'To show the world how beautiful' })} <em>{t('mission.title_em', { defaultValue: 'Tanzania' })}</em>{titleSuffix === '.' ? titleSuffix : ` ${titleSuffix}`}</h2>
-        <p className="ab-mission__sub">{t('mission.sub', { defaultValue: 'Simple, and the same as it was on that first piece of paper — every island, every coast, every corner of the mainland has a story worth meeting in person.' })}</p>
+        <span className="ab-mission__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('mission.eyebrow', { defaultValue: 'Our Mission' })}</span>
+        <h2 className="ab-mission__statement reveal" style={{ '--reveal-index': 1 }}>{t('mission.title_prefix', { defaultValue: 'To show the world how beautiful' })} <em>{t('mission.title_em', { defaultValue: 'Tanzania' })}</em>{titleSuffix === '.' ? titleSuffix : ` ${titleSuffix}`}</h2>
+        <p className="ab-mission__sub reveal" style={{ '--reveal-index': 2 }}>{t('mission.sub', { defaultValue: 'Simple, and the same as it was on that first piece of paper — every island, every coast, every corner of the mainland has a story worth meeting in person.' })}</p>
       </div>
     </section>
   );

--- a/src/components/about/AboutStory.jsx
+++ b/src/components/about/AboutStory.jsx
@@ -14,15 +14,15 @@ export default function AboutStory() {
   const timeline = t('story.timeline', { returnObjects: true, defaultValue: aboutTimeline });
 
   return (
-    <section className="ab-story reveal" id="story">
+    <section className="ab-story" id="story">
       <div className="ab-story__head">
         <div>
-          <span className="ab-story__eyebrow">{t('story.eyebrow', { defaultValue: 'Our Story' })}</span>
-          <h2 className="ab-story__title">{t('story.title_prefix', { defaultValue: 'It started with a' })} <em>{t('story.title_em', { defaultValue: 'dream' })}</em>, {t('story.title_suffix', { defaultValue: 'far from home.' })}</h2>
+          <span className="ab-story__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('story.eyebrow', { defaultValue: 'Our Story' })}</span>
+          <h2 className="ab-story__title reveal" style={{ '--reveal-index': 1 }}>{t('story.title_prefix', { defaultValue: 'It started with a' })} <em>{t('story.title_em', { defaultValue: 'dream' })}</em>, {t('story.title_suffix', { defaultValue: 'far from home.' })}</h2>
         </div>
         <div className="ab-story__lead">
-          {Array.isArray(lead) && lead.map((paragraph) => (
-            <p key={paragraph}>{paragraph}</p>
+          {Array.isArray(lead) && lead.map((paragraph, index) => (
+            <p className="reveal" style={{ '--reveal-index': index + 2 }} key={paragraph}>{paragraph}</p>
           ))}
         </div>
       </div>
@@ -30,7 +30,7 @@ export default function AboutStory() {
       <div className="ab-timeline">
         <div className="ab-timeline__rail">
           {Array.isArray(timeline) && timeline.map((item, index) => (
-            <div className="ab-tl-item reveal" key={`timeline-${index}`} style={{ transitionDelay: `${index * 80}ms` }}>
+            <div className="ab-tl-item reveal" key={`timeline-${index}`} style={{ '--reveal-index': index }}>
               <div className="ab-tl-item__year">{item.year}</div>
               <h4>{item.title}</h4>
               <p>{item.body}</p>
@@ -38,7 +38,7 @@ export default function AboutStory() {
           ))}
         </div>
         <div className="ab-timeline__photo-wrap">
-          <div className="ab-timeline__photo">
+          <div className="ab-timeline__photo reveal" style={{ '--reveal-index': 0 }}>
             <ResponsiveImage src={ABOUT_STORY_IMAGE} alt={t('story.image_alt', { defaultValue: 'A traditional dhow on the Zanzibar coast' })} loading="lazy" />
             <div className="ab-timeline__caption">{t('story.caption', { defaultValue: 'From an idea on paper to a real company — Zanzibar, where it all began.' })}</div>
           </div>

--- a/src/components/booking/BookingFlow.jsx
+++ b/src/components/booking/BookingFlow.jsx
@@ -25,8 +25,8 @@ export default function BookingFlow() {
 
   return (
     <section className="booking-flow" aria-label={t('flow.aria', { defaultValue: 'Booking process' })}>
-      {Array.isArray(steps) && steps.map((step) => (
-        <article key={step.number}>
+      {Array.isArray(steps) && steps.map((step, i) => (
+        <article className="reveal dp-lift" key={step.number} style={{ '--reveal-index': i }}>
           <span>{step.number}</span>
           <h2>{step.title}</h2>
           <p>{step.text}</p>

--- a/src/components/booking/BookingSummary.jsx
+++ b/src/components/booking/BookingSummary.jsx
@@ -36,7 +36,7 @@ export default function BookingSummary({
         ref={summaryRef}
         style={summaryFloat.mode === 'floating' ? { left: summaryFloat.left, width: summaryFloat.width } : undefined}
       >
-        <div className="booking-summary__card">
+        <div className="booking-summary__card reveal" style={{ '--reveal-index': 0 }}>
           <span className="section-eyebrow">{t('summary.eyebrow', { defaultValue: 'Your request' })}</span>
           <h3>{selectedProduct?.label || selectedService?.label || t('summary.custom_plan', { defaultValue: 'Custom plan' })}</h3>
           <p>{selectedProduct?.category || t('summary.flexible_route', { defaultValue: 'Flexible route' })}</p>
@@ -53,7 +53,7 @@ export default function BookingSummary({
           </dl>
         </div>
 
-        <div className="booking-summary__card booking-summary__card--dark">
+        <div className="booking-summary__card booking-summary__card--dark reveal" style={{ '--reveal-index': 1 }}>
           <span>{t('summary.payment_title', { defaultValue: 'How payment works' })}</span>
           <ol>
             {Array.isArray(paymentSteps) && paymentSteps.map((step) => (
@@ -63,7 +63,7 @@ export default function BookingSummary({
           <p>{t('summary.payment_note', { defaultValue: 'No card details are entered or stored on this website.' })}</p>
         </div>
 
-        <div className="booking-summary__mini">
+        <div className="booking-summary__mini reveal" style={{ '--reveal-index': 2 }}>
           <strong>{t('summary.mini_title', { defaultValue: 'Prefer to plan first?' })}</strong>
           <Link to="/trip-planner">{t('summary.mini_link', { defaultValue: 'Open the AI planner →' })}</Link>
         </div>

--- a/src/components/booking/BookingSupportCta.jsx
+++ b/src/components/booking/BookingSupportCta.jsx
@@ -7,11 +7,11 @@ export default function BookingSupportCta() {
 
   return (
     <section className="exc-cta">
-      <div className="exc-cta__bg"><ResponsiveImage src="/assets/images/excursions/stone-town-old-fort.webp" alt="" /></div>
+      <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src="/assets/images/excursions/stone-town-old-fort.webp" alt="" /></div>
       <div className="exc-cta__inner">
-        <h2>{t('support_cta.title', { defaultValue: 'Need help before you send it?' })}</h2>
-        <p>{t('support_cta.text', { defaultValue: 'Open the planner if you want to shape the route first, or explore the full map to choose the right beach, safari circuit, and island days.' })}</p>
-        <div className="exc-cta__btns">
+        <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('support_cta.title', { defaultValue: 'Need help before you send it?' })}</h2>
+        <p className="reveal" style={{ '--reveal-index': 1 }}>{t('support_cta.text', { defaultValue: 'Open the planner if you want to shape the route first, or explore the full map to choose the right beach, safari circuit, and island days.' })}</p>
+        <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
           <Link className="btn btn--lg btn--accent" to="/trip-planner">{t('support_cta.planner', { defaultValue: 'Plan with AI' })}</Link>
           <Link className="btn btn--ghost-light btn--lg" to="/explore">{t('support_cta.explore', { defaultValue: 'Explore the map' })}</Link>
         </div>

--- a/src/components/excursions/ExcursionsCta.jsx
+++ b/src/components/excursions/ExcursionsCta.jsx
@@ -7,13 +7,13 @@ export default function ExcursionsCta() {
   const { t } = useTranslation('excursions');
   return (
     <section className="exc-cta">
-      <div className="exc-cta__bg"><ResponsiveImage src={EXCURSIONS_CTA_IMAGE} alt="" /></div>
+      <div className="exc-cta__bg"><ResponsiveImage src={EXCURSIONS_CTA_IMAGE} alt="" className="dp-drift" /></div>
       <div className="exc-cta__inner">
-        <h2>{t('cta.title')}</h2>
-        <p>{t('cta.text')}</p>
+        <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('cta.title')}</h2>
+        <p className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.text')}</p>
         <div className="exc-cta__btns">
-          <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.get_in_touch')}</Link>
-          <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
+          <Link className="btn btn--lg btn--accent reveal" style={{ '--reveal-index': 2 }} to="/booking">{t('cta.get_in_touch')}</Link>
+          <Link className="btn btn--ghost-light btn--lg reveal" style={{ '--reveal-index': 3 }} to="/trip-planner">{t('cta.ai_planner')}</Link>
         </div>
       </div>
     </section>

--- a/src/components/excursions/ExcursionsFaq.jsx
+++ b/src/components/excursions/ExcursionsFaq.jsx
@@ -4,29 +4,29 @@ import { useTranslation } from 'react-i18next';
 export default function ExcursionsFaq() {
   const { t } = useTranslation('excursions');
   return (
-    <section className="exc-faq reveal">
+    <section className="exc-faq">
       <div className="exc-faq__head">
-        <span className="section-eyebrow">{t('faq.eyebrow')}</span>
-        <h2 className="section-title">{t('faq.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('faq.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('faq.title')}</h2>
       </div>
       <div className="exc-faq__list">
-        <details className="exc-faq__item" open>
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 0 }} open>
           <summary>{t('faq.items.private.q')}</summary>
           <div className="exc-faq__body">{t('faq.items.private.a')}</div>
         </details>
-        <details className="exc-faq__item">
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 1 }}>
           <summary>{t('faq.items.rain.q')}</summary>
           <div className="exc-faq__body">{t('faq.items.rain.a')}</div>
         </details>
-        <details className="exc-faq__item">
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 2 }}>
           <summary>{t('faq.items.pickup.q')}</summary>
           <div className="exc-faq__body">{t('faq.items.pickup.a')}</div>
         </details>
-        <details className="exc-faq__item">
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 3 }}>
           <summary>{t('faq.items.ramadan.q')}</summary>
           <div className="exc-faq__body">{t('faq.items.ramadan.a')}</div>
         </details>
-        <details className="exc-faq__item">
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 4 }}>
           <summary>{t('faq.items.safari.q')}</summary>
           <div className="exc-faq__body">
             {t('faq.items.safari.a_prefix')}
@@ -36,7 +36,7 @@ export default function ExcursionsFaq() {
             {t('faq.items.safari.a_suffix')}
           </div>
         </details>
-        <details className="exc-faq__item">
+        <details className="exc-faq__item reveal" style={{ '--reveal-index': 5 }}>
           <summary>{t('faq.items.tipping.q')}</summary>
           <div className="exc-faq__body">{t('faq.items.tipping.a')}</div>
         </details>

--- a/src/components/excursions/ExcursionsGrid.jsx
+++ b/src/components/excursions/ExcursionsGrid.jsx
@@ -25,9 +25,9 @@ export default function ExcursionsGrid({
   return (
     <section className="exc-grid-wrap" id="list">
       <header className="exc-list__head">
-        <span className="section-eyebrow">{t('grid.eyebrow')}</span>
-        <h2 className="section-title">{t('grid.title')}</h2>
-        <p className="section-lead">{t('grid.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('grid.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('grid.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('grid.lead')}</p>
       </header>
 
       <div className="exc-filter">
@@ -47,11 +47,12 @@ export default function ExcursionsGrid({
       </div>
 
       <div className="exc-grid">
-        {visible.map((e) => (
+        {visible.map((e, i) => (
           <Link
             key={e.id}
             to={`/excursions/${e.id}`}
             className="exc-card reveal"
+            style={{ '--reveal-index': i }}
             data-cat={categoryToSlug(e.category)}
             aria-label={t('grid.explore_aria', { title: e.title })}
           >

--- a/src/components/excursions/ExcursionsPairings.jsx
+++ b/src/components/excursions/ExcursionsPairings.jsx
@@ -7,15 +7,15 @@ export default function ExcursionsPairings() {
   const { t } = useTranslation('excursions');
   const { format } = useCurrency();
   return (
-    <section className="exc-pair reveal">
+    <section className="exc-pair">
       <div className="exc-pair__head">
-        <span className="section-eyebrow">{t('pairings.eyebrow')}</span>
-        <h2 className="section-title">{t('pairings.title')}</h2>
-        <p className="section-lead">{t('pairings.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('pairings.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('pairings.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('pairings.lead')}</p>
       </div>
       <div className="exc-pair__grid">
-        {EXCURSION_COMBINATIONS.map((p) => (
-          <Link className="exc-pair__card" key={p.title} to={`/excursions/combinations/${p.id}`} aria-label={t('pairings.explore_aria', { title: p.title })}>
+        {EXCURSION_COMBINATIONS.map((p, i) => (
+          <Link className="exc-pair__card reveal" style={{ '--reveal-index': i }} key={p.title} to={`/excursions/combinations/${p.id}`} aria-label={t('pairings.explore_aria', { title: p.title })}>
             <div className="exc-pair__combo">
               <span>{p.combo[0]}</span>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 12h14M13 6l6 6-6 6" /></svg>

--- a/src/components/excursions/ExcursionsPractical.jsx
+++ b/src/components/excursions/ExcursionsPractical.jsx
@@ -23,10 +23,10 @@ export default function ExcursionsPractical() {
   return (
     <section className="exc-prac">
       <div className="exc-prac__grid">
-        {PRACTICAL_COLUMNS.map((col) => {
+        {PRACTICAL_COLUMNS.map((col, i) => {
           const items = arrayFromTranslation(t(`practical.columns.${col.key}.items`, { returnObjects: true }));
           return (
-            <div className="exc-prac__col" key={col.key}>
+            <div className="exc-prac__col reveal" style={{ '--reveal-index': i }} key={col.key}>
               <h4>{t(`practical.columns.${col.key}.heading`)}</h4>
               <ul>
                 {items.map((it) => (

--- a/src/components/explore/ExploreCta.jsx
+++ b/src/components/explore/ExploreCta.jsx
@@ -7,13 +7,13 @@ export default function ExploreCta() {
   const { t } = useTranslation('explore');
   return (
     <section className="exc-cta">
-      <div className="exc-cta__bg"><ResponsiveImage src={EXPLORE_CTA_IMAGE} alt="" /></div>
+      <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src={EXPLORE_CTA_IMAGE} alt="" /></div>
       <div className="exc-cta__inner">
-        <h2>{t('cta.title')}</h2>
-        <p>{t('cta.text')}</p>
+        <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('cta.title')}</h2>
+        <p className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.text')}</p>
         <div className="exc-cta__btns">
-          <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.get_quote')}</Link>
-          <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.plan_ai')}</Link>
+          <Link className="btn btn--lg btn--accent reveal" style={{ '--reveal-index': 2 }} to="/booking">{t('cta.get_quote')}</Link>
+          <Link className="btn btn--ghost-light btn--lg reveal" style={{ '--reveal-index': 3 }} to="/trip-planner">{t('cta.plan_ai')}</Link>
         </div>
       </div>
     </section>

--- a/src/components/explore/ExploreDoorways.jsx
+++ b/src/components/explore/ExploreDoorways.jsx
@@ -18,14 +18,14 @@ export default function ExploreDoorways() {
   const items = arrayFromTranslation(t('doorways.items', { returnObjects: true }));
 
   return (
-    <section className="saf-steps reveal">
+    <section className="saf-steps">
       <header className="saf-steps__head">
-        <span className="section-eyebrow">{t('doorways.eyebrow')}</span>
-        <h2 className="section-title">{t('doorways.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('doorways.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('doorways.title')}</h2>
       </header>
       <div className="saf-steps__grid">
         {items.map((item, index) => (
-          <article className="saf-step" key={item.step}>
+          <article className="saf-step reveal" style={{ '--reveal-index': index }} key={item.step}>
             <span>{item.step}</span>
             <h3>{item.title}</h3>
             <p>{t(`doorways.items.${index}.text`, { price: prices[index] })}</p>

--- a/src/components/explore/ExploreHub.jsx
+++ b/src/components/explore/ExploreHub.jsx
@@ -10,20 +10,20 @@ export default function ExploreHub({ hub, plannerHref }) {
   ];
 
   return (
-    <section className="explore-hub reveal" aria-live="polite">
+    <section className="explore-hub" aria-live="polite">
       <div className="explore-hub__inner">
         <div className="explore-hub__copy">
-          <span className="section-eyebrow">{hub.type}</span>
-          <h2 className="section-title">{hub.title}</h2>
-          <p className="section-lead">{hub.text}</p>
-          <div className="explore-hub__tags">
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{hub.type}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{hub.title}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{hub.text}</p>
+          <div className="explore-hub__tags reveal" style={{ '--reveal-index': 3 }}>
             {hub.bestFor.map((item) => <span key={item}>{item}</span>)}
           </div>
-          <Link className="btn btn--ghost-dark" to={plannerHref}>{t('hub.plan_around', { title: hub.title })}</Link>
+          <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 4 }} to={plannerHref}>{t('hub.plan_around', { title: hub.title })}</Link>
         </div>
         <div className="explore-hub__matches">
-          {matches.map(([label, items]) => (
-            <div className="explore-hub__match" key={label}>
+          {matches.map(([label, items], index) => (
+            <div className="explore-hub__match reveal" style={{ '--reveal-index': index }} key={label}>
               <h3>{label}</h3>
               {items && items.length > 0 ? (
                 <ul>{items.map((item) => <li key={item.to}><Link to={item.to}>{item.label}</Link></li>)}</ul>

--- a/src/components/explore/ExplorePaths.jsx
+++ b/src/components/explore/ExplorePaths.jsx
@@ -4,15 +4,15 @@ import { useTranslation } from 'react-i18next';
 export default function ExplorePaths({ paths }) {
   const { t } = useTranslation('explore');
   return (
-    <section className="saf-compare reveal" id="paths">
+    <section className="saf-compare" id="paths">
       <header className="saf-compare__head">
-        <span className="section-eyebrow">{t('paths.eyebrow')}</span>
-        <h2 className="section-title">{t('paths.title')}</h2>
-        <p className="section-lead">{t('paths.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('paths.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('paths.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('paths.lead')}</p>
       </header>
       <div className="explore-path-grid">
-        {paths.map((path) => (
-          <Link className="explore-path-card" to={path.to} key={path.title}>
+        {paths.map((path, index) => (
+          <Link className="explore-path-card reveal" style={{ '--reveal-index': index }} to={path.to} key={path.title}>
             <img src={path.image} alt="" loading="lazy" />
             <div>
               <span>{path.eyebrow}</span>

--- a/src/components/homepage/AboutSection.jsx
+++ b/src/components/homepage/AboutSection.jsx
@@ -9,9 +9,9 @@ export default function AboutSection() {
   const highlights = t('about.highlights', { returnObjects: true, defaultValue: [] });
 
   return (
-    <section className="home-about reveal" id="about-intro">
+    <section className="home-about" id="about-intro">
       <div className="home-about__inner">
-        <figure className="home-about__media">
+        <figure className="home-about__media reveal" style={{ '--reveal-index': 0 }}>
           <ResponsiveImage
             src={ABOUT_HERO_IMAGE}
             alt={t('about.image_alt', { defaultValue: 'Crowned cranes in long grass at dawn' })}
@@ -25,13 +25,13 @@ export default function AboutSection() {
         </figure>
 
         <div className="home-about__copy">
-          <span className="section-eyebrow">{t('about.eyebrow', { defaultValue: 'About us' })}</span>
-          <h2 className="home-about__title">
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('about.eyebrow', { defaultValue: 'About us' })}</span>
+          <h2 className="home-about__title reveal" style={{ '--reveal-index': 1 }}>
             {t('about.title_prefix', { defaultValue: 'A vision,' })}{' '}
             <em>{t('about.title_em', { defaultValue: 'finally' })}</em>{' '}
             <span className="home-about__title-tail">{t('about.title_suffix', { defaultValue: 'taking its first journey.' })}</span>
           </h2>
-          <p className="home-about__lead">
+          <p className="home-about__lead reveal" style={{ '--reveal-index': 2 }}>
             {t('about.lead', {
               defaultValue: 'Destination Paradise was born from a dream — to connect people to the beauty, culture and spirit of Tanzania. After years of preparation, we are officially launching from Unguja, Zanzibar.',
             })}
@@ -39,8 +39,8 @@ export default function AboutSection() {
 
           {Array.isArray(highlights) && highlights.length > 0 && (
             <ul className="home-about__highlights">
-              {highlights.map((item) => (
-                <li key={`${item.value}-${item.label}`}>
+              {highlights.map((item, i) => (
+                <li className="reveal" style={{ '--reveal-index': i }} key={`${item.value}-${item.label}`}>
                   <strong>{item.em ? <em>{item.value}</em> : item.value}</strong>
                   <span>{item.label}</span>
                 </li>
@@ -49,7 +49,7 @@ export default function AboutSection() {
           )}
 
           <div className="home-about__cta">
-            <Link className="btn" to="/aboutus">
+            <Link className="btn reveal" style={{ '--reveal-index': 0 }} to="/aboutus">
               {t('about.cta', { defaultValue: 'Read our story' })} <ArrowIcon size={14} />
             </Link>
           </div>

--- a/src/components/homepage/ContactSection.jsx
+++ b/src/components/homepage/ContactSection.jsx
@@ -82,11 +82,11 @@ export default function ContactSection() {
   };
 
   return (
-    <section className="contact reveal" id="contact">
+    <section className="contact" id="contact">
       <header className="contact__head">
-        <span className="section-eyebrow">{t('contact.eyebrow')}</span>
-        <h2 className="section-title">{t('contact.title')}</h2>
-        <p className="section-lead">{t('contact.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('contact.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('contact.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('contact.lead')}</p>
       </header>
 
       <div className="contact__grid">

--- a/src/components/homepage/ExcursionsSection.jsx
+++ b/src/components/homepage/ExcursionsSection.jsx
@@ -9,19 +9,19 @@ export default function ExcursionsSection({ tweaks, excursions }) {
   const { t } = useTranslation('home');
   const { format } = useCurrency();
   return (
-    <section className="excursions reveal" id="excursions" data-layout={tweaks.layout}>
+    <section className="excursions" id="excursions" data-layout={tweaks.layout}>
       <header className="excursions__head">
-        <span className="section-eyebrow">{t('excursions.eyebrow')}</span>
-        <h2 className="section-title">{t('excursions.title')}</h2>
-        <p className="section-lead">{t('excursions.lead')}</p>
-        <ul className="excursions__modes">
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('excursions.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('excursions.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('excursions.lead')}</p>
+        <ul className="excursions__modes reveal" style={{ '--reveal-index': 3 }}>
           <li><span className="excursions__mode-tag">{t('excursions.modes.ocean_tag')}</span> {t('excursions.modes.ocean_text')}</li>
           <li><span className="excursions__mode-tag excursions__mode-tag--accent">{t('excursions.modes.culture_tag')}</span> {t('excursions.modes.culture_text')}</li>
           <li><span className="excursions__mode-tag">{t('excursions.modes.nature_tag')}</span> {t('excursions.modes.nature_text')}</li>
         </ul>
       </header>
       <div className="excursions__grid">
-        {excursions.map((tr) => {
+        {excursions.map((tr, i) => {
           const localized = objectFromTranslation(t(`excursions.featured.${tr.id}`, { returnObjects: true, defaultValue: {} }), {});
           const title = localized.title || tr.title;
           const description = localized.description || tr.description;
@@ -30,7 +30,7 @@ export default function ExcursionsSection({ tweaks, excursions }) {
           const group = localized.group || tr.group;
 
           return (
-          <Link className="ex-card" key={tr.id} to={`/excursions/${tr.id}`} aria-label={t('excursions.card.explore_aria', { title })}>
+          <Link className="ex-card reveal" style={{ '--reveal-index': i }} key={tr.id} to={`/excursions/${tr.id}`} aria-label={t('excursions.card.explore_aria', { title })}>
             <div className="ex-card__img">
               <ResponsiveImage src={tr.image} alt={title} loading="lazy" decoding="async" sizes="(max-width: 600px) 220px, (max-width: 1000px) 45vw, 360px" />
               <span className="ex-card__badge">{duration}</span>
@@ -64,7 +64,7 @@ export default function ExcursionsSection({ tweaks, excursions }) {
         })}
       </div>
       <div className="excursions__more">
-        <Link className="btn btn--on-light" to="/excursions">{t('excursions.view_all')} <ArrowIcon size={16} /></Link>
+        <Link className="btn btn--on-light reveal" style={{ '--reveal-index': 0 }} to="/excursions">{t('excursions.view_all')} <ArrowIcon size={16} /></Link>
       </div>
     </section>
   );

--- a/src/components/homepage/GallerySection.jsx
+++ b/src/components/homepage/GallerySection.jsx
@@ -20,15 +20,15 @@ export default function GallerySection() {
   const { t } = useTranslation('home');
 
   return (
-    <section className="gallery-section reveal" id="gallery">
+    <section className="gallery-section" id="gallery">
       <div className="gallery-head">
-        <span className="section-eyebrow">{t('gallery.eyebrow')}</span>
-        <h2 className="section-title">{t('gallery.title')}</h2>
-        <p className="section-lead">{t('gallery.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('gallery.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('gallery.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('gallery.lead')}</p>
       </div>
       <div className="gallery-strip">
-        {PHOTOS.map((photo) => (
-          <figure className={photo.className} key={photo.src}>
+        {PHOTOS.map((photo, i) => (
+          <figure className={`${photo.className} reveal`} style={{ '--reveal-index': i }} key={photo.src}>
             <ResponsiveImage src={photo.src} alt="" loading="lazy" decoding="async" sizes="(max-width: 600px) 50vw, (max-width: 1000px) 33vw, 320px" />
             <figcaption className="gallery-tile__caption">{t(`gallery.captions.${photo.key}`)}</figcaption>
           </figure>

--- a/src/components/homepage/NewsletterSection.jsx
+++ b/src/components/homepage/NewsletterSection.jsx
@@ -40,11 +40,11 @@ export default function NewsletterSection() {
   };
 
   return (
-    <section className="newsletter reveal" id="newsletter">
+    <section className="newsletter" id="newsletter">
       <div>
-        <span className="newsletter__eyebrow">{t('newsletter.eyebrow')}</span>
-        <h3 className="newsletter__title">{t('newsletter.title')}</h3>
-        <p className="newsletter__desc">{t('newsletter.description')}</p>
+        <span className="newsletter__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('newsletter.eyebrow')}</span>
+        <h3 className="newsletter__title reveal" style={{ '--reveal-index': 1 }}>{t('newsletter.title')}</h3>
+        <p className="newsletter__desc reveal" style={{ '--reveal-index': 2 }}>{t('newsletter.description')}</p>
       </div>
       <form
         className="newsletter__form"

--- a/src/components/homepage/PackagesSection.jsx
+++ b/src/components/homepage/PackagesSection.jsx
@@ -59,17 +59,17 @@ export default function PackagesSection() {
   }, [t]);
 
   return (
-    <section className="packages reveal" id="packages">
+    <section className="packages" id="packages">
       <header className="packages__head">
-        <span className="section-eyebrow">{t('packages.eyebrow')}</span>
-        <h2 className="section-title">{t('packages.title', { count: destinationParadisePackages.length })}</h2>
-        <p className="section-lead">{t('packages.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('packages.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('packages.title', { count: destinationParadisePackages.length })}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('packages.lead')}</p>
       </header>
       <div className="packages__grid">
-        {packageCards.map((pkg) => {
+        {packageCards.map((pkg, i) => {
           const ribbonKey = getPackageRibbonKey(pkg.slug);
           return (
-            <article className={`pkg-card${pkg.slug === 'ten-day-classic-safari-zanzibar' ? ' pkg-card--feature' : ''}`} key={pkg.slug}>
+            <article className={`pkg-card reveal${pkg.slug === 'ten-day-classic-safari-zanzibar' ? ' pkg-card--feature' : ''}`} style={{ '--reveal-index': i }} key={pkg.slug}>
               {ribbonKey && (
                 <div className={`pkg-card__rib${pkg.slug === 'ten-day-classic-safari-zanzibar' ? ' pkg-card__rib--gold' : ''}`}>{t(`packages.ribbons.${ribbonKey}`)}</div>
               )}
@@ -91,9 +91,9 @@ export default function PackagesSection() {
           );
         })}
       </div>
-      <div className="packages__note">{t('packages.note')}</div>
+      <div className="packages__note reveal" style={{ '--reveal-index': 0 }}>{t('packages.note')}</div>
       <div className="excursions__more">
-        <Link className="btn btn--on-light" to="/packages">{t('packages.view_all')} <ArrowIcon size={16} /></Link>
+        <Link className="btn btn--on-light reveal" style={{ '--reveal-index': 1 }} to="/packages">{t('packages.view_all')} <ArrowIcon size={16} /></Link>
       </div>
     </section>
   );

--- a/src/components/homepage/SafarisSection.jsx
+++ b/src/components/homepage/SafarisSection.jsx
@@ -37,20 +37,20 @@ export default function SafarisSection() {
   const totalSafaris = destinationParadiseSafariPricing.length + nextLevelSafariProducts.length;
 
   return (
-    <section className="safaris reveal" id="safaris">
+    <section className="safaris" id="safaris">
       <header className="safaris__head">
-        <span className="section-eyebrow">{t('safaris.eyebrow')}</span>
-        <h2 className="section-title">{t('safaris.title', { count: totalSafaris })}</h2>
-        <p className="section-lead">{t('safaris.lead')}</p>
-        <ul className="safaris__modes">
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('safaris.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('safaris.title', { count: totalSafaris })}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('safaris.lead')}</p>
+        <ul className="safaris__modes reveal" style={{ '--reveal-index': 3 }}>
           <li><span className="safaris__mode-tag">{t('safaris.modes.classic_tag')}</span> {t('safaris.modes.classic_text')}</li>
           <li><span className="safaris__mode-tag safaris__mode-tag--accent">{t('safaris.modes.fly_in_tag')}</span> {t('safaris.modes.fly_in_text')}</li>
           <li><span className="safaris__mode-tag">{t('safaris.modes.specialists_tag')}</span> {t('safaris.modes.specialists_text')}</li>
         </ul>
       </header>
       <div className="safaris__grid">
-        {safariCards.map((trip) => (
-          <article className={`safari-card${trip.featured ? ' safari-card--feature' : ''}`} key={trip.slug}>
+        {safariCards.map((trip, i) => (
+          <article className={`safari-card reveal${trip.featured ? ' safari-card--feature' : ''}`} style={{ '--reveal-index': i }} key={trip.slug}>
             <div className="safari-card__img">
               <ResponsiveImage src={trip.image} alt="" loading="lazy" decoding="async" sizes="(max-width: 600px) 100vw, (max-width: 1000px) 50vw, 380px" />
               <span className="safari-card__nights">{t(`safaris.features.${trip.slug}.label`)}</span>
@@ -67,7 +67,7 @@ export default function SafarisSection() {
         ))}
       </div>
       <div className="excursions__more">
-        <Link className="btn btn--on-light" to="/safaris">{t('safaris.view_all')} <ArrowIcon size={16} /></Link>
+        <Link className="btn btn--on-light reveal" style={{ '--reveal-index': 0 }} to="/safaris">{t('safaris.view_all')} <ArrowIcon size={16} /></Link>
       </div>
     </section>
   );

--- a/src/components/homepage/TestimonialsSection.jsx
+++ b/src/components/homepage/TestimonialsSection.jsx
@@ -9,14 +9,14 @@ const TESTIMONIALS = [
 export default function TestimonialsSection() {
   const { t } = useTranslation('home');
   return (
-    <section className="testimonials reveal" id="reviews">
+    <section className="testimonials" id="reviews">
       <div className="testimonials__head">
-        <span className="section-eyebrow">{t('testimonials.eyebrow')}</span>
-        <h2 className="section-title">{t('testimonials.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('testimonials.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('testimonials.title')}</h2>
       </div>
       <div className="testimonials__grid">
-        {TESTIMONIALS.map((tm) => (
-          <figure className="tm" key={tm.key}>
+        {TESTIMONIALS.map((tm, i) => (
+          <figure className="tm reveal" style={{ '--reveal-index': i }} key={tm.key}>
             <div className="tm__mark">"</div>
             <blockquote className="tm__quote">{t(`testimonials.quotes.${tm.key}.quote`)}</blockquote>
             <div className="tm__foot">

--- a/src/components/homepage/TransfersSection.jsx
+++ b/src/components/homepage/TransfersSection.jsx
@@ -28,16 +28,16 @@ export default function TransfersSection() {
   }, [t]);
 
   return (
-    <section className="home-transfers reveal" id="transfers">
+    <section className="home-transfers" id="transfers">
       <header className="home-transfers__head">
-        <span className="section-eyebrow">{t('transfers.eyebrow')}</span>
-        <h2 className="section-title">{t('transfers.title')}</h2>
-        <p className="section-lead">{t('transfers.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('transfers.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('transfers.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('transfers.lead')}</p>
       </header>
 
       <div className="home-transfers__grid">
-        {transferCards.map((transfer) => (
-          <article className={`home-transfer-card${transfer.featured ? ' home-transfer-card--feature' : ''}`} key={transfer.slug}>
+        {transferCards.map((transfer, i) => (
+          <article className={`home-transfer-card reveal dp-lift${transfer.featured ? ' home-transfer-card--feature' : ''}`} style={{ '--reveal-index': i }} key={transfer.slug}>
             {transfer.featured && <span className="home-transfer-card__rib">{t('transfers.tags.vip')}</span>}
             <div className="home-transfer-card__head">
               <span className="home-transfer-card__tag">{t(`transfers.tags.${getTransferTagKey(transfer)}`)}</span>
@@ -66,7 +66,7 @@ export default function TransfersSection() {
       </div>
 
       <div className="home-transfers__more">
-        <Link className="btn btn--on-light" to="/transfers">{t('transfers.view_all')} <ArrowIcon size={16} /></Link>
+        <Link className="btn btn--on-light reveal" style={{ '--reveal-index': 0 }} to="/transfers">{t('transfers.view_all')} <ArrowIcon size={16} /></Link>
       </div>
     </section>
   );

--- a/src/components/homepage/WhySection.jsx
+++ b/src/components/homepage/WhySection.jsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 export default function WhySection() {
   const { t } = useTranslation('home');
   return (
-    <section className="why reveal" id="why">
+    <section className="why" id="why">
       <div className="why__head">
-        <span className="section-eyebrow">{t('why.eyebrow')}</span>
-        <h2 className="section-title">{t('why.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('why.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('why.title')}</h2>
       </div>
       <div className="why__grid">
-        <article className="why-card">
+        <article className="why-card reveal" style={{ '--reveal-index': 0 }}>
           <span className="why-card__num">01</span>
           <span className="why-card__icon">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" /></svg>
@@ -17,7 +17,7 @@ export default function WhySection() {
           <h3 className="why-card__title">{t('why.cards.rooted.title')}</h3>
           <p className="why-card__text">{t('why.cards.rooted.text')}</p>
         </article>
-        <article className="why-card">
+        <article className="why-card reveal" style={{ '--reveal-index': 1 }}>
           <span className="why-card__num">02</span>
           <span className="why-card__icon">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -28,7 +28,7 @@ export default function WhySection() {
           <h3 className="why-card__title">{t('why.cards.group_or_private.title')}</h3>
           <p className="why-card__text">{t('why.cards.group_or_private.text')}</p>
         </article>
-        <article className="why-card">
+        <article className="why-card reveal" style={{ '--reveal-index': 2 }}>
           <span className="why-card__num">03</span>
           <span className="why-card__icon">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.2.6-.6.5-1.1z" /></svg>

--- a/src/components/safaris/SafariBookingSteps.jsx
+++ b/src/components/safaris/SafariBookingSteps.jsx
@@ -4,14 +4,14 @@ import { BOOKING_STEPS } from '../../data/safarisPageContent.js';
 export default function SafariBookingSteps() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="saf-steps reveal" id="booking-steps">
+    <section className="saf-steps" id="booking-steps">
       <header className="saf-steps__head">
-        <span className="section-eyebrow">{t('steps.eyebrow')}</span>
-        <h2 className="section-title">{t('steps.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('steps.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('steps.title')}</h2>
       </header>
       <div className="saf-steps__grid">
-        {BOOKING_STEPS.map((item) => (
-          <article className="saf-step" key={item.step}>
+        {BOOKING_STEPS.map((item, i) => (
+          <article className="saf-step reveal" style={{ '--reveal-index': i }} key={item.step}>
             <span>{item.step}</span>
             <h3>{t(`steps.items.${item.step}.title`, item.title)}</h3>
             <p>{t(`steps.items.${item.step}.text`, item.text)}</p>

--- a/src/components/safaris/SafariComparison.jsx
+++ b/src/components/safaris/SafariComparison.jsx
@@ -5,19 +5,19 @@ import { SAFARI_COMPARISON } from '../../data/safarisPageContent.js';
 export default function SafariComparison() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="saf-compare reveal" id="choose">
+    <section className="saf-compare" id="choose">
       <header className="saf-compare__head">
-        <span className="section-eyebrow">{t('compare.eyebrow')}</span>
-        <h2 className="section-title">{t('compare.title')}</h2>
-        <p className="section-lead">{t('compare.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('compare.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('compare.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('compare.lead')}</p>
       </header>
       <div className="saf-compare__grid">
-        {SAFARI_COMPARISON.map((item) => {
+        {SAFARI_COMPARISON.map((item, i) => {
           const label = t(`compare.items.${item.slug}.label`, item.label);
           const pick = t(`compare.items.${item.slug}.pick`, item.pick);
           const note = t(`compare.items.${item.slug}.note`, item.note);
           return (
-            <Link className="saf-compare__card" key={item.slug} to={`/safaris/${item.slug}`} aria-label={t('compare.explore_aria', { pick })}>
+            <Link className="saf-compare__card reveal" style={{ '--reveal-index': i }} key={item.slug} to={`/safaris/${item.slug}`} aria-label={t('compare.explore_aria', { pick })}>
               <span>{label}</span>
               <h3>{pick}</h3>
               <p>{note}</p>

--- a/src/components/safaris/SafariCta.jsx
+++ b/src/components/safaris/SafariCta.jsx
@@ -8,14 +8,14 @@ export default function SafariCta() {
   return (
     <section className="saf-cta">
       <div className="saf-cta__bg">
-        <ResponsiveImage src={safariImg('lioness-and-cub-resting.webp')} alt="" />
+        <ResponsiveImage className="dp-drift" src={safariImg('lioness-and-cub-resting.webp')} alt="" />
       </div>
       <div className="saf-cta__inner">
-        <h2>{t('cta.title')}</h2>
-        <p>{t('cta.text')}</p>
+        <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('cta.title')}</h2>
+        <p className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.text')}</p>
         <div className="saf-cta__btns">
-          <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.get_quote')}</Link>
-          <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
+          <Link className="btn btn--lg btn--accent reveal" style={{ '--reveal-index': 0 }} to="/booking">{t('cta.get_quote')}</Link>
+          <Link className="btn btn--ghost-light btn--lg reveal" style={{ '--reveal-index': 1 }} to="/trip-planner">{t('cta.ai_planner')}</Link>
         </div>
       </div>
     </section>

--- a/src/components/safaris/SafariFaq.jsx
+++ b/src/components/safaris/SafariFaq.jsx
@@ -13,14 +13,14 @@ const FAQ_ITEMS = [
 export default function SafariFaq() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="saf-faq reveal" id="faq">
+    <section className="saf-faq" id="faq">
       <header className="saf-faq__head">
-        <span className="section-eyebrow">{t('faq.eyebrow')}</span>
-        <h2 className="section-title">{t('faq.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('faq.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('faq.title')}</h2>
       </header>
       <div className="saf-faq__list">
-        {FAQ_ITEMS.map((faq) => (
-          <details className="saf-faq__item" key={faq.key} {...(faq.open ? { open: true } : {})}>
+        {FAQ_ITEMS.map((faq, i) => (
+          <details className="saf-faq__item reveal" style={{ '--reveal-index': i }} key={faq.key} {...(faq.open ? { open: true } : {})}>
             <summary>{t(`faq.items.${faq.key}.q`)}</summary>
             <div className="saf-faq__body">
               {faq.extendLink ? (

--- a/src/components/safaris/SafariIncluded.jsx
+++ b/src/components/safaris/SafariIncluded.jsx
@@ -5,16 +5,16 @@ export default function SafariIncluded() {
   const { t } = useTranslation('safaris');
   const items = arrayFromTranslation(t('included.items', { returnObjects: true }));
   return (
-    <section className="included reveal">
+    <section className="included">
       <div className="included__wrap">
         <div className="included__copy">
-          <span className="section-eyebrow">{t('included.eyebrow')}</span>
-          <h2 className="section-title">{t('included.title')}</h2>
-          <p className="section-lead">{t('included.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('included.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('included.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('included.lead')}</p>
         </div>
         <ul className="included__list">
-          {items.map((item) => (
-            <li key={item}><span>✓</span> {item}</li>
+          {items.map((item, i) => (
+            <li className="reveal" style={{ '--reveal-index': i }} key={item}><span>✓</span> {item}</li>
           ))}
         </ul>
       </div>

--- a/src/components/safaris/SafariIntro.jsx
+++ b/src/components/safaris/SafariIntro.jsx
@@ -3,31 +3,31 @@ import { useTranslation } from 'react-i18next';
 export default function SafariIntro() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="saf-intro reveal">
+    <section className="saf-intro">
       <div className="saf-intro__grid">
         <div className="saf-intro__copy">
-          <span className="section-eyebrow">{t('intro.eyebrow')}</span>
-          <h2 className="section-title">{t('intro.title')}</h2>
-          <p className="section-lead">
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('intro.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('intro.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>
             {t('intro.lead')}
           </p>
         </div>
         <ul className="saf-intro__bullets">
-          <li>
+          <li className="reveal" style={{ '--reveal-index': 0 }}>
             <span className="saf-intro__num">01</span>
             <div>
               <strong>{t('intro.bullets.vehicles_title')}</strong>
               <p>{t('intro.bullets.vehicles_text')}</p>
             </div>
           </li>
-          <li>
+          <li className="reveal" style={{ '--reveal-index': 1 }}>
             <span className="saf-intro__num">02</span>
             <div>
               <strong>{t('intro.bullets.flights_title')}</strong>
               <p>{t('intro.bullets.flights_text')}</p>
             </div>
           </li>
-          <li>
+          <li className="reveal" style={{ '--reveal-index': 2 }}>
             <span className="saf-intro__num">03</span>
             <div>
               <strong>{t('intro.bullets.fees_title')}</strong>

--- a/src/components/safaris/SafariItineraries.jsx
+++ b/src/components/safaris/SafariItineraries.jsx
@@ -19,11 +19,11 @@ export default function SafariItineraries({
   const filterLabel = (item) => textFromTranslation(t(`filters.${item.key}`, { defaultValue: item.label }), item.label);
   const priceUnit = (sub) => (sub ? textFromTranslation(t(`price_units.${sub}`, { defaultValue: sub }), sub) : '');
   return (
-    <section className="itineraries reveal" id="itineraries">
+    <section className="itineraries" id="itineraries">
       <header className="itineraries__head">
-        <span className="section-eyebrow">{t('itineraries.eyebrow')}</span>
-        <h2 className="section-title">{t('itineraries.title')}</h2>
-        <p className="section-lead">{t('itineraries.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('itineraries.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('itineraries.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('itineraries.lead')}</p>
       </header>
 
       <div className="exc-filter saf-filter">
@@ -42,11 +42,12 @@ export default function SafariItineraries({
       </div>
 
       <div className="exc-grid saf-route-grid">
-        {visibleSafaris.map((itinerary) => (
+        {visibleSafaris.map((itinerary, i) => (
           <Link
             key={itinerary.id}
             to={`/safaris/${itinerary.id}`}
             className="exc-card saf-route-card reveal"
+            style={{ '--reveal-index': i }}
             aria-label={t('itineraries.explore_aria', { title: itinerary.title })}
           >
             <div className="exc-card__img">

--- a/src/components/safaris/SafariParks.jsx
+++ b/src/components/safaris/SafariParks.jsx
@@ -13,19 +13,19 @@ const PARK_KEYS = {
 export default function SafariParks() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="parks reveal" id="parks">
+    <section className="parks" id="parks">
       <header className="parks__head">
-        <span className="section-eyebrow">{t('parks.eyebrow')}</span>
-        <h2 className="section-title">{t('parks.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('parks.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('parks.title')}</h2>
       </header>
       <div className="parks__grid">
-        {PARKS.map((park) => {
+        {PARKS.map((park, i) => {
           const key = PARK_KEYS[park.name];
           const name = key ? textFromTranslation(t(`parks.items.${key}.name`, { defaultValue: park.name }), park.name) : park.name;
           const blurb = key ? textFromTranslation(t(`parks.items.${key}.blurb`, { defaultValue: park.blurb }), park.blurb) : park.blurb;
           const tags = key ? arrayFromTranslation(t(`parks.items.${key}.tags`, { returnObjects: true, defaultValue: park.tags }), park.tags) : park.tags;
           return (
-            <article className={`park-card${park.size === 'lg' ? ' park-card--lg' : ''}`} key={park.name}>
+            <article className={`park-card reveal${park.size === 'lg' ? ' park-card--lg' : ''}`} style={{ '--reveal-index': i }} key={park.name}>
               <div className="park-card__img"><img src={park.image} alt="" loading="lazy" /></div>
               <div className="park-card__body">
                 <div className="park-card__meta"><span>{park.label}</span><span>{park.area}</span></div>

--- a/src/components/safaris/SafariSeasons.jsx
+++ b/src/components/safaris/SafariSeasons.jsx
@@ -4,14 +4,14 @@ import { SEASONS } from '../../data/safarisPageContent.js';
 export default function SafariSeasons() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="when reveal" id="when">
+    <section className="when" id="when">
       <header className="when__head">
-        <span className="section-eyebrow">{t('seasons.eyebrow')}</span>
-        <h2 className="section-title">{t('seasons.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('seasons.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('seasons.title')}</h2>
       </header>
       <div className="when__grid">
-        {SEASONS.map((season) => (
-          <article className={`when-card when-card--${season.mod}`} key={season.mod}>
+        {SEASONS.map((season, i) => (
+          <article className={`when-card when-card--${season.mod} reveal dp-lift`} style={{ '--reveal-index': i }} key={season.mod}>
             <div className="when-card__months">{season.months}</div>
             <h4>{t(`seasons.items.${season.mod}.title`, season.title)}</h4>
             <p>{t(`seasons.items.${season.mod}.blurb`, season.blurb)}</p>

--- a/src/components/safaris/SafariTypes.jsx
+++ b/src/components/safaris/SafariTypes.jsx
@@ -5,12 +5,12 @@ import { SAFARI_TYPES } from '../../data/safariPageData.js';
 export default function SafariTypes() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="saf-types reveal" id="safari-types">
+    <section className="saf-types" id="safari-types">
       <header className="saf-types__head">
-        <span className="section-eyebrow">{t('types.eyebrow')}</span>
-        <h2 className="section-title">{t('types.title')}</h2>
-        <p className="section-lead">{t('types.lead')}</p>
-        <ul className="saf-types__modes">
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('types.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('types.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('types.lead')}</p>
+        <ul className="saf-types__modes reveal" style={{ '--reveal-index': 3 }}>
           <li>
             <span className="saf-types__mode-tag">{t('types.modes.dedicated_tag')}</span>
             {t('types.modes.dedicated_text')}
@@ -26,12 +26,12 @@ export default function SafariTypes() {
         </ul>
       </header>
       <div className="saf-types__grid">
-        {SAFARI_TYPES.map((item) => {
+        {SAFARI_TYPES.map((item, i) => {
           const title = t(`types.items.${item.id}.title`, item.title);
           const desc = t(`types.items.${item.id}.desc`, item.desc);
           const bestFor = t(`types.items.${item.id}.best_for`, item.bestFor);
           return (
-            <Link className="saf-type-card" key={item.id} to={`/safaris/types/${item.id}`} aria-label={t('types.card.explore_aria', { title })}>
+            <Link className="saf-type-card reveal" style={{ '--reveal-index': i }} key={item.id} to={`/safaris/types/${item.id}`} aria-label={t('types.card.explore_aria', { title })}>
               <div className="saf-type-card__media">
                 <img src={item.image} alt={item.alt} loading="lazy" />
               </div>

--- a/src/components/safaris/SafariWildlife.jsx
+++ b/src/components/safaris/SafariWildlife.jsx
@@ -4,23 +4,24 @@ import { WILDLIFE_CATEGORIES, safariImg } from '../../data/safarisPageContent.js
 export default function SafariWildlife() {
   const { t } = useTranslation('safaris');
   return (
-    <section className="wildlife reveal" id="wildlife">
+    <section className="wildlife" id="wildlife">
       <header className="wildlife__head">
-        <span className="section-eyebrow">{t('wildlife.eyebrow')}</span>
-        <h2 className="section-title">{t('wildlife.title')}</h2>
-        <p className="section-lead">{t('wildlife.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('wildlife.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('wildlife.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('wildlife.lead')}</p>
       </header>
 
       {WILDLIFE_CATEGORIES.map((category) => (
         <div className="wildlife__cat" key={category.rowMod}>
-          <h3 className="wildlife__cat-title">
+          <h3 className="wildlife__cat-title reveal" style={{ '--reveal-index': 0 }}>
             <span>{t(`wildlife.categories.${category.rowMod}.title`, category.title)}</span>
             <em>{t(`wildlife.categories.${category.rowMod}.sub`, category.sub)}</em>
           </h3>
           <div className={`wildlife__row wildlife__row--${category.rowMod}`}>
-            {category.tiles.map((tile) => (
+            {category.tiles.map((tile, j) => (
               <figure
-                className={`wildlife__tile${tile.mod ? ` wildlife__tile--${tile.mod}` : ''}`}
+                className={`wildlife__tile reveal${tile.mod ? ` wildlife__tile--${tile.mod}` : ''}`}
+                style={{ '--reveal-index': j }}
                 key={tile.src}
               >
                 <img src={safariImg(tile.src)} alt={t(`wildlife.categories.${category.rowMod}.tiles.${tile.src}.alt`, tile.alt)} loading="lazy" />

--- a/src/components/transfers/TransfersCta.jsx
+++ b/src/components/transfers/TransfersCta.jsx
@@ -17,14 +17,14 @@ export default function TransfersCta() {
   return (
     <section className="tr-cta">
       <div className="tr-cta__bg">
-        <img src={TRANSFERS_CTA_IMAGE} alt="" loading="lazy" />
+        <img className="dp-drift" src={TRANSFERS_CTA_IMAGE} alt="" loading="lazy" />
         <div className="tr-cta__overlay" />
       </div>
       <div className="tr-cta__inner">
-        <span className="section-eyebrow">{t('cta.eyebrow')}</span>
-        <h2>{t('cta.title')}</h2>
-        <p>{t('cta.text')}</p>
-        <div className="tr-cta__btns">
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('cta.eyebrow')}</span>
+        <h2 className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.title')}</h2>
+        <p className="reveal" style={{ '--reveal-index': 2 }}>{t('cta.text')}</p>
+        <div className="tr-cta__btns reveal" style={{ '--reveal-index': 3 }}>
           <a
             className="btn btn--lg btn--accent"
             href={CONTACT_INFO.whatsappUrl}
@@ -37,7 +37,7 @@ export default function TransfersCta() {
             {t('cta.booking_form')}
           </Link>
         </div>
-        <div className="tr-cta__contacts">
+        <div className="tr-cta__contacts reveal" style={{ '--reveal-index': 4 }}>
           <a href={`tel:${CONTACT_INFO.phones[0]}`}>
             <PhoneIcon />
             +255 768 779 517

--- a/src/components/transfers/TransfersFaq.jsx
+++ b/src/components/transfers/TransfersFaq.jsx
@@ -7,12 +7,12 @@ export default function TransfersFaq() {
   return (
     <section className="tr-faq">
       <header className="tr-faq__head">
-        <span className="section-eyebrow">{t('faq.eyebrow')}</span>
-        <h2 className="section-title">{t('faq.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('faq.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('faq.title')}</h2>
       </header>
       <div className="tr-faq__list">
-        {Array.isArray(faqs) && faqs.map((faq) => (
-          <details className="tr-faq__item" key={faq.q} {...(faq.open ? { open: true } : {})}>
+        {Array.isArray(faqs) && faqs.map((faq, i) => (
+          <details className="tr-faq__item reveal" key={faq.q} style={{ '--reveal-index': i }} {...(faq.open ? { open: true } : {})}>
             <summary>{faq.q}</summary>
             <div className="tr-faq__body">{faq.a}</div>
           </details>

--- a/src/components/transfers/TransfersFleet.jsx
+++ b/src/components/transfers/TransfersFleet.jsx
@@ -69,13 +69,13 @@ export default function TransfersFleet() {
   return (
     <section className="tr-fleet">
       <header className="tr-fleet__head">
-        <span className="section-eyebrow">{t('fleet.eyebrow')}</span>
-        <h2 className="section-title">{t('fleet.title')}</h2>
-        <p className="section-lead">{t('fleet.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('fleet.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('fleet.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('fleet.lead')}</p>
       </header>
       <div className="tr-fleet__grid">
-        {Array.isArray(fleet) && fleet.map((v) => (
-          <article className="tr-vehicle" key={v.type}>
+        {Array.isArray(fleet) && fleet.map((v, i) => (
+          <article className="tr-vehicle reveal" key={v.type} style={{ '--reveal-index': i }}>
             <span className="tr-vehicle__icon">{FLEET_ICONS[v.key]}</span>
             <h3 className="tr-vehicle__type">{v.type}</h3>
             <span className="tr-vehicle__cap">{v.capacity}</span>

--- a/src/components/transfers/TransfersHow.jsx
+++ b/src/components/transfers/TransfersHow.jsx
@@ -7,12 +7,12 @@ export default function TransfersHow() {
   return (
     <section className="tr-how">
       <header className="tr-how__head">
-        <span className="section-eyebrow">{t('how.eyebrow')}</span>
-        <h2 className="section-title">{t('how.title')}</h2>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('how.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('how.title')}</h2>
       </header>
       <div className="tr-how__steps">
-        {Array.isArray(steps) && steps.map((item) => (
-          <article className="tr-step" key={item.step}>
+        {Array.isArray(steps) && steps.map((item, i) => (
+          <article className="tr-step reveal" key={item.step} style={{ '--reveal-index': i }}>
             <span className="tr-step__num">{item.step}</span>
             <h3>{item.title}</h3>
             <p>{item.text}</p>

--- a/src/components/transfers/TransfersIncluded.jsx
+++ b/src/components/transfers/TransfersIncluded.jsx
@@ -8,16 +8,16 @@ export default function TransfersIncluded() {
     <section className="tr-included">
       <div className="tr-included__wrap">
         <div className="tr-included__copy">
-          <span className="section-eyebrow">{t('included.eyebrow')}</span>
-          <h2 className="section-title">{t('included.title')}</h2>
-          <p className="section-lead">{t('included.lead')}</p>
-          <a className="btn btn--accent btn--lg" href="#transfer-types">
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('included.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('included.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('included.lead')}</p>
+          <a className="btn btn--accent btn--lg reveal" style={{ '--reveal-index': 3 }} href="#transfer-types">
             {t('included.choose_route')}
           </a>
         </div>
         <ul className="tr-included__list">
-          {Array.isArray(included) && included.map((item) => (
-            <li key={item}>
+          {Array.isArray(included) && included.map((item, i) => (
+            <li className="reveal" key={item} style={{ '--reveal-index': i }}>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
               {item}
             </li>

--- a/src/components/transfers/TransfersTypes.jsx
+++ b/src/components/transfers/TransfersTypes.jsx
@@ -51,13 +51,13 @@ export default function TransfersTypes() {
   return (
     <section className="tr-types" id="transfer-types">
       <header className="tr-types__head">
-        <span className="section-eyebrow">{t('types.eyebrow')}</span>
-        <h2 className="section-title">{t('types.title')}</h2>
-        <p className="section-lead">{t('types.lead')}</p>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('types.eyebrow')}</span>
+        <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('types.title')}</h2>
+        <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('types.lead')}</p>
       </header>
       <div className="tr-types__grid">
-        {transferProducts.map((type) => (
-          <article className={`tr-card ${type.featured ? 'tr-card--feature' : ''}`} key={type.slug} id={type.slug}>
+        {transferProducts.map((type, i) => (
+          <article className={`tr-card reveal ${type.featured ? 'tr-card--feature' : ''}`} key={type.slug} id={type.slug} style={{ '--reveal-index': i }}>
             <div className="tr-card__icon">{TRANSFER_ICONS[type.icon]}</div>
             <div className="tr-card__body">
               <span className="tr-card__sub">{type.duration}</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import { applyTheme, readStoredTheme } from './utils/theme.js';
 import './i18n/index.js';
 import './styles/tokens.css';
 import './styles/site-shell.css';
+import './styles/reveal.css';
 import './styles/components/lang-switcher.css';
 import './styles/components/theme-toggle.css';
 

--- a/src/pages/Booking.jsx
+++ b/src/pages/Booking.jsx
@@ -19,6 +19,7 @@ import {
 import { TRANSFER_SERVICE_TIERS } from '../data/transferProducts.js';
 import { useBookingProducts } from '../hooks/useBookingProducts.js';
 import { useFloatingBookingSummary } from '../hooks/useFloatingBookingSummary.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import usePageMeta from '../hooks/usePageMeta.js';
 import { buildPlannerHandoff, clearPlannerHandoff, isPlannerHandoffMessage, readPlannerHandoff } from '../utils/plannerHandoff.js';
 import { useCurrency } from '../context/useCurrency.js';
@@ -27,7 +28,7 @@ import '../styles/excursions.css';
 import '../styles/booking.css';
 
 export default function Booking() {
-  const { t, i18n } = useTranslation('booking');
+  const { t, i18n, ready } = useTranslation('booking');
   const { format } = useCurrency();
   const [searchParams] = useSearchParams();
   const location = useLocation();
@@ -38,10 +39,12 @@ export default function Booking() {
   );
   const [status, setStatus] = useState('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const pageRef = useRef(null);
   const layoutRef = useRef(null);
   const summarySlotRef = useRef(null);
   const summaryRef = useRef(null);
   const prefillKeyRef = useRef(/** @type {string | null} */ (null));
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? i18n.resolvedLanguage : 'loading');
   // Only the fields that change the summary's rendered height/content drive a
   // re-measure — keying on the whole `form` would re-subscribe the scroll/resize
   // listeners on every keystroke.
@@ -275,15 +278,15 @@ export default function Booking() {
   };
 
   return (
-    <main className="booking-page">
+    <main className="booking-page" ref={pageRef}>
       <BookingHero />
       <BookingFlow />
 
       <section className="booking-shell" id="booking-form">
         <div className="booking-intro">
-          <span className="section-eyebrow">{t('intro.eyebrow', { defaultValue: 'Tell us what to build' })}</span>
-          <h2 className="section-title">{t('intro.title', { defaultValue: 'Request availability, quote, and payment link.' })}</h2>
-          <p className="section-lead">{t('intro.lead', { defaultValue: 'We do not collect card details on this page. If you choose online payment, we will send a secure payment link after the route and price are confirmed.' })}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('intro.eyebrow', { defaultValue: 'Tell us what to build' })}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('intro.title', { defaultValue: 'Request availability, quote, and payment link.' })}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('intro.lead', { defaultValue: 'We do not collect card details on this page. If you choose online payment, we will send a secure payment link after the route and price are confirmed.' })}</p>
         </div>
 
         <div className="booking-layout" ref={layoutRef}>

--- a/src/pages/ExcursionCombinationDetail.jsx
+++ b/src/pages/ExcursionCombinationDetail.jsx
@@ -1,6 +1,8 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import { EXCURSIONS } from '../data/excursionsData.js';
 import { EXCURSION_COMBINATIONS } from '../data/excursionCombinations.js';
 import usePageMeta, { clampDescription } from '../hooks/usePageMeta.js';
@@ -13,9 +15,14 @@ import '../styles/excursions.css';
 const fallbackImage = '/assets/images/excursions/safari-blue-sandbank.webp';
 
 export default function ExcursionCombinationDetail() {
-  const { t, ready } = useTranslation('excursions');
+  const { t, i18n, ready } = useTranslation('excursions');
   const { id } = useParams();
   const { format } = useCurrency();
+  const pageRef = useRef(null);
+  // Key on the route id too: detail routes reuse one component instance across
+  // :id changes, so without it the observer wouldn't re-scan the new combo's
+  // reveal elements and they'd stay hidden.
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? `${i18n.resolvedLanguage}-${id}` : 'loading');
   const combo = EXCURSION_COMBINATIONS.find((item) => item.id === id);
   const excursions = /** @type {Array<(typeof EXCURSIONS)[number]>} */ (
     combo
@@ -65,8 +72,8 @@ export default function ExcursionCombinationDetail() {
   }
 
   return (
-    <main className="excursions-page exc-detail">
-      <nav className="exc-detail__crumbs" aria-label={t('combination.breadcrumb_aria')}>
+    <main className="excursions-page exc-detail" ref={pageRef}>
+      <nav className="exc-detail__crumbs reveal" aria-label={t('combination.breadcrumb_aria')}>
         <Link to="/">{t('combination.breadcrumb_home')}</Link>
         <span aria-hidden="true">→</span>
         <Link to="/excursions">{t('combination.breadcrumb_excursions')}</Link>
@@ -75,32 +82,32 @@ export default function ExcursionCombinationDetail() {
       </nav>
 
       <article id={combo.id} className="exc-block exc-block--detail">
-        <div className="exc-block__img">
+        <div className="exc-block__img reveal">
           <ResponsiveImage src={heroImage} alt="" />
           <span className="exc-block__cat">{t('combination.category')}</span>
         </div>
         <div className="exc-block__body">
-          <span className="exc-block__eyebrow">{combo.combo.join(' + ')}</span>
-          <h1 className="exc-block__title">{combo.title}</h1>
-          <p className="exc-block__desc">{combo.desc}</p>
+          <span className="exc-block__eyebrow reveal" style={{ '--reveal-index': 0 }}>{combo.combo.join(' + ')}</span>
+          <h1 className="exc-block__title reveal" style={{ '--reveal-index': 1 }}>{combo.title}</h1>
+          <p className="exc-block__desc reveal" style={{ '--reveal-index': 2 }}>{combo.desc}</p>
           <dl className="exc-block__facts">
-            <div><dt>{t('combination.facts.length')}</dt><dd>{combo.length}<small>{t('combination.facts.length_sub')}</small></dd></div>
-            <div><dt>{t('combination.facts.stops')}</dt><dd>{combo.combo.length}<small>{combo.combo.join(' + ')}</small></dd></div>
-            <div><dt>{t('combination.facts.style')}</dt><dd>{t('combination.facts.style_value')}<small>{t('combination.facts.style_sub')}</small></dd></div>
-            <div><dt>{t('combination.facts.quote')}</dt><dd>24h<small>{t('combination.facts.quote_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 0 }}><dt>{t('combination.facts.length')}</dt><dd>{combo.length}<small>{t('combination.facts.length_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 1 }}><dt>{t('combination.facts.stops')}</dt><dd>{combo.combo.length}<small>{combo.combo.join(' + ')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 2 }}><dt>{t('combination.facts.style')}</dt><dd>{t('combination.facts.style_value')}<small>{t('combination.facts.style_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 3 }}><dt>{t('combination.facts.quote')}</dt><dd>24h<small>{t('combination.facts.quote_sub')}</small></dd></div>
           </dl>
           <div className="exc-block__cols">
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
               <h4>{t('combination.included_experiences')}</h4>
               <ul>{combo.combo.map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
               <h4>{t('combination.ideal_for')}</h4>
               <ul>{combo.idealFor.map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
           </div>
           <div className="exc-block__cols">
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
               <h4>{t('combination.open_each_stop')}</h4>
               <ul>
                 {excursions.map((item) => (
@@ -108,7 +115,7 @@ export default function ExcursionCombinationDetail() {
                 ))}
               </ul>
             </div>
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
               <h4>{t('combination.planning_note')}</h4>
               <ul>
                 {arrayFromTranslation(t('combination.planning_note_items', { returnObjects: true })).map((note) => (
@@ -119,26 +126,26 @@ export default function ExcursionCombinationDetail() {
           </div>
           <div className="exc-block__actions">
             {minPrice > 0 ? (
-              <span className="exc-block__price">{format(minPrice)}<small>{t('combination.price_estimated')}</small></span>
+              <span className="exc-block__price reveal" style={{ '--reveal-index': 0 }}>{format(minPrice)}<small>{t('combination.price_estimated')}</small></span>
             ) : (
-              <span className="exc-block__price-note">{t('combination.price_on_request')}</span>
+              <span className="exc-block__price-note reveal" style={{ '--reveal-index': 0 }}>{t('combination.price_on_request')}</span>
             )}
-            <span className="exc-block__price-note">{t('combination.price_note')}</span>
-            <Link className="btn" to={`/booking?type=custom&title=${encodeURIComponent(combo.title)}`}>{t('combination.book_this')}</Link>
-            <Link className="btn btn--ghost-dark" to="/excursions">{t('combination.all_excursions')}</Link>
+            <span className="exc-block__price-note reveal" style={{ '--reveal-index': 1 }}>{t('combination.price_note')}</span>
+            <Link className="btn reveal" style={{ '--reveal-index': 2 }} to={`/booking?type=custom&title=${encodeURIComponent(combo.title)}`}>{t('combination.book_this')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 3 }} to="/excursions">{t('combination.all_excursions')}</Link>
           </div>
         </div>
       </article>
 
       <section className="exc-day" id="sequence">
         <div className="exc-day__head">
-          <span className="section-eyebrow">{t('combination.sequence.eyebrow')}</span>
-          <h2 className="section-title">{t('combination.sequence.title')}</h2>
-          <p className="section-lead">{t('combination.sequence.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('combination.sequence.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('combination.sequence.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('combination.sequence.lead')}</p>
         </div>
         <div className="exc-day__timeline">
-          {combo.rhythm.map(([time, title, text]) => (
-            <div className="exc-day__row" key={`${time}-${title}`}>
+          {combo.rhythm.map(([time, title, text], i) => (
+            <div className="exc-day__row reveal" style={{ '--reveal-index': i }} key={`${time}-${title}`}>
               <div className="exc-day__time">{time}</div>
               <div className="exc-day__what"><strong>{title}</strong><p>{text}</p></div>
             </div>
@@ -147,11 +154,11 @@ export default function ExcursionCombinationDetail() {
       </section>
 
       <section className="exc-cta">
-        <div className="exc-cta__bg"><ResponsiveImage src={heroImage} alt="" /></div>
+        <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src={heroImage} alt="" /></div>
         <div className="exc-cta__inner">
-          <h2>{t('combination.cta.title', { title: combo.title })}</h2>
-          <p>{t('combination.cta.text')}</p>
-          <div className="exc-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('combination.cta.title', { title: combo.title })}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('combination.cta.text')}</p>
+          <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg" to={`/booking?type=custom&title=${encodeURIComponent(combo.title)}`}>{t('cta.get_in_touch')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('combination.cta.plan_ai')}</Link>
           </div>

--- a/src/pages/ExcursionDetail.jsx
+++ b/src/pages/ExcursionDetail.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
@@ -6,6 +7,7 @@ import usePageMeta, { clampDescription } from '../hooks/usePageMeta.js';
 import { touristTripJsonLd } from '../utils/productJsonLd.js';
 import { useCurrency } from '../context/useCurrency.js';
 import { arrayFromTranslation } from '../utils/translationValues.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
 
@@ -20,10 +22,16 @@ function formatTierName(key) {
 }
 
 export default function ExcursionDetail() {
-  const { t, ready } = useTranslation('excursions');
+  const { t, i18n, ready } = useTranslation('excursions');
   const { id } = useParams();
   const { format } = useCurrency();
+  const pageRef = useRef(null);
   const excursion = EXCURSIONS.find((item) => item.id === id);
+
+  // Key on the route id too: detail routes reuse one component instance across
+  // :id changes, so without it the observer wouldn't re-scan the new product's
+  // reveal elements and they'd stay hidden.
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? `${i18n.resolvedLanguage}-${id}` : 'loading');
 
   usePageMeta(
     excursion
@@ -70,8 +78,8 @@ export default function ExcursionDetail() {
   })) : [];
 
   return (
-    <main className="excursions-page exc-detail">
-      <nav className="exc-detail__crumbs" aria-label={t('detail.breadcrumb_aria')}>
+    <main className="excursions-page exc-detail" ref={pageRef}>
+      <nav className="exc-detail__crumbs reveal" aria-label={t('detail.breadcrumb_aria')}>
         <Link to="/">{t('detail.breadcrumb_home')}</Link>
         <span aria-hidden="true">→</span>
         <Link to="/excursions">{t('detail.breadcrumb_excursions')}</Link>
@@ -80,26 +88,26 @@ export default function ExcursionDetail() {
       </nav>
 
       <article id={e.id} data-cat={categoryToSlug(e.category)} className="exc-block exc-block--detail">
-        <div className="exc-block__img">
+        <div className="exc-block__img reveal">
           <ResponsiveImage src={e.image} alt={e.imageNeeded ? '' : e.alt || e.title} />
           <span className="exc-block__cat" data-cat={categoryToSlug(e.category)}>{e.category}</span>
           {e.season && <span className="exc-block__season">{t('detail.season_prefix')} · {e.season}</span>}
         </div>
         <div className="exc-block__body">
-          <span className="exc-block__eyebrow">{e.eyebrow}</span>
-          <h1 className="exc-block__title">{e.title}</h1>
-          <p className="exc-block__desc">{e.intro || e.description}</p>
+          <span className="exc-block__eyebrow reveal" style={{ '--reveal-index': 0 }}>{e.eyebrow}</span>
+          <h1 className="exc-block__title reveal" style={{ '--reveal-index': 1 }}>{e.title}</h1>
+          <p className="exc-block__desc reveal" style={{ '--reveal-index': 2 }}>{e.intro || e.description}</p>
           {e.facts && (
             <dl className="exc-block__facts">
-              {e.facts.map(([dt, dd, sub]) => (
-                <div key={dt}><dt>{dt}</dt><dd>{dd}<small>{sub}</small></dd></div>
+              {e.facts.map(([dt, dd, sub], i) => (
+                <div className="reveal" style={{ '--reveal-index': i }} key={dt}><dt>{dt}</dt><dd>{dd}<small>{sub}</small></dd></div>
               ))}
             </dl>
           )}
           {e.cols && (
             <div className="exc-block__cols">
-              {e.cols.map((col) => (
-                <div className="exc-block__col" key={col.h}>
+              {e.cols.map((col, i) => (
+                <div className="exc-block__col reveal" style={{ '--reveal-index': i }} key={col.h}>
                   <h4>{col.h}</h4>
                   <ul>{col.items.map((it) => <li key={it}>{it}</li>)}</ul>
                 </div>
@@ -108,7 +116,7 @@ export default function ExcursionDetail() {
           )}
           {e.highlights && !e.cols && (
             <div className="exc-block__cols">
-              <div className="exc-block__col">
+              <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
                 <h4>{t('detail.highlights')}</h4>
                 <ul>{e.highlights.map((it) => <li key={it}>{it}</li>)}</ul>
               </div>
@@ -116,7 +124,7 @@ export default function ExcursionDetail() {
           )}
           {pricingTiers.length > 0 && (
             <div className="exc-block__cols">
-              <div className="exc-block__col">
+              <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
                 <h4>{t('detail.experience_pricing')}</h4>
                 <ul>{pricingTiers.map((tier) => <li key={tier.label}>{tier.label}: {t('detail.from')} {format(tier.price)}</li>)}</ul>
               </div>
@@ -124,13 +132,13 @@ export default function ExcursionDetail() {
           )}
           <div className="exc-block__actions">
             {typeof e.price === 'number' ? (
-              <span className="exc-block__price">{format(e.price)}<small>{e.priceSub || t('detail.per_person')}</small></span>
+              <span className="exc-block__price reveal" style={{ '--reveal-index': 0 }}>{format(e.price)}<small>{e.priceSub || t('detail.per_person')}</small></span>
             ) : (
-              <span className="exc-block__price-note">{t('detail.price_on_request')}</span>
+              <span className="exc-block__price-note reveal" style={{ '--reveal-index': 0 }}>{t('detail.price_on_request')}</span>
             )}
-            {e.priceNote && <span className="exc-block__price-note">{e.priceNote}</span>}
-            <Link className="btn" to={`/booking?type=excursion&item=${encodeURIComponent(e.id)}`}>{t('detail.book_this')}</Link>
-            <Link className="btn btn--ghost-dark" to="/excursions">{t('detail.all_excursions')}</Link>
+            {e.priceNote && <span className="exc-block__price-note reveal" style={{ '--reveal-index': 1 }}>{e.priceNote}</span>}
+            <Link className="btn reveal" style={{ '--reveal-index': 2 }} to={`/booking?type=excursion&item=${encodeURIComponent(e.id)}`}>{t('detail.book_this')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 3 }} to="/excursions">{t('detail.all_excursions')}</Link>
           </div>
         </div>
       </article>
@@ -138,13 +146,13 @@ export default function ExcursionDetail() {
       {e.timeline && e.timeline.length > 0 && (
         <section className="exc-day" id="day">
           <div className="exc-day__head">
-            <span className="section-eyebrow">{t('detail.timeline.eyebrow')}</span>
-            <h2 className="section-title">{t('detail.timeline.title')}</h2>
-            <p className="section-lead">{t('detail.timeline.lead')}</p>
+            <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('detail.timeline.eyebrow')}</span>
+            <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('detail.timeline.title')}</h2>
+            <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('detail.timeline.lead')}</p>
           </div>
           <div className="exc-day__timeline">
-            {e.timeline.map(([t, h, p]) => (
-              <div className="exc-day__row" key={t}>
+            {e.timeline.map(([t, h, p], i) => (
+              <div className="exc-day__row reveal" key={t} style={{ '--reveal-index': i }}>
                 <div className="exc-day__time">{t}</div>
                 <div className="exc-day__what"><strong>{h}</strong><p>{p}</p></div>
               </div>
@@ -155,8 +163,8 @@ export default function ExcursionDetail() {
 
       <section className="exc-prac">
         <div className="exc-prac__grid">
-          {PRACTICAL_COLUMNS.map((key) => (
-            <div className="exc-prac__col" key={key}>
+          {PRACTICAL_COLUMNS.map((key, i) => (
+            <div className="exc-prac__col reveal" key={key} style={{ '--reveal-index': i }}>
               <h4>{t(`detail.practical.${key}.heading`)}</h4>
               <ul>
                 {arrayFromTranslation(t(`detail.practical.${key}.items`, { returnObjects: true })).map((it) => (
@@ -172,11 +180,11 @@ export default function ExcursionDetail() {
       </section>
 
       <section className="exc-cta">
-        <div className="exc-cta__bg"><ResponsiveImage src={e.imageNeeded ? '/assets/images/excursions/safari-blue-sandbank.webp' : e.image} alt="" /></div>
+        <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src={e.imageNeeded ? '/assets/images/excursions/safari-blue-sandbank.webp' : e.image} alt="" /></div>
         <div className="exc-cta__inner">
-          <h2>{t('detail.cta.title', { title: e.title })}</h2>
-          <p>{t('detail.cta.text')}</p>
-          <div className="exc-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('detail.cta.title', { title: e.title })}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('detail.cta.text')}</p>
+          <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg" to={`/booking?type=excursion&item=${encodeURIComponent(e.id)}`}>{t('cta.get_in_touch')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
           </div>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,8 +1,13 @@
+import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import usePageMeta from '../hooks/usePageMeta.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 
 export default function NotFound() {
+  const pageRef = useRef(null);
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', 1);
+
   usePageMeta({
     title: 'Page Not Found · Destination Paradise',
     description: "That page isn't on the map. Head back to the homepage and pick a route through Zanzibar and Tanzania.",
@@ -11,6 +16,7 @@ export default function NotFound() {
 
   return (
     <main
+      ref={pageRef}
       style={{
         minHeight: '100vh',
         display: 'flex',
@@ -21,12 +27,12 @@ export default function NotFound() {
       }}
     >
       <div style={{ maxWidth: 640, textAlign: 'center' }}>
-        <span className="section-eyebrow">404</span>
-        <h1 className="section-title" style={{ marginTop: '1rem' }}>Lost at sea</h1>
-        <p className="section-lead" style={{ marginBottom: '2rem' }}>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>404</span>
+        <h1 className="section-title reveal" style={{ marginTop: '1rem', '--reveal-index': 1 }}>Lost at sea</h1>
+        <p className="section-lead reveal" style={{ marginBottom: '2rem', '--reveal-index': 2 }}>
           That page isn&apos;t on the map. Head back to the homepage and pick a route.
         </p>
-        <Link className="btn" to="/">← Back to home</Link>
+        <Link className="btn reveal" to="/" style={{ '--reveal-index': 3 }}>← Back to home</Link>
       </div>
     </main>
   );

--- a/src/pages/PackageDetail.jsx
+++ b/src/pages/PackageDetail.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
@@ -6,17 +6,24 @@ import { buildLocalizedPackages } from '../data/packagePresentation.js';
 import usePageMeta, { clampDescription } from '../hooks/usePageMeta.js';
 import { touristTripJsonLd } from '../utils/productJsonLd.js';
 import { useCurrency } from '../context/useCurrency.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
 import '../styles/safaris.css';
 
 export default function PackageDetail() {
-  const { t, ready } = useTranslation('packages');
+  const { t, i18n, ready } = useTranslation('packages');
   const { format } = useCurrency();
   const priceText = (pricing) => (pricing.to ? `${format(pricing.from)} – ${format(pricing.to)}` : format(pricing.from));
   const { id } = useParams();
+  const pageRef = useRef(null);
   const packages = useMemo(() => buildLocalizedPackages(t), [t]);
   const pkg = packages.find((item) => item.id === id);
+
+  // Key on the route id too: detail routes reuse one component instance across
+  // :id changes, so without it the observer wouldn't re-scan the new package's
+  // reveal elements and they'd stay hidden.
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? `${i18n.resolvedLanguage}-${id}` : 'loading');
 
   usePageMeta(
     pkg
@@ -41,13 +48,13 @@ export default function PackageDetail() {
 
   if (!pkg) {
     return (
-      <main className="excursions-page">
+      <main className="excursions-page" ref={pageRef}>
         <section className="exc-day" style={{ textAlign: 'center', minHeight: '60vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <div>
-            <span className="section-eyebrow">{t('detail.not_found_eyebrow')}</span>
-            <h1 className="section-title">{t('detail.not_found_title')}</h1>
-            <p className="section-lead">{t('detail.not_found_text')}</p>
-            <Link className="btn btn--ghost-dark" to="/packages" style={{ marginTop: '1.5rem' }}>{t('detail.back_to_packages')}</Link>
+            <span className="section-eyebrow reveal">{t('detail.not_found_eyebrow')}</span>
+            <h1 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('detail.not_found_title')}</h1>
+            <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('detail.not_found_text')}</p>
+            <Link className="btn btn--ghost-dark reveal" to="/packages" style={{ marginTop: '1.5rem', '--reveal-index': 3 }}>{t('detail.back_to_packages')}</Link>
           </div>
         </section>
       </main>
@@ -65,8 +72,8 @@ export default function PackageDetail() {
   ].filter(Boolean);
 
   return (
-    <main className="excursions-page exc-detail package-detail">
-      <nav className="exc-detail__crumbs" aria-label={t('detail.breadcrumb_aria')}>
+    <main className="excursions-page exc-detail package-detail" ref={pageRef}>
+      <nav className="exc-detail__crumbs reveal" aria-label={t('detail.breadcrumb_aria')}>
         <Link to="/">{t('detail.breadcrumb_home')}</Link>
         <span aria-hidden="true">→</span>
         <Link to="/packages">{t('detail.breadcrumb_packages')}</Link>
@@ -75,26 +82,26 @@ export default function PackageDetail() {
       </nav>
 
       <article id={pkg.id} className="exc-block exc-block--detail">
-        <div className="exc-block__img">
+        <div className="exc-block__img reveal">
           <ResponsiveImage src={pkg.image} alt="" />
           <span className="exc-block__cat">{pkg.category}</span>
         </div>
         <div className="exc-block__body">
-          <span className="exc-block__eyebrow">{pkg.duration}</span>
-          <h1 className="exc-block__title">{pkg.title}</h1>
-          <p className="exc-block__desc">{pkg.description}</p>
+          <span className="exc-block__eyebrow reveal" style={{ '--reveal-index': 0 }}>{pkg.duration}</span>
+          <h1 className="exc-block__title reveal" style={{ '--reveal-index': 1 }}>{pkg.title}</h1>
+          <p className="exc-block__desc reveal" style={{ '--reveal-index': 2 }}>{pkg.description}</p>
           <dl className="exc-block__facts">
-            <div><dt>{t('detail.facts.duration')}</dt><dd>{pkg.duration}<small>{t('detail.facts.flexible_pacing')}</small></dd></div>
-            <div><dt>{t('detail.facts.category')}</dt><dd>{pkg.category}<small>{t('detail.facts.package_style')}</small></dd></div>
-            <div><dt>{t('detail.facts.price')}</dt><dd>{priceText(pkg.pricing)}<small>{pkg.priceSub}</small></dd></div>
-            <div><dt>{t('detail.facts.quote')}</dt><dd>24h<small>{t('detail.facts.custom_proposal')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 0 }}><dt>{t('detail.facts.duration')}</dt><dd>{pkg.duration}<small>{t('detail.facts.flexible_pacing')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 1 }}><dt>{t('detail.facts.category')}</dt><dd>{pkg.category}<small>{t('detail.facts.package_style')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 2 }}><dt>{t('detail.facts.price')}</dt><dd>{priceText(pkg.pricing)}<small>{pkg.priceSub}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 3 }}><dt>{t('detail.facts.quote')}</dt><dd>24h<small>{t('detail.facts.custom_proposal')}</small></dd></div>
           </dl>
           <div className="exc-block__cols">
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
               <h4>{t('detail.included')}</h4>
               <ul>{pkg.includes.map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
               <h4>{audience.length ? t('detail.ideal_for') : t('detail.route_notes')}</h4>
               <ul>{(audience.length ? audience : routeItems).map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
@@ -102,25 +109,25 @@ export default function PackageDetail() {
           {(pkg.priceTiers || routeItems.length > 0 || contextItems.length > 0 || upsells.length > 0) && (
             <div className="exc-block__cols">
               {pkg.priceTiers && (
-                <div className="exc-block__col">
+                <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
                   <h4>{t('detail.starting_prices')}</h4>
                   <ul>{pkg.priceTiers.map((tier) => <li key={tier.label}>{tier.label}: {format(tier.price)}{tier.suffix || ''}</li>)}</ul>
                 </div>
               )}
               {routeItems.length > 0 && audience.length > 0 && (
-                <div className="exc-block__col">
+                <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
                   <h4>{pkg.destinations ? t('detail.destination_options') : t('detail.route')}</h4>
                   <ul>{routeItems.map((item) => <li key={item}>{item}</li>)}</ul>
                 </div>
               )}
               {contextItems.length > 0 && (
-                <div className="exc-block__col">
+                <div className="exc-block__col reveal" style={{ '--reveal-index': 2 }}>
                   <h4>{t('detail.planning_notes')}</h4>
                   <ul>{contextItems.map((item) => <li key={item}>{item}</li>)}</ul>
                 </div>
               )}
               {upsells.length > 0 && (
-                <div className="exc-block__col">
+                <div className="exc-block__col reveal" style={{ '--reveal-index': 3 }}>
                   <h4>{t('detail.optional_upgrades')}</h4>
                   <ul>{upsells.map((item) => <li key={item}>{item}</li>)}</ul>
                 </div>
@@ -128,20 +135,20 @@ export default function PackageDetail() {
             </div>
           )}
           <div className="exc-block__actions">
-            <span className="exc-block__price">{priceText(pkg.pricing)}<small>{pkg.priceSub}</small></span>
-            <span className="exc-block__price-note">{t('detail.price_note')}</span>
-            <Link className="btn" to={`/booking?type=package&item=${encodeURIComponent(pkg.slug)}`}>{t('detail.build_package')}</Link>
-            <Link className="btn btn--ghost-dark" to="/packages">{t('detail.all_packages')}</Link>
+            <span className="exc-block__price reveal" style={{ '--reveal-index': 0 }}>{priceText(pkg.pricing)}<small>{pkg.priceSub}</small></span>
+            <span className="exc-block__price-note reveal" style={{ '--reveal-index': 1 }}>{t('detail.price_note')}</span>
+            <Link className="btn reveal" style={{ '--reveal-index': 2 }} to={`/booking?type=package&item=${encodeURIComponent(pkg.slug)}`}>{t('detail.build_package')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 3 }} to="/packages">{t('detail.all_packages')}</Link>
           </div>
         </div>
       </article>
 
       <section className="exc-cta">
-        <div className="exc-cta__bg"><ResponsiveImage src={pkg.image} alt="" /></div>
+        <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src={pkg.image} alt="" /></div>
         <div className="exc-cta__inner">
-          <h2>{t('detail.cta.title', { title: pkg.title })}</h2>
-          <p>{t('detail.cta.text')}</p>
-          <div className="exc-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('detail.cta.title', { title: pkg.title })}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('detail.cta.text')}</p>
+          <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg btn--accent" to={`/booking?type=package&item=${encodeURIComponent(pkg.slug)}`}>{t('cta.get_quote')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
           </div>

--- a/src/pages/Packages.jsx
+++ b/src/pages/Packages.jsx
@@ -109,9 +109,9 @@ export default function Packages() {
 
       <section className="exc-grid-wrap" id="packages">
         <header className="exc-list__head">
-          <span className="section-eyebrow">{t('grid.eyebrow')}</span>
-          <h2 className="section-title">{t('grid.title')}</h2>
-          <p className="section-lead">{t('grid.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('grid.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('grid.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('grid.lead')}</p>
         </header>
 
         <div className="exc-filter">
@@ -130,8 +130,8 @@ export default function Packages() {
         </div>
 
         <div className="exc-grid">
-          {visible.map((pkg) => (
-            <Link key={pkg.id} to={`/packages/${pkg.id}`} className="exc-card reveal" aria-label={t('grid.explore_aria', { title: pkg.title })}>
+          {visible.map((pkg, i) => (
+            <Link key={pkg.id} to={`/packages/${pkg.id}`} className="exc-card reveal" style={{ '--reveal-index': i }} aria-label={t('grid.explore_aria', { title: pkg.title })}>
               <div className="exc-card__img">
                 <img src={pkg.image} alt="" loading="lazy" />
                 <span className="exc-card__cat">{pkg.category}</span>
@@ -179,15 +179,15 @@ export default function Packages() {
         )}
       </section>
 
-      <section className="saf-compare reveal">
+      <section className="saf-compare">
         <header className="saf-compare__head">
-          <span className="section-eyebrow">{t('matches.eyebrow')}</span>
-          <h2 className="section-title">{t('matches.title')}</h2>
-          <p className="section-lead">{t('matches.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('matches.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('matches.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('matches.lead')}</p>
         </header>
         <div className="saf-compare__grid">
-          {packageMatches.map((item) => (
-            <Link className="saf-compare__card" key={item.slug} to={`/packages/${item.slug}`} aria-label={t('matches.explore_aria', { pick: item.pick })}>
+          {packageMatches.map((item, i) => (
+            <Link className="saf-compare__card reveal" style={{ '--reveal-index': i }} key={item.slug} to={`/packages/${item.slug}`} aria-label={t('matches.explore_aria', { pick: item.pick })}>
               <span>{item.label}</span>
               <h3>{item.pick}</h3>
               <p>{item.note}</p>
@@ -196,44 +196,44 @@ export default function Packages() {
         </div>
       </section>
 
-      <section className="included reveal">
+      <section className="included">
         <div className="included__wrap">
           <div className="included__copy">
-            <span className="section-eyebrow">{t('market.eyebrow')}</span>
-            <h2 className="section-title">{t('market.title')}</h2>
-            <p className="section-lead">{t('market.lead')}</p>
+            <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('market.eyebrow')}</span>
+            <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('market.title')}</h2>
+            <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('market.lead')}</p>
           </div>
           <ul className="included__list">
-            {marketCategories.map((item) => (
-              <li key={item}><span>✓</span> {item}</li>
+            {marketCategories.map((item, i) => (
+              <li className="reveal" style={{ '--reveal-index': i }} key={item}><span>✓</span> {item}</li>
             ))}
           </ul>
         </div>
       </section>
 
-      <section className="included reveal">
+      <section className="included">
         <div className="included__wrap">
           <div className="included__copy">
-            <span className="section-eyebrow">{t('included.eyebrow')}</span>
-            <h2 className="section-title">{t('included.title')}</h2>
-            <p className="section-lead">{t('included.lead')}</p>
+            <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('included.eyebrow')}</span>
+            <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('included.title')}</h2>
+            <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('included.lead')}</p>
           </div>
           <ul className="included__list">
-            {packageIncluded.map((item) => (
-              <li key={item}><span>✓</span> {item}</li>
+            {packageIncluded.map((item, i) => (
+              <li className="reveal" style={{ '--reveal-index': i }} key={item}><span>✓</span> {item}</li>
             ))}
           </ul>
         </div>
       </section>
 
-      <section className="saf-steps reveal">
+      <section className="saf-steps">
         <header className="saf-steps__head">
-          <span className="section-eyebrow">{t('steps.eyebrow')}</span>
-          <h2 className="section-title">{t('steps.title')}</h2>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('steps.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('steps.title')}</h2>
         </header>
         <div className="saf-steps__grid">
-          {packageSteps.map((item) => (
-            <article className="saf-step" key={item.step}>
+          {packageSteps.map((item, i) => (
+            <article className="saf-step reveal" style={{ '--reveal-index': i }} key={item.step}>
               <span>{item.step}</span>
               <h3>{item.title}</h3>
               <p>{item.text}</p>
@@ -243,11 +243,11 @@ export default function Packages() {
       </section>
 
       <section className="exc-cta">
-        <div className="exc-cta__bg"><ResponsiveImage src="/assets/images/excursions/prison-island-tortoise.webp" alt="" /></div>
+        <div className="exc-cta__bg"><ResponsiveImage className="dp-drift" src="/assets/images/excursions/prison-island-tortoise.webp" alt="" /></div>
         <div className="exc-cta__inner">
-          <h2>{t('cta.title')}</h2>
-          <p>{t('cta.text')}</p>
-          <div className="exc-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('cta.title')}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.text')}</p>
+          <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.get_quote')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
           </div>

--- a/src/pages/Policy.jsx
+++ b/src/pages/Policy.jsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { CONTACT_INFO } from '../constants/contactInfo.js';
 import { usePageMeta } from '../hooks/usePageMeta.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import { objectFromTranslation } from '../utils/translationValues.js';
 import '../styles/homepage.css';
 import '../styles/policy.css';
@@ -10,10 +11,10 @@ import '../styles/policy.css';
 function PolicySection({ title, items }) {
   return (
     <section className="policy-section">
-      <h2>{title}</h2>
+      <h2 className="reveal" style={{ '--reveal-index': 0 }}>{title}</h2>
       <ul>
-        {items.map((item) => (
-          <li key={item}>{item}</li>
+        {items.map((item, i) => (
+          <li className="reveal" style={{ '--reveal-index': i + 1 }} key={item}>{item}</li>
         ))}
       </ul>
     </section>
@@ -21,7 +22,13 @@ function PolicySection({ title, items }) {
 }
 
 export default function Policy({ section = 'privacy' }) {
-  const { t } = useTranslation('policy');
+  const { t, i18n, ready } = useTranslation('policy');
+  const pageRef = useRef(null);
+  useRevealOnScroll(
+    pageRef,
+    '.reveal:not(.is-visible)',
+    ready ? `${i18n.resolvedLanguage}-${section}` : 'loading',
+  );
   const policies = objectFromTranslation(t('policies', { returnObjects: true }), {});
   const policy = policies?.[section] || policies?.privacy;
   const actions = objectFromTranslation(t('contact.actions', { returnObjects: true }), {});
@@ -36,13 +43,13 @@ export default function Policy({ section = 'privacy' }) {
   usePageMeta(pageTitle, policy.intro);
 
   return (
-    <main className="policy-page">
+    <main className="policy-page" ref={pageRef}>
       <section className="policy-hero">
         <div className="policy-hero__inner">
-          <span className="section-eyebrow">{policy.eyebrow}</span>
-          <h1>{policy.title}</h1>
-          <p>{policy.intro}</p>
-          <dl className="policy-meta" aria-label={meta.aria_label}>
+          <span className="section-eyebrow reveal">{policy.eyebrow}</span>
+          <h1 className="reveal" style={{ '--reveal-index': 1 }}>{policy.title}</h1>
+          <p className="reveal" style={{ '--reveal-index': 2 }}>{policy.intro}</p>
+          <dl className="policy-meta reveal" style={{ '--reveal-index': 3 }} aria-label={meta.aria_label}>
             <div>
               <dt>{meta.last_updated}</dt>
               <dd>{meta.last_updated_value}</dd>
@@ -61,13 +68,13 @@ export default function Policy({ section = 'privacy' }) {
         ))}
 
         <section className="policy-section policy-section--contact">
-          <h2>{contact.title}</h2>
-          <p>
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{contact.title}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>
             {contact.copy_prefix}{' '}
             <a href={`mailto:${CONTACT_INFO.email}`}>{CONTACT_INFO.email}</a>
             {' '}{contact.copy_suffix}
           </p>
-          <div className="policy-actions">
+          <div className="policy-actions reveal" style={{ '--reveal-index': 2 }}>
             <a className="btn" href={`mailto:${CONTACT_INFO.email}`}>{actions.email}</a>
             <Link className="btn btn--ghost" to="/trip-planner">{actions.plan}</Link>
           </div>

--- a/src/pages/SafariDetail.jsx
+++ b/src/pages/SafariDetail.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
@@ -6,6 +7,7 @@ import usePageMeta, { clampDescription } from '../hooks/usePageMeta.js';
 import { touristTripJsonLd } from '../utils/productJsonLd.js';
 import { useCurrency } from '../context/useCurrency.js';
 import { arrayFromTranslation } from '../utils/translationValues.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
 import '../styles/safaris.css';
@@ -17,10 +19,16 @@ function cleanInclude(item = '') {
 }
 
 export default function SafariDetail() {
-  const { t, ready } = useTranslation('safaris');
+  const { t, i18n, ready } = useTranslation('safaris');
   const { id } = useParams();
   const { format } = useCurrency();
   const safari = ALL_SAFARI_PRODUCTS.find((item) => item.id === id);
+  const pageRef = useRef(null);
+
+  // Key on the route id too: detail routes reuse one component instance across
+  // :id changes, so without it the observer wouldn't re-scan the new product's
+  // reveal elements and they'd stay hidden.
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? `${i18n.resolvedLanguage}-${id}` : 'loading');
 
   usePageMeta(
     safari
@@ -64,8 +72,8 @@ export default function SafariDetail() {
   const upsells = safari.upsells || [];
 
   return (
-    <main className="safaris-page exc-detail saf-detail">
-      <nav className="exc-detail__crumbs" aria-label={t('detail.breadcrumb_aria')}>
+    <main className="safaris-page exc-detail saf-detail" ref={pageRef}>
+      <nav className="exc-detail__crumbs reveal" aria-label={t('detail.breadcrumb_aria')}>
         <Link to="/">{t('detail.breadcrumb_home')}</Link>
         <span aria-hidden="true">→</span>
         <Link to="/safaris">{t('detail.breadcrumb_safaris')}</Link>
@@ -74,20 +82,20 @@ export default function SafariDetail() {
       </nav>
 
       <article id={safari.id} className="exc-block exc-block--detail">
-        <div className="exc-block__img">
+        <div className="exc-block__img reveal">
           <ResponsiveImage src={safari.image} alt={safari.alt || safari.title} />
           <span className="exc-block__cat">{safari.category}</span>
           {safari.feature && <span className="exc-block__season">{t('detail.most_popular')}</span>}
         </div>
         <div className="exc-block__body">
-          <span className="exc-block__eyebrow">{safari.rib}</span>
-          <h1 className="exc-block__title">{safari.title}</h1>
-          <p className="exc-block__desc">{safari.intro}</p>
+          <span className="exc-block__eyebrow reveal" style={{ '--reveal-index': 0 }}>{safari.rib}</span>
+          <h1 className="exc-block__title reveal" style={{ '--reveal-index': 1 }}>{safari.title}</h1>
+          <p className="exc-block__desc reveal" style={{ '--reveal-index': 2 }}>{safari.intro}</p>
           <dl className="exc-block__facts">
-            <div><dt>{t('detail.facts.duration')}</dt><dd>{safari.duration}<small>{t('detail.facts.duration_sub')}</small></dd></div>
-            <div><dt>{t('detail.facts.starts_from')}</dt><dd>{safari.from}<small>{t('detail.facts.starts_from_sub')}</small></dd></div>
-            <div><dt>{t('detail.facts.style')}</dt><dd>{safari.positioning || safari.category}<small>{t('detail.facts.style_sub')}</small></dd></div>
-            <div>
+            <div className="reveal" style={{ '--reveal-index': 0 }}><dt>{t('detail.facts.duration')}</dt><dd>{safari.duration}<small>{t('detail.facts.duration_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 1 }}><dt>{t('detail.facts.starts_from')}</dt><dd>{safari.from}<small>{t('detail.facts.starts_from_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 2 }}><dt>{t('detail.facts.style')}</dt><dd>{safari.positioning || safari.category}<small>{t('detail.facts.style_sub')}</small></dd></div>
+            <div className="reveal" style={{ '--reveal-index': 3 }}>
               <dt>{t('detail.facts.price')}</dt>
               <dd>
                 {format(price ? price.lowSeason : safari.price)}
@@ -97,31 +105,31 @@ export default function SafariDetail() {
             </div>
           </dl>
           <div className="exc-block__cols">
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
               <h4>{safari.productType ? t('detail.highlights') : t('detail.included_in_route')}</h4>
               <ul>{included.map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
               <h4>{safari.idealFor?.length ? t('detail.ideal_for') : t('detail.typical_inclusions')}</h4>
               <ul>{(safari.idealFor?.length ? safari.idealFor : INCLUDED_LIST.slice(0, 4)).map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
           </div>
           {upsells.length > 0 && (
             <div className="exc-block__cols">
-              <div className="exc-block__col">
+              <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
                 <h4>{t('detail.optional_upgrades')}</h4>
                 <ul>{upsells.map((item) => <li key={item.name}>{item.name} · +{format(item.price)}</li>)}</ul>
               </div>
             </div>
           )}
           <div className="exc-block__actions">
-            <span className="exc-block__price">
+            <span className="exc-block__price reveal" style={{ '--reveal-index': 0 }}>
               {format(price ? price.lowSeason : safari.price)}
               <small>{price ? t('detail.price_low_peak', { price: format(price.peakSeason) }) : safari.priceSub}</small>
             </span>
-            <span className="exc-block__price-note">{t('detail.price_note')}</span>
-            <Link className="btn" to={`/booking?type=safari&item=${encodeURIComponent(safari.id)}`}>{t('detail.book_route')}</Link>
-            <Link className="btn btn--ghost-dark" to="/safaris">{t('detail.all_safaris')}</Link>
+            <span className="exc-block__price-note reveal" style={{ '--reveal-index': 1 }}>{t('detail.price_note')}</span>
+            <Link className="btn reveal" style={{ '--reveal-index': 2 }} to={`/booking?type=safari&item=${encodeURIComponent(safari.id)}`}>{t('detail.book_route')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 3 }} to="/safaris">{t('detail.all_safaris')}</Link>
           </div>
         </div>
       </article>
@@ -129,13 +137,13 @@ export default function SafariDetail() {
       {safari.days?.length > 0 && (
         <section className="exc-day" id="route">
           <div className="exc-day__head">
-            <span className="section-eyebrow">{t('detail.route.eyebrow')}</span>
-            <h2 className="section-title">{t('detail.route.title')}</h2>
-            <p className="section-lead">{t('detail.route.lead')}</p>
+            <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('detail.route.eyebrow')}</span>
+            <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('detail.route.title')}</h2>
+            <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('detail.route.lead')}</p>
           </div>
           <div className="exc-day__timeline">
-            {safari.days.map((day) => (
-              <div className="exc-day__row" key={day.d}>
+            {safari.days.map((day, i) => (
+              <div className="exc-day__row reveal" key={day.d} style={{ '--reveal-index': i }}>
                 <div className="exc-day__time">{day.d}</div>
                 <div className="exc-day__what"><strong>{day.h}</strong><p>{day.p}</p></div>
               </div>
@@ -146,8 +154,8 @@ export default function SafariDetail() {
 
       <section className="exc-prac">
         <div className="exc-prac__grid">
-          {PRACTICAL_COLUMNS.map((key) => (
-            <div className="exc-prac__col" key={key}>
+          {PRACTICAL_COLUMNS.map((key, i) => (
+            <div className="exc-prac__col reveal" key={key} style={{ '--reveal-index': i }}>
               <h4>{t(`detail.practical.${key}.heading`)}</h4>
               <ul>
                 {arrayFromTranslation(t(`detail.practical.${key}.items`, { returnObjects: true })).map((item) => (
@@ -164,12 +172,12 @@ export default function SafariDetail() {
 
       <section className="saf-cta">
         <div className="saf-cta__bg">
-          <ResponsiveImage src={safari.image} alt="" />
+          <ResponsiveImage className="dp-drift" src={safari.image} alt="" />
         </div>
         <div className="saf-cta__inner">
-          <h2>{t('detail.cta.title', { title: safari.title })}</h2>
-          <p>{t('detail.cta.text')}</p>
-          <div className="saf-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('detail.cta.title', { title: safari.title })}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('detail.cta.text')}</p>
+          <div className="saf-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg btn--accent" to={`/booking?type=safari&item=${encodeURIComponent(safari.id)}`}>{t('cta.get_quote')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
           </div>

--- a/src/pages/SafariTypeDetail.jsx
+++ b/src/pages/SafariTypeDetail.jsx
@@ -1,7 +1,9 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
 import { ALL_SAFARI_PRODUCTS, SAFARI_TYPES } from '../data/safariPageData.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import usePageMeta, { clampDescription } from '../hooks/usePageMeta.js';
 import { touristTripJsonLd } from '../utils/productJsonLd.js';
 import { useCurrency } from '../context/useCurrency.js';
@@ -10,10 +12,16 @@ import '../styles/excursions.css';
 import '../styles/safaris.css';
 
 export default function SafariTypeDetail() {
-  const { t, ready } = useTranslation('safaris');
+  const { t, i18n, ready } = useTranslation('safaris');
   const { typeId } = useParams();
   const { format } = useCurrency();
   const type = SAFARI_TYPES.find((item) => item.id === typeId);
+  const pageRef = useRef(null);
+
+  // Key on the route param too: the route reuses one component instance across
+  // :typeId changes, so without it the observer wouldn't re-scan the new type's
+  // reveal elements and they'd stay hidden.
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? `${i18n.resolvedLanguage}-${typeId}` : 'loading');
 
   usePageMeta(
     type
@@ -54,8 +62,8 @@ export default function SafariTypeDetail() {
   const routes = ALL_SAFARI_PRODUCTS.filter((route) => type.routeIds.includes(route.id));
 
   return (
-    <main className="safaris-page exc-detail saf-type-detail">
-      <nav className="exc-detail__crumbs" aria-label={t('type_detail.breadcrumb_aria')}>
+    <main className="safaris-page exc-detail saf-type-detail" ref={pageRef}>
+      <nav className="exc-detail__crumbs reveal" aria-label={t('type_detail.breadcrumb_aria')}>
         <Link to="/">{t('type_detail.breadcrumb_home')}</Link>
         <span aria-hidden="true">→</span>
         <Link to="/safaris">{t('type_detail.breadcrumb_safaris')}</Link>
@@ -64,40 +72,40 @@ export default function SafariTypeDetail() {
       </nav>
 
       <article className="exc-block exc-block--detail">
-        <div className="exc-block__img">
+        <div className="exc-block__img reveal">
           <ResponsiveImage src={type.image} alt={type.alt || type.title} />
           <span className="exc-block__cat">{t('type_detail.cat')}</span>
         </div>
         <div className="exc-block__body">
-          <span className="exc-block__eyebrow">{t('type_detail.best_for', { audience: type.bestFor })}</span>
-          <h1 className="exc-block__title">{type.title}</h1>
-          <p className="exc-block__desc">{type.desc}</p>
+          <span className="exc-block__eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('type_detail.best_for', { audience: type.bestFor })}</span>
+          <h1 className="exc-block__title reveal" style={{ '--reveal-index': 1 }}>{type.title}</h1>
+          <p className="exc-block__desc reveal" style={{ '--reveal-index': 2 }}>{type.desc}</p>
           <div className="exc-block__cols">
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 0 }}>
               <h4>{t('type_detail.why_choose')}</h4>
               <ul>{type.highlights.map((item) => <li key={item}>{item}</li>)}</ul>
             </div>
-            <div className="exc-block__col">
+            <div className="exc-block__col reveal" style={{ '--reveal-index': 1 }}>
               <h4>{t('type_detail.matching_routes')}</h4>
               <ul>{routes.map((route) => <li key={route.id}>{route.title}</li>)}</ul>
             </div>
           </div>
           <div className="exc-block__actions">
-            <Link className="btn btn--ghost-dark" to={`/booking?type=custom&title=${encodeURIComponent(type.title)}`}>{t('cta.get_quote')}</Link>
-            <Link className="btn btn--ghost-dark" to="/safaris">{t('type_detail.all_safaris')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 0 }} to={`/booking?type=custom&title=${encodeURIComponent(type.title)}`}>{t('cta.get_quote')}</Link>
+            <Link className="btn btn--ghost-dark reveal" style={{ '--reveal-index': 1 }} to="/safaris">{t('type_detail.all_safaris')}</Link>
           </div>
         </div>
       </article>
 
-      <section className="itineraries reveal">
+      <section className="itineraries">
         <header className="itineraries__head">
-          <span className="section-eyebrow">{t('type_detail.routes.eyebrow')}</span>
-          <h2 className="section-title">{t('type_detail.routes.title')}</h2>
-          <p className="section-lead">{t('type_detail.routes.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('type_detail.routes.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('type_detail.routes.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('type_detail.routes.lead')}</p>
         </header>
         <div className="exc-grid saf-route-grid">
-          {routes.map((route) => (
-            <Link key={route.id} to={`/safaris/${route.id}`} className="exc-card saf-route-card" aria-label={t('itineraries.explore_aria', { title: route.title })}>
+          {routes.map((route, i) => (
+            <Link key={route.id} to={`/safaris/${route.id}`} className="exc-card saf-route-card reveal" style={{ '--reveal-index': i }} aria-label={t('itineraries.explore_aria', { title: route.title })}>
               <div className="exc-card__img">
                 <img src={route.image} alt={route.alt || route.title} loading="lazy" />
                 <span className="exc-card__cat">{route.category}</span>
@@ -123,12 +131,12 @@ export default function SafariTypeDetail() {
 
       <section className="saf-cta">
         <div className="saf-cta__bg">
-          <ResponsiveImage src={type.image} alt="" />
+          <ResponsiveImage src={type.image} alt="" className="dp-drift" />
         </div>
         <div className="saf-cta__inner">
-          <h2>{t('type_detail.cta.title')}</h2>
-          <p>{t('type_detail.cta.text')}</p>
-          <div className="saf-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('type_detail.cta.title')}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('type_detail.cta.text')}</p>
+          <div className="saf-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg btn--accent" to={`/booking?type=custom&title=${encodeURIComponent(type.title)}`}>{t('cta.get_quote')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('type_detail.cta.plan_ai')}</Link>
           </div>

--- a/src/pages/Safaris.jsx
+++ b/src/pages/Safaris.jsx
@@ -50,7 +50,7 @@ export default function Safaris() {
     setVisibleCount(INITIAL_SAFARI_COUNT);
   }, [filter]);
 
-  useRevealOnScroll(pageRef, '.reveal', visibleSafaris, 0.08);
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', visibleSafaris, 0.08);
 
   return (
     <main className="safaris-page" ref={pageRef}>

--- a/src/pages/Transfers.jsx
+++ b/src/pages/Transfers.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import TransfersCta from '../components/transfers/TransfersCta.jsx';
 import TransfersFaq from '../components/transfers/TransfersFaq.jsx';
@@ -7,15 +8,19 @@ import TransfersHow from '../components/transfers/TransfersHow.jsx';
 import TransfersIncluded from '../components/transfers/TransfersIncluded.jsx';
 import TransfersTypes from '../components/transfers/TransfersTypes.jsx';
 import { usePageMeta } from '../hooks/usePageMeta.js';
+import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 import '../styles/transfers.css';
 
 export default function Transfers() {
-  const { t } = useTranslation('transfers');
+  const { t, i18n, ready } = useTranslation('transfers');
   usePageMeta(t('page_title'), t('page_description'));
 
+  const pageRef = useRef(null);
+  useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', ready ? i18n.resolvedLanguage : 'loading');
+
   return (
-    <main className="transfers-page">
+    <main className="transfers-page" ref={pageRef}>
       <TransfersHero />
       <TransfersTypes />
       <TransfersHow />

--- a/src/pages/TripPlannerPage.jsx
+++ b/src/pages/TripPlannerPage.jsx
@@ -121,18 +121,19 @@ export default function TripPlannerPage() {
         </div>
       </section>
 
-      <section className="trip-prompts reveal">
+      <section className="trip-prompts">
         <header className="trip-prompts__head">
-          <span className="section-eyebrow">{t('prompts.eyebrow')}</span>
-          <h2 className="section-title">{t('prompts.title')}</h2>
-          <p className="section-lead">{t('prompts.lead')}</p>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('prompts.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('prompts.title')}</h2>
+          <p className="section-lead reveal" style={{ '--reveal-index': 2 }}>{t('prompts.lead')}</p>
         </header>
         <div className="trip-prompts__grid">
-          {plannerPrompts.map((prompt) => (
+          {plannerPrompts.map((prompt, i) => (
             <button
-              className={`trip-prompt-card${selectedPrompt === prompt.key ? ' is-selected' : ''}`}
+              className={`trip-prompt-card reveal${selectedPrompt === prompt.key ? ' is-selected' : ''}`}
               key={prompt.key}
               type="button"
+              style={{ '--reveal-index': i }}
               onClick={() => startPrompt(prompt)}
               aria-pressed={selectedPrompt === prompt.key}
             >
@@ -147,14 +148,14 @@ export default function TripPlannerPage() {
 
       <PlannerSection initialPrompt={initialPrompt} />
 
-      <section className="trip-steps reveal">
+      <section className="trip-steps">
         <header className="trip-steps__head">
-          <span className="section-eyebrow">{t('steps.eyebrow')}</span>
-          <h2 className="section-title">{t('steps.title')}</h2>
+          <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('steps.eyebrow')}</span>
+          <h2 className="section-title reveal" style={{ '--reveal-index': 1 }}>{t('steps.title')}</h2>
         </header>
         <div className="trip-steps__grid">
-          {plannerSteps.map((item) => (
-            <article className="trip-step" key={item.step}>
+          {plannerSteps.map((item, i) => (
+            <article className="trip-step reveal dp-lift" key={item.step} style={{ '--reveal-index': i }}>
               <span>{item.step}</span>
               <h3>{item.title}</h3>
               <p>{item.text}</p>
@@ -164,11 +165,11 @@ export default function TripPlannerPage() {
       </section>
 
       <section className="exc-cta">
-        <div className="exc-cta__bg"><ResponsiveImage src="/assets/images/safaris/crowned-cranes-in-grass.webp" alt="" /></div>
+        <div className="exc-cta__bg"><ResponsiveImage src="/assets/images/safaris/crowned-cranes-in-grass.webp" alt="" className="dp-drift" /></div>
         <div className="exc-cta__inner">
-          <h2>{t('cta.title')}</h2>
-          <p>{t('cta.text')}</p>
-          <div className="exc-cta__btns">
+          <h2 className="reveal" style={{ '--reveal-index': 0 }}>{t('cta.title')}</h2>
+          <p className="reveal" style={{ '--reveal-index': 1 }}>{t('cta.text')}</p>
+          <div className="exc-cta__btns reveal" style={{ '--reveal-index': 2 }}>
             <Link className="btn btn--lg btn--accent" to="/booking">{t('cta.get_quote')}</Link>
             <a className="btn btn--ghost-light btn--lg" href="#planner">{t('cta.keep_planning')}</a>
           </div>

--- a/src/styles/about/states.css
+++ b/src/styles/about/states.css
@@ -21,9 +21,8 @@
 [data-theme="dark"] .ab-press__strip { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.08); }
 [data-theme="dark"] .ab-tl-item::before { box-shadow: 0 0 0 4px #0B2030; }
 
-/* Reveal — matches homepage sections-base */
-.about-page .reveal { opacity: 0; transform: translateY(24px); transition: opacity .8s var(--dp-ease-out), transform .8s var(--dp-ease-out); }
-.about-page .reveal.is-visible { opacity: 1; transform: none; }
+/* Reveal entrance comes from the global, polished .reveal in
+   src/styles/reveal.css. */
 
 /* Anchor sticky entrance */
 .ab-anchor { transition: background .4s ease, border-color .4s ease; }

--- a/src/styles/excursions/reveal.css
+++ b/src/styles/excursions/reveal.css
@@ -1,3 +1,3 @@
 /* ============ REVEAL ============ */
-.excursions-page .reveal { opacity: 0; transform: translateY(24px); transition: opacity .8s ease, transform .8s ease; }
-.excursions-page .reveal.is-visible { opacity: 1; transform: none; }
+/* Reveal entrance now comes from the global, polished .reveal in
+   src/styles/reveal.css (fade + rise + scale + de-blur + stagger). */

--- a/src/styles/homepage/sections-base.css
+++ b/src/styles/homepage/sections-base.css
@@ -27,8 +27,7 @@
   line-height: 1.6;
 }
 
-.reveal { opacity: 0; transform: translateY(24px); transition: opacity .8s var(--dp-ease-out), transform .8s var(--dp-ease-out); }
-.reveal.is-visible { opacity: 1; transform: none; }
+/* .reveal entrance is defined globally in src/styles/reveal.css. */
 
 .scroll-cue {
   display: flex;

--- a/src/styles/reveal.css
+++ b/src/styles/reveal.css
@@ -1,0 +1,119 @@
+/* Site-wide animation system.
+   Promotes the retreat page's polished motion vocabulary to a single global
+   layer so every page shares one look. Imported once from main.jsx (after
+   site-shell.css) so the unscoped selectors apply everywhere.
+
+   Vocabulary:
+   - .reveal / .is-visible  scroll-in entrance (fade + rise + scale + de-blur).
+                            Stagger sequential items with `style={{ '--reveal-index': i }}`.
+   - .dp-lift               hover lift for cards/tiles (pairs with .reveal).
+   - .dp-zoom               media wrapper; its <img> zooms + saturates on hover.
+   - .dp-drift              slow ambient pan/zoom for hero & banner backgrounds.
+
+   The page must run a reveal observer (useRevealOnScroll, or the inline
+   IntersectionObserver on Homepage/Packages/etc.) so `.reveal` elements gain
+   `.is-visible`. Without it `.reveal` content stays hidden by design.
+
+   IMPORTANT: the entrance is an `animation`, not a `transition`. Many cards
+   define their own `transition` (for hover lift/zoom); a transition-based
+   reveal would be clobbered by those (losing the stagger and the opacity/blur
+   fade). Using `animation` keeps the entrance independent of `transition`, so
+   the cascade works on every element and hover transitions keep working. */
+
+/* ---------- Scroll reveal ---------- */
+/* Hidden state carries NO transform — only opacity — so it never establishes a
+   containing block for position:fixed/sticky descendants while at rest. The
+   transform/blur live in the keyframes and exist only during the entrance. */
+.reveal {
+  opacity: 0;
+}
+.reveal.is-visible {
+  opacity: 1;
+  animation: dpRevealIn 0.7s var(--dp-ease-out) calc(var(--reveal-index, 0) * 55ms) backwards;
+}
+@keyframes dpRevealIn {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.99);
+    filter: blur(4px);
+  }
+}
+/* The retreat page has its own scoped, transition-based reveal (with
+   --ret-reveal-index). Neutralise the global animation there so it stays
+   exactly as designed. */
+.retreat-page .reveal.is-visible {
+  animation: none;
+}
+
+/* ---------- Hover lift (cards, tiles, stat chips) ---------- */
+.dp-lift {
+  transition:
+    transform 0.3s var(--dp-ease-out),
+    box-shadow 0.3s ease,
+    background 0.3s ease,
+    border-color 0.3s ease;
+}
+.dp-lift:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 44px rgba(14, 36, 56, 0.12);
+}
+[data-theme="dark"] .dp-lift:hover {
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.45);
+}
+
+/* ---------- Media zoom on hover ---------- */
+.dp-zoom {
+  overflow: hidden;
+}
+.dp-zoom img {
+  transition:
+    transform 0.8s var(--dp-ease-out),
+    filter 0.8s var(--dp-ease-out);
+}
+.dp-zoom:hover img,
+a:hover > .dp-zoom img {
+  transform: scale(1.07);
+  filter: saturate(1.08);
+}
+
+/* ---------- Ambient background drift ---------- */
+@keyframes dpDrift {
+  from { transform: scale(1.04) translate3d(0, 0, 0); }
+  to   { transform: scale(1.1) translate3d(-1.2%, -1%, 0); }
+}
+.dp-drift {
+  animation: dpDrift 22s ease-in-out infinite alternate;
+  will-change: transform;
+}
+/* When a hero plays the shared heroImageReveal entrance first, this variant
+   starts the drift afterwards from the resting scale (1.05) with no snap. */
+@keyframes dpHeroDrift {
+  from { transform: scale(1.05) translate3d(0, 0, 0); }
+  to   { transform: scale(1.11) translate3d(-1.2%, -1%, 0); }
+}
+.dp-hero-drift {
+  animation: heroImageReveal 1.4s var(--dp-ease-out) both,
+             dpHeroDrift 20s ease-in-out 1.4s infinite alternate;
+  will-change: transform, opacity;
+}
+
+/* ---------- Respect reduced motion everywhere ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .reveal.is-visible {
+    opacity: 1;
+    animation: none;
+  }
+  .dp-lift,
+  .dp-lift:hover,
+  .dp-zoom img,
+  .dp-zoom:hover img {
+    transition: none;
+    transform: none;
+    filter: none;
+  }
+  .dp-drift,
+  .dp-hero-drift {
+    animation: none;
+  }
+}

--- a/src/styles/safaris/states.css
+++ b/src/styles/safaris/states.css
@@ -1,13 +1,6 @@
-/* Reveal — match homepage */
-.safaris-page .reveal { opacity: 0; transform: translateY(20px); transition: opacity .8s var(--dp-ease-out), transform .8s var(--dp-ease-out); }
-.safaris-page .reveal.is-visible { opacity: 1; transform: translateY(0); }
+/* Reveal entrance comes from the global, polished .reveal in
+   src/styles/reveal.css (which also handles prefers-reduced-motion). */
 
 @media (prefers-reduced-motion: reduce) {
-  .safaris-page .reveal,
-  .safaris-page .reveal.is-visible {
-    opacity: 1;
-    transform: none;
-    transition: none;
-  }
   .saf-hero__bg img { animation: none; transform: scale(1.05); }
 }


### PR DESCRIPTION
## What & why

The retreat page had a rich animation system; the rest of the site was inconsistent (5 divergent `.reveal` definitions, several pages with no animation at all). This promotes that motion vocabulary into **one global layer** and applies it across every page — with each **small component** animating in on its own staggered cascade rather than whole sections sliding in as a block.

## How it works

**Foundation** — new [`src/styles/reveal.css`](src/styles/reveal.css), imported once in `main.jsx`:
- One polished `reveal` entrance + `dp-lift` (hover), `dp-zoom` (image hover), `dp-drift` / `dp-hero-drift` (ambient background drift), with a global `prefers-reduced-motion` guard.
- The 5 divergent per-page `.reveal` definitions now defer to this single version.
- The entrance is a **CSS animation, not a transition** — so it's immune to per-card `transition` overrides (the stagger + fade work on *every* element while hover transitions stay intact), and it carries no transform at rest (so it never breaks `position:fixed`/`sticky` descendants).

**Coverage**
- Wired a reveal observer into every page that lacked one (Transfers, all detail pages, Booking, Policy, 404) and fixed a latent hidden-content bug on SafariTypeDetail.
- Detail-page observers are keyed on the route param, so navigating product → product re-scans the new page's elements (otherwise they stayed hidden — reused component instance).
- Kept `reveal` off the ancestors of the floating booking summary and the About pinned timeline photo to avoid containing-block breakage.

**Granularity** (the headline behavior)
- `reveal` + staggered `--reveal-index` live on individual small elements (eyebrow, title, lead, each card, each list item, each button) — **not** on section/grouping containers — so pieces cascade in individually.
- Converted About's now-inert `transitionDelay` staggers to `--reveal-index`.

## Scope

~60 files: `src/styles/reveal.css` (+ 4 reconciled CSS files), `main.jsx`, all page components, and per-page child components across homepage / excursions / safaris / transfers / explore / about / booking. JSX changes are class + `--reveal-index` additions; the Retreats reference page and interactive widgets (map/weather/planner) are intentionally untouched.

## Verification
- ✅ `npm run typecheck` clean
- ✅ `npm run lint` — 0 errors (13 pre-existing warnings, unrelated)
- ✅ `npm run build` — prerenders **120/120 routes** cleanly
- ✅ Browser checks: per-element stagger confirmed (distinct `animation-delay` per element), section roots no longer block-animate, hover transitions intact, no hidden content, no animation-related console errors

## Reviewer notes
- This work was developed and adversarially reviewed via multi-agent workflows; the review surfaced the route-param `refreshKey` and booking-summary containing-block issues, which are fixed here.
- Worth a manual smoke test of the **booking floating summary** while scrolling and the **About pinned timeline photo**, since those interact with the reveal transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)