### PR TITLE
Fix Netlify build-time prerendering (serve real SEO HTML on production)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,15 @@
   publish = "dist"
   functions = "netlify/functions"
 
+[build.environment]
+  # Pin Node so the build is reproducible (Vite 8 needs >= 20.19).
+  NODE_VERSION = "22"
+  # Don't download puppeteer's bundled Chromium during install — it can't launch
+  # on the Netlify build image. The post-build prerender crawl (scripts/prerender.mjs)
+  # uses @sparticuz/chromium instead. Prerender failures fail the build (PRERENDER_STRICT
+  # defaults on in CI) so missing SEO HTML can't ship unnoticed.
+  PUPPETEER_SKIP_DOWNLOAD = "true"
+
 # Note: /api/* routes are registered by each function's own `export const config`
 # (e.g. planner.mjs -> path: '/api/planner'), which takes precedence over the SPA
 # catch-all below — no per-function rewrite is needed here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
+        "@sparticuz/chromium": "^149.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.26.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -2763,6 +2764,19 @@
         "win32"
       ]
     },
+    "node_modules/@sparticuz/chromium": {
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
+      "integrity": "sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tar-fs": "^3.1.2"
+      },
+      "engines": {
+        "node": "^22.17.0 || >=24.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3405,6 +3419,119 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.37",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
@@ -4008,6 +4135,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -4512,6 +4649,16 @@
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4532,6 +4679,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7185,6 +7339,16 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7461,6 +7625,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -8237,6 +8412,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8482,6 +8669,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -8528,6 +8768,31 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/tinybench": {
@@ -9634,6 +9899,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
+    "@sparticuz/chromium": "^149.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.26.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -23,6 +23,26 @@ import { getPrerenderPaths } from './routes.mjs';
 const here = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(here, '../dist');
 
+// On Netlify/CI, puppeteer's bundled Chromium usually can't launch (it's skipped
+// from download and/or the build image lacks the system libs it needs). There we
+// drive @sparticuz/chromium — a self-contained Chromium built for serverless/CI —
+// instead. Locally we keep using puppeteer's own Chromium (fast, already cached).
+const ON_CI = !!(process.env.NETLIFY || process.env.CI);
+
+// Use @sparticuz/chromium when on CI (override with PRERENDER_CHROMIUM=sparticuz|bundled).
+const USE_SPARTICUZ = process.env.PRERENDER_CHROMIUM
+  ? process.env.PRERENDER_CHROMIUM === 'sparticuz'
+  : ON_CI;
+
+// Strict mode fails the build instead of silently shipping a bare SPA shell when
+// prerendering can't run — so missing SEO HTML can't regress unnoticed. On by
+// default in CI; disable with PRERENDER_STRICT=false (or skip with PRERENDER=false).
+const STRICT = process.env.PRERENDER_STRICT
+  ? !['false', '0', 'no'].includes(process.env.PRERENDER_STRICT.toLowerCase())
+  : ON_CI;
+
+const BASE_ARGS = ['--no-sandbox', '--disable-setuid-sandbox'];
+
 const MIME = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8',
@@ -117,6 +137,55 @@ async function renderRoute(browser, port, path) {
   }
 }
 
