### PR TITLE
Widen site layout to 1400px and center nav menu

### DIFF
--- a/src/styles/about/careers.css
+++ b/src/styles/about/careers.css
@@ -16,7 +16,7 @@
   position: absolute; inset: 0; z-index: -1;
   background: linear-gradient(rgba(20,12,8,.78), rgba(20,12,8,.86));
 }
-.ab-careers__inner { max-width: 1240px; margin: 0 auto; }
+.ab-careers__inner { max-width: var(--site-max-width); margin: 0 auto; }
 .ab-careers__head {
   display: grid; grid-template-columns: 1fr 1.2fr;
   gap: clamp(2rem, 5vw, 4rem); align-items: end;

--- a/src/styles/about/community.css
+++ b/src/styles/about/community.css
@@ -3,7 +3,7 @@
   background: linear-gradient(180deg, rgba(184,84,26,.06) 0%, transparent 100%);
   padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
 }
-.ab-sus__inner { max-width: 1240px; margin: 0 auto; }
+.ab-sus__inner { max-width: var(--site-max-width); margin: 0 auto; }
 .ab-sus__head {
   display: grid; grid-template-columns: 1fr 1.2fr;
   gap: clamp(2rem, 5vw, 4rem);

--- a/src/styles/about/guides.css
+++ b/src/styles/about/guides.css
@@ -1,7 +1,7 @@
 /* ============ GUIDES ============ */
 .ab-guides {
   padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
-  max-width: 1240px; margin: 0 auto;
+  max-width: var(--site-max-width); margin: 0 auto;
 }
 .ab-guides__head {
   display: grid;

--- a/src/styles/about/mission.css
+++ b/src/styles/about/mission.css
@@ -20,7 +20,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: clamp(1.5rem, 3vw, 3rem);
-  max-width: 1240px; margin: 0 auto;
+  max-width: var(--site-max-width); margin: 0 auto;
 }
 @media (max-width: 720px) { .ab-numbers__grid { grid-template-columns: repeat(2, 1fr); } }
 .ab-numbers__item { display: flex; flex-direction: column; gap: .5rem; text-align: left; }

--- a/src/styles/about/press.css
+++ b/src/styles/about/press.css
@@ -1,7 +1,7 @@
 /* ============ PRESS ============ */
 .ab-press {
   padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
-  max-width: 1240px; margin: 0 auto;
+  max-width: var(--site-max-width); margin: 0 auto;
 }
 .ab-press__head {
   display: grid; grid-template-columns: 1fr 1.2fr;

--- a/src/styles/about/story.css
+++ b/src/styles/about/story.css
@@ -1,7 +1,7 @@
 /* ============ STORY ============ */
 .ab-story {
   padding: clamp(4rem, 8vw, 7rem) clamp(1.25rem, 5vw, 6rem);
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .ab-story__head {

--- a/src/styles/booking/layout.css
+++ b/src/styles/booking/layout.css
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
-  max-width: calc(1240px + (clamp(1.25rem, 5vw, 6rem) * 2));
+  max-width: calc(var(--site-max-width) + (clamp(1.25rem, 5vw, 6rem) * 2));
   margin: 0 auto;
 }
 
@@ -54,7 +54,7 @@
 }
 
 .booking-layout {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 1.28fr) minmax(320px, .72fr);

--- a/src/styles/excursions/block.css
+++ b/src/styles/excursions/block.css
@@ -6,7 +6,7 @@
   gap: clamp(2rem, 6vw, 6rem);
   align-items: center;
   padding: clamp(2rem, 4.5vw, 3rem) clamp(1.25rem, 5vw, 6rem);
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto 1.5rem;
   border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
   border-radius: 18px;

--- a/src/styles/excursions/grid.css
+++ b/src/styles/excursions/grid.css
@@ -12,7 +12,7 @@
   max-width: 680px;
 }
 .exc-grid-wrap > .exc-filter {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto clamp(1.2rem, 2vw, 1.75rem);
 }
 .exc-grid {
@@ -20,7 +20,7 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: clamp(1.25rem, 2vw, 1.75rem);
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .exc-grid .exc-card {
@@ -88,7 +88,7 @@
   justify-content: center;
   flex-wrap: wrap;
   gap: .9rem 1.15rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: clamp(1.5rem, 3vw, 2.25rem) auto 0;
   color: color-mix(in srgb, currentColor 62%, transparent);
   font-size: .92rem;

--- a/src/styles/excursions/pairings.css
+++ b/src/styles/excursions/pairings.css
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.5rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .exc-pair__card {

--- a/src/styles/excursions/practical.css
+++ b/src/styles/excursions/practical.css
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 2rem;
-  max-width: 1240px; margin: 0 auto;
+  max-width: var(--site-max-width); margin: 0 auto;
 }
 .exc-prac__col h4 {
   font-size: 11px; letter-spacing: .2em; text-transform: uppercase;

--- a/src/styles/homepage/about.css
+++ b/src/styles/homepage/about.css
@@ -5,7 +5,7 @@
 }
 
 .home-about__inner {
-  max-width: 1180px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);

--- a/src/styles/homepage/contact.css
+++ b/src/styles/homepage/contact.css
@@ -9,7 +9,7 @@
   text-align: center;
 }
 .contact__grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1.4fr;

--- a/src/styles/homepage/excursions.css
+++ b/src/styles/homepage/excursions.css
@@ -13,7 +13,7 @@
 .excursions__grid {
   display: grid;
   gap: 1.5rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 

--- a/src/styles/homepage/footer.css
+++ b/src/styles/homepage/footer.css
@@ -7,7 +7,7 @@
   color: var(--text-soft);
   font-family: var(--dp-font-sans);
 }
-.footer__inner { max-width: 1240px; margin: 0 auto; display: grid; grid-template-columns: 1.3fr 1fr 1fr 1fr; gap: 2rem; }
+.footer__inner { max-width: var(--site-max-width); margin: 0 auto; display: grid; grid-template-columns: 1.3fr 1fr 1fr 1fr; gap: 2rem; }
 @media (max-width: 820px) { .footer__inner { grid-template-columns: 1fr 1fr; } }
 @media (max-width: 500px) { .footer__inner { grid-template-columns: 1fr; } }
 .footer__logo { display: flex; align-items: center; gap: .65rem; margin-bottom: 1rem; }
@@ -92,7 +92,7 @@
 }
 .footer__socials a:hover { background: var(--dp-accent); color: #fff; border-color: var(--dp-accent); transform: translateY(-2px); }
 .footer__bottom {
-  max-width: 1240px; margin: 1.25rem auto 0; padding-top: 1.25rem;
+  max-width: var(--site-max-width); margin: 1.25rem auto 0; padding-top: 1.25rem;
   border-top: 1px solid var(--border);
   display: flex;
   justify-content: space-between;

--- a/src/styles/homepage/map.css
+++ b/src/styles/homepage/map.css
@@ -1,6 +1,6 @@
 /* ------------ MAP ------------ */
 .map-section {
-  width: min(95%, 1240px);
+  width: var(--section-contained-width);
   margin: clamp(3rem, 6vw, 5rem) auto;
   padding: 0 clamp(1rem, 3vw, 2rem);
 }

--- a/src/styles/homepage/nav.css
+++ b/src/styles/homepage/nav.css
@@ -16,19 +16,20 @@
   pointer-events: none;
 }
 .nav__inner {
-  width: min(100%, 1200px);
+  width: min(100%, var(--site-max-width));
   margin: 0 auto;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   gap: clamp(1rem, 2vw, 2rem);
 }
-.nav__logo { display: flex; align-items: center; gap: .6rem; text-decoration: none; color: var(--text); }
+.nav__logo { justify-self: start; display: flex; align-items: center; gap: .6rem; text-decoration: none; color: var(--text); }
 .nav__logo img { height: 38px; width: auto; }
 .nav__logo-text { font-family: var(--dp-font-script); font-size: 1.1rem; color: var(--text); line-height: 1; }
 .nav__logo-text small { display: block; font-family: var(--dp-font-sans); font-size: 9px; letter-spacing: .24em; text-transform: uppercase; color: var(--text-muted); margin-top: 3px; font-weight: 600; }
 
 .nav__menu {
+  justify-self: center;
   display: flex; gap: 2rem; list-style: none; margin: 0; padding: 0;
   font-family: var(--dp-font-sans);
 }
@@ -83,7 +84,7 @@
   translate: 0 -1px;
 }
 
-.nav__right { display: flex; align-items: center; gap: .75rem; }
+.nav__right { justify-self: end; display: flex; align-items: center; gap: .75rem; }
 
 /* Theme toggle — single circular button with crossfading sun/moon icons.
    Shared .theme-toggle styles live in styles/components/theme-toggle.css */
@@ -188,6 +189,8 @@
   }
 
   .nav__inner {
+    display: flex;
+    justify-content: space-between;
     width: 100%;
     gap: clamp(.6rem, 1.2vw, 1rem);
   }