+// Launch Chromium, trying each viable strategy in order so a single broken
+// environment doesn't silently skip the whole crawl. Returns a browser or throws
+// the last error (the caller decides whether that's fatal — see STRICT).
+async function launchBrowser(puppeteer) {
+  const strategies = [];
+
+  const explicit = process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (explicit) {
+    strategies.push({
+      name: `executablePath (${explicit})`,
+      opts: async () => ({ headless: true, executablePath: explicit, args: BASE_ARGS }),
+    });
+  }
+
+  if (USE_SPARTICUZ) {
+    strategies.push({
+      name: '@sparticuz/chromium',
+      opts: async () => {
+        const { default: chromium } = await import('@sparticuz/chromium');
+        return {
+          headless: chromium.headless ?? true,
+          args: [...chromium.args, ...BASE_ARGS],
+          executablePath: await chromium.executablePath(),
+          defaultViewport: chromium.defaultViewport,
+        };
+      },
+    });
+  }
+
+  // puppeteer's own bundled Chromium — primary path locally, last-resort on CI.
+  strategies.push({
+    name: 'puppeteer bundled Chromium',
+    opts: async () => ({ headless: true, args: BASE_ARGS }),
+  });
+
+  let lastErr;
+  for (const s of strategies) {
+    try {
+      const browser = await puppeteer.launch(await s.opts());
+      console.log(`[prerender] launched Chromium via ${s.name}.`);
+      return browser;
+    } catch (err) {
+      lastErr = err;
+      console.warn(`[prerender] launch via ${s.name} failed: ${err.message}`);
+    }
+  }
+  throw lastErr || new Error('no Chromium launch strategy available');
+}
+
 async function main() {
   if (process.env.PRERENDER === 'false') {
     console.log('[prerender] PRERENDER=false — skipping.');
@@ -145,16 +214,17 @@ async function main() {
 
   let browser;
   try {
-    browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
+    browser = await launchBrowser(puppeteer);
   } catch (err) {
-    console.warn(
-      `\n[prerender] ⚠ Could not launch Chromium — skipping prerender. ` +
-        `SPA ships with client-side meta only.\n  ${err.message}\n`,
-    );
     server.close();
+    const msg = `Could not launch Chromium for prerender — ${err.message}`;
+    if (STRICT) {
+      throw new Error(
+        `${msg}\n  Set PRERENDER=false to ship the SPA without prerendered SEO, ` +
+          `or PRERENDER_STRICT=false to warn instead of failing.`,
+      );
+    }
+    console.warn(`\n[prerender] ⚠ ${msg} — skipping. SPA ships with client-side meta only.\n`);
     return;
   }
 
@@ -193,9 +263,20 @@ async function main() {
   console.log(
     `[prerender] wrote ${results.length}/${paths.length} routes${failed ? ` (${failed} failed)` : ''}.`,
   );
+
+  // Chromium launched but every route failed — the build would ship a bare shell.
+  // Treat that like a launch failure so it can't silently regress SEO.
+  if (STRICT && results.length === 0 && paths.length > 0) {
+    throw new Error(`prerendered 0/${paths.length} routes — refusing to ship a bare SPA shell.`);
+  }
 }
 
 main().catch((err) => {
-  // Never fail the production build because of prerendering.
+  if (STRICT) {
+    // Fail the build loudly so missing prerendered HTML can't ship unnoticed.
+    console.error(`\n[prerender] ✖ ${err?.message || err}\n`);
+    process.exitCode = 1;
+    return;
+  }
   console.warn(`[prerender] ⚠ Unexpected error — skipping. ${err?.stack || err}`);
 });


### PR DESCRIPTION
## Problem
Production (`main` → Netlify) served the bare Vite SPA shell (~5.3KB, empty `<div id="root">`) for **every** route. `scripts/prerender.mjs` "degraded gracefully" — when puppeteer's bundled Chromium failed to launch on Netlify's build image, it warned and let the build succeed anyway, shipping **no** prerendered SEO HTML. The prerendering feature from #67 was effectively dead in production.

## Fix
- Add **`@sparticuz/chromium@149.0.0`** (self-contained Chromium for serverless/CI; pinned to match puppeteer 25's bundled Chrome 149 — no CDP mismatch) and launch via it on CI. Local builds keep using puppeteer's bundled Chromium. Launch tries strategies in order: explicit `PUPPETEER_EXECUTABLE_PATH` → sparticuz (CI) → bundled.
- **`PRERENDER_STRICT`** (defaults on in CI): the build now **fails loudly** if Chromium can't launch or 0 routes render, so missing SEO HTML can't silently regress again. Escape hatches: `PRERENDER_STRICT=false` (warn only), `PRERENDER=false` (skip).
- **`netlify.toml`**: pin `NODE_VERSION=22`, set `PUPPETEER_SKIP_DOWNLOAD=true` (the bundled Chromium can't launch on Netlify; sparticuz is used instead).

## Verification
Verified on the **`development` branch deploy** (real Netlify build image), commit `94b5780d`:
- 122 files uploaded (vs. a bare shell before)
- `/safaris/` → 78KB prerendered HTML, correct `<title>`, nav + footer
- `/packages/two-day-fly-in-safari-zanzibar` → 39KB, correct title, 2 JSON-LD blocks (TouristTrip + Offer), canonical set
- Locally: `npm run build` writes 120/120 routes; strict-fail exits 1 when all launchers are broken, warns + exits 0 with `PRERENDER_STRICT=false`

Merging deploys the fix to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)