@@ -269,6 +272,7 @@
 
 @media (max-width: 960px) {
   .nav__backdrop { display: block; }
+  .nav__inner { display: flex; justify-content: space-between; }
   .nav__cta { display: none; }
   .nav__logo, .nav__right { position: relative; z-index: 3; }
   .nav__menu {

--- a/src/styles/homepage/packages.css
+++ b/src/styles/homepage/packages.css
@@ -9,7 +9,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 1.5rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .pkg-card {

--- a/src/styles/homepage/planner.css
+++ b/src/styles/homepage/planner.css
@@ -148,7 +148,7 @@
 }
 .trip-prompts__grid,
 .trip-steps__grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -253,7 +253,7 @@
   overflow: hidden;
 }
 .planner__wrap {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1.05fr;

--- a/src/styles/homepage/safaris.css
+++ b/src/styles/homepage/safaris.css
@@ -9,7 +9,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 1.25rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .safari-card {

--- a/src/styles/homepage/transfers.css
+++ b/src/styles/homepage/transfers.css
@@ -19,7 +19,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 1.5rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 

--- a/src/styles/retreats.css
+++ b/src/styles/retreats.css
@@ -148,7 +148,7 @@ html[data-theme="dark"] .retreat-page {
 
 /* ---------- Teacher ---------- */
 .ret-teacher {
-  width: min(var(--dp-container-lg), 92%);
+  width: min(var(--site-max-width), 92%);
   margin: 0 auto;
   padding: 0 0 clamp(4rem, 8vw, 7rem);
   display: grid;
@@ -249,7 +249,7 @@ html[data-theme="dark"] .retreat-page {
 
 /* Practice cards */
 .ret-practice__grid {
-  width: min(var(--dp-container-lg), 92%);
+  width: min(var(--site-max-width), 92%);
   margin: clamp(2.5rem, 5vw, 3.5rem) auto 0;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -295,7 +295,7 @@ html[data-theme="dark"] .retreat-page {
 
 /* Journey / itinerary (reuses .ret-practice__card styling) */
 .ret-journey__grid {
-  width: min(var(--dp-container-lg), 92%);
+  width: min(var(--site-max-width), 92%);
   margin: clamp(2.5rem, 5vw, 3.5rem) auto 0;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -372,7 +372,7 @@ html[data-theme="dark"] .retreat-page {
 
 /* Gallery — bento */
 .ret-gallery__grid {
-  width: min(var(--dp-container-lg), 92%);
+  width: min(var(--site-max-width), 92%);
   margin: clamp(2.5rem, 5vw, 3.5rem) auto 0;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -421,8 +421,8 @@ html[data-theme="dark"] .retreat-page {
   width: 100%;
   box-sizing: border-box;
   margin: 0;
-  padding-left: max(4%, calc((100% - var(--dp-container-lg)) / 2));
-  padding-right: max(4%, calc((100% - var(--dp-container-lg)) / 2));
+  padding-left: max(4%, calc((100% - var(--site-max-width)) / 2));
+  padding-right: max(4%, calc((100% - var(--site-max-width)) / 2));
 }
 .ret-included__price {
   margin: 1.6rem 0 0;

--- a/src/styles/safaris/explore-itinerary.css
+++ b/src/styles/safaris/explore-itinerary.css
@@ -4,7 +4,7 @@
   color: var(--text);
 }
 .explore-path-grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -70,7 +70,7 @@
   background: var(--page-bg);
 }
 .explore-hub__inner {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(260px, .85fr) minmax(0, 1.4fr);

--- a/src/styles/safaris/included.css
+++ b/src/styles/safaris/included.css
@@ -5,7 +5,7 @@
   color: var(--text);
 }
 .included__wrap {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1.1fr;

--- a/src/styles/safaris/intro.css
+++ b/src/styles/safaris/intro.css
@@ -4,7 +4,7 @@
   background: var(--surface);
 }
 .saf-intro__grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/styles/safaris/itineraries.css
+++ b/src/styles/safaris/itineraries.css
@@ -15,7 +15,7 @@
   max-width: 680px;
 }
 .saf-filter {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto clamp(1.2rem, 2vw, 1.75rem);
   padding: 0;
   justify-content: center;

--- a/src/styles/safaris/parks.css
+++ b/src/styles/safaris/parks.css
@@ -5,7 +5,7 @@
 }
 .parks__head { max-width: 720px; margin: 0 auto clamp(2.5rem, 4vw, 3.5rem); text-align: center; }
 .parks__grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(6, 1fr);

--- a/src/styles/safaris/seasons.css
+++ b/src/styles/safaris/seasons.css
@@ -5,7 +5,7 @@
 }
 .when__head { max-width: 720px; margin: 0 auto clamp(2.5rem, 4vw, 3.5rem); text-align: center; }
 .when__grid {
-  max-width: 1240px; margin: 0 auto;
+  max-width: var(--site-max-width); margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;

--- a/src/styles/safaris/types.css
+++ b/src/styles/safaris/types.css
@@ -59,7 +59,7 @@
 }
 
 .saf-types__grid {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -160,7 +160,7 @@
   transform: scale(1.05);
 }
 
-@media (max-width: 1240px) {
+@media (max-width: var(--site-max-width)) {
   .saf-types__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 

--- a/src/styles/safaris/types.css
+++ b/src/styles/safaris/types.css
@@ -160,7 +160,8 @@
   transform: scale(1.05);
 }
 
-@media (max-width: var(--site-max-width)) {
+/* Literal breakpoint — media query conditions can't read var(); mirrors --site-max-width (1400px). */
+@media (max-width: 1400px) {
   .saf-types__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 

--- a/src/styles/safaris/wildlife.css
+++ b/src/styles/safaris/wildlife.css
@@ -5,7 +5,7 @@
 }
 [data-theme="dark"] .wildlife { background: linear-gradient(180deg, var(--surface), #0a1d2a 100%); }
 .wildlife__head { max-width: 720px; margin: 0 auto clamp(2.5rem, 4vw, 3.5rem); text-align: center; }
-.wildlife__cat { max-width: 1240px; margin: 0 auto 3rem; }
+.wildlife__cat { max-width: var(--site-max-width); margin: 0 auto 3rem; }
 .wildlife__cat-title {
   display: flex; align-items: baseline; gap: 1rem;
   margin: 0 0 1rem;

--- a/src/styles/site-shell.css
+++ b/src/styles/site-shell.css
@@ -27,7 +27,8 @@
   --section-pad-block: var(--section-gap);
   --section-pad-inline: clamp(1.5rem, 7vw, 6rem);
   --section-stack-gap: clamp(3rem, 6vw, 5rem);
-  --section-contained-width: min(95%, 1240px);
+  --site-max-width: 1400px;
+  --section-contained-width: min(95%, var(--site-max-width));
   --section-contained-inline: clamp(1rem, 3vw, 2rem);
   --section-transition-gap: clamp(.75rem, 1.5vw, 1.1rem);
   --section-cue-overlap: clamp(.5rem, 1vw, .85rem);

--- a/src/styles/transfers/fleet.css
+++ b/src/styles/transfers/fleet.css
@@ -12,7 +12,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 1.5rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 .tr-vehicle {

--- a/src/styles/transfers/included.css
+++ b/src/styles/transfers/included.css
@@ -4,7 +4,7 @@
   background: var(--surface);
 }
 .tr-included__wrap {
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/styles/transfers/types.css
+++ b/src/styles/transfers/types.css
@@ -12,7 +12,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 1.75rem;
-  max-width: 1240px;
+  max-width: var(--site-max-width);
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## What

Widens the whole app to a consistent **1400px** (up from 1200/1240px) and re-centers the primary navigation.

### Nav
- `.nav__inner` becomes a 3-column grid (`1fr auto 1fr`) above 1180px: the menu sits dead-center on the page, the logo pins to the far left, and the EN/theme/search/**Book Now** cluster pins to the far right — naturally spreading the logo and CTA apart.
- Mid-range (961–1180px) keeps the tuned flex `space-between` layout; mobile (≤960px) keeps the burger menu. Grid only applies on wide desktop where there's room.

### Width consolidation
- New single source of truth: `--site-max-width: 1400px` in `site-shell.css`; `--section-contained-width` now references it.
- Replaced the hardcoded `max-width: 1240px` content width (**33 occurrences across 28 files** — Excursions, Safaris, Packages, About, Transfers, Booking, homepage sections) with the shared token.
- Brought the homepage **About** section (was 1180px), the **map** section, the **booking** flow wrapper, and the **Retreats** page's wide tier (`--dp-container-lg`, used only by retreats) onto the same width so nav, footer, and content all line up.

### Intentionally left narrow (not stragglers)
Policy legal text (920px), the Safari/Packages compare & steps grid (1120px, with its own 720px heading), the Transfers CTA (1000px), and hero/reading columns — these were always narrower than content by design.

## Why
After the initial nav/footer widening, most page content still hardcoded 1240px, leaving the chrome 160px wider than the content. This routes everything through one token so the app widens uniformly.

## Verification
- **Zero horizontal overflow** on every audited route: homepage, `/excursions`, `/safaris`, `/packages`, `/aboutus`, `/transfers`, `/booking`, `/retreats`, `/explore`, `/trip-planner`, `/privacy-policy`, the excursion/safari/package **detail** pages, and 404.
- All main containers report 1400px, matching nav and footer.
- Nav verified at all three breakpoints (grid >1180px, flex 961–1180px, burger ≤960px) with no overflow.
- No build/console errors (CSS-only change).

## Reviewer note
**Retreats** was widened from its boutique 1200px to 1400px for consistency with the chrome. If that page should keep a more editorial/narrow feel, that's a one-line revert of its tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)