### PR TITLE
Add Sentry monitoring

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,6 @@
 DEV_HOST=0.0.0.0
 DEV_PORT=5280
+
+# Optional local Sentry testing.
+# VITE_SENTRY_DSN=
+# SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ npm run test       # Vitest tests
 Set this on Netlify:
 
 - `ANTHROPIC_API_KEY` — required for the AI Trip Planner. Without it, the planner returns a friendly fallback message and points guests to WhatsApp.
+- `VITE_SENTRY_DSN` — optional browser Sentry DSN for React errors and performance traces. Without it, Sentry is disabled.
+- `SENTRY_DSN` — optional server-side Sentry DSN for Netlify Function errors. This can be the same Sentry project DSN as the browser, or a separate Node project DSN.
+- `SENTRY_ENVIRONMENT` / `VITE_SENTRY_ENVIRONMENT` — optional environment labels. Netlify's deploy context is used for functions when this is omitted.
+- `SENTRY_TRACES_SAMPLE_RATE` / `VITE_SENTRY_TRACES_SAMPLE_RATE` — optional tracing sample rates from `0` to `1`; production defaults to `0.1`.
 
 The planner endpoint registers its own route:
 

--- a/netlify/functions/_sentry.mjs
+++ b/netlify/functions/_sentry.mjs
@@ -1,0 +1,76 @@
+import * as Sentry from '@sentry/node';
+
+function readSampleRate(value, fallback) {
+  const parsed = Number.parseFloat(value);
+  if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) return parsed;
+  return fallback;
+}
+
+function truncate(value, maxLength = 1000) {
+  const text = String(value || '');
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+const sentryDsn = (process.env.SENTRY_DSN || process.env.NETLIFY_SENTRY_DSN || '').trim();
+
+export const isFunctionSentryEnabled = Boolean(sentryDsn);
+
+if (isFunctionSentryEnabled) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: process.env.SENTRY_ENVIRONMENT || process.env.CONTEXT || process.env.NODE_ENV || 'production',
+    release: process.env.SENTRY_RELEASE || process.env.COMMIT_REF || undefined,
+    sendDefaultPii: false,
+    tracesSampleRate: readSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0.1),
+  });
+}
+
+function requestContext(req) {
+  if (!req) return undefined;
+
+  try {
+    const url = new URL(req.url);
+    return {
+      method: req.method,
+      path: url.pathname,
+      contentType: req.headers.get('content-type') || undefined,
+    };
+  } catch {
+    return { method: req.method };
+  }
+}
+
+function applyContext(scope, { functionName, req, extra } = {}) {
+  if (functionName) scope.setTag('netlify.function', functionName);
+
+  const request = requestContext(req);
+  if (request) scope.setContext('request', request);
+
+  if (extra) {
+    scope.setContext('netlify_function', {
+      ...extra,
+      errorBody: extra.errorBody ? truncate(extra.errorBody) : undefined,
+    });
+  }
+}
+
+export async function captureFunctionException(error, context) {
+  if (!isFunctionSentryEnabled) return;
+
+  Sentry.withScope((scope) => {
+    applyContext(scope, context);
+    Sentry.captureException(error);
+  });
+  await Sentry.flush(2000);
+}
+
+export async function captureFunctionMessage(message, context) {
+  if (!isFunctionSentryEnabled) return;
+
+  Sentry.withScope((scope) => {
+    applyContext(scope, context);
+    scope.setLevel(context?.level || 'error');
+    Sentry.captureMessage(message);
+  });
+  await Sentry.flush(2000);
+}

--- a/netlify/functions/booking-send.mjs
+++ b/netlify/functions/booking-send.mjs
@@ -9,9 +9,12 @@ import {
   trimField,
   validateEmailAddress,
 } from './_shared.mjs';
+import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
 
 // Re-exported for unit tests (test/netlify/booking-send.test.mjs).
 export { validateEmailAddress };
+
+const FUNCTION_NAME = 'booking-send';
 
 const TEAM_TO = process.env.TEAM_EMAIL_BOOKING || 'info@yournexttriptoparadise.com';
 const FROM_ADDRESS = process.env.RESEND_FROM_BOOKING || 'Destination Paradise <booking@yournexttriptoparadise.com>';
@@ -90,6 +93,11 @@ export default async (req) => {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     console.error('booking-send: missing RESEND_API_KEY');
+    await captureFunctionMessage('Missing RESEND_API_KEY', {
+      functionName: FUNCTION_NAME,
+      req,
+      level: 'warning',
+    });
     return errorResponse('The mailer is not configured yet. Please email us directly, or message us on WhatsApp.', 503);
   }
 
@@ -247,6 +255,11 @@ export default async (req) => {
     if (!teamRes.ok) {
       const errText = await teamRes.text().catch(() => '');
       console.error('Resend team error', teamRes.status, errText);
+      await captureFunctionMessage('Resend team email failed', {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'team-email', status: teamRes.status, errorBody: errText },
+      });
       return errorResponse('We could not send your booking request just now. Please try again in a moment, or message us on WhatsApp.', 502);
     }
 
@@ -262,14 +275,29 @@ export default async (req) => {
       if (!guestRes.ok) {
         const errText = await guestRes.text().catch(() => '');
         console.error('Resend guest copy failed', guestRes.status, errText);
+        await captureFunctionMessage('Resend guest copy failed', {
+          functionName: FUNCTION_NAME,
+          req,
+          extra: { stage: 'guest-copy', status: guestRes.status, errorBody: errText },
+        });
       }
     } catch (err) {
       console.error('Guest copy send failure', err);
+      await captureFunctionException(err, {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'guest-copy' },
+      });
     }
 
     return Response.json({ ok: true });
   } catch (err) {
     console.error('booking-send failure', err);
+    await captureFunctionException(err, {
+      functionName: FUNCTION_NAME,
+      req,
+      extra: { stage: 'send-email' },
+    });
     return errorResponse('We could not send your booking request just now. Please try again.', 502);
   }
 };

--- a/netlify/functions/contact-send.mjs
+++ b/netlify/functions/contact-send.mjs
@@ -8,6 +8,9 @@ import {
   rateLimitKey,
   validateEmailAddress,
 } from './_shared.mjs';
+import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
+
+const FUNCTION_NAME = 'contact-send';
 
 const TEAM_TO = process.env.TEAM_EMAIL_CONTACT || 'info@yournexttriptoparadise.com';
 const FROM_ADDRESS = process.env.RESEND_FROM_CONTACT || 'Destination Paradise <booking@yournexttriptoparadise.com>';
@@ -41,6 +44,11 @@ export default async (req) => {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     console.error('contact-send: missing RESEND_API_KEY');
+    await captureFunctionMessage('Missing RESEND_API_KEY', {
+      functionName: FUNCTION_NAME,
+      req,
+      level: 'warning',
+    });
     return errorResponse('The mailer is not configured yet. Please email us directly, or message us on WhatsApp.', 503);
   }
 
@@ -151,6 +159,11 @@ export default async (req) => {
     if (!teamRes.ok) {
       const errText = await teamRes.text().catch(() => '');
       console.error('Resend team error', teamRes.status, errText);
+      await captureFunctionMessage('Resend team email failed', {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'team-email', status: teamRes.status, errorBody: errText },
+      });
       return errorResponse('We could not send your message just now. Please try again in a moment, or message us on WhatsApp.', 502);
     }
 
@@ -166,14 +179,29 @@ export default async (req) => {
       if (!guestRes.ok) {
         const errText = await guestRes.text().catch(() => '');
         console.error('Resend guest copy failed', guestRes.status, errText);
+        await captureFunctionMessage('Resend guest copy failed', {
+          functionName: FUNCTION_NAME,
+          req,
+          extra: { stage: 'guest-copy', status: guestRes.status, errorBody: errText },
+        });
       }
     } catch (err) {
       console.error('Guest copy send failure', err);
+      await captureFunctionException(err, {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'guest-copy' },
+      });
     }
 
     return Response.json({ ok: true });
   } catch (err) {
     console.error('contact-send failure', err);
+    await captureFunctionException(err, {
+      functionName: FUNCTION_NAME,
+      req,
+      extra: { stage: 'send-email' },
+    });
     return errorResponse('We could not send your message just now. Please try again.', 502);
   }
 };

--- a/netlify/functions/planner-send.mjs
+++ b/netlify/functions/planner-send.mjs
@@ -10,6 +10,9 @@ import {
   rateLimitKey,
   validateEmailAddress,
 } from './_shared.mjs';
+import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
+
+const FUNCTION_NAME = 'planner-send';
 
 const TEAM_TO = process.env.TEAM_EMAIL_PLANNER || 'info@yournexttriptoparadise.com';
 const FROM_ADDRESS = process.env.RESEND_FROM_PLANNER || 'Destination Paradise Planner <booking@yournexttriptoparadise.com>';
@@ -417,6 +420,11 @@ export default async (req) => {
     if (!teamRes.ok) {
       const errText = await teamRes.text().catch(() => '');
       console.error('Resend team error', teamRes.status, errText);
+      await captureFunctionMessage('Resend team email failed', {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'team-email', status: teamRes.status, errorBody: errText },
+      });
       return errorResponse('We could not send the draft just now. Please try again in a moment, or message us on WhatsApp.', 502);
     }
 
@@ -433,14 +441,29 @@ export default async (req) => {
       if (!guestRes.ok) {
         const errText = await guestRes.text().catch(() => '');
         console.error('Resend guest copy failed', guestRes.status, errText);
+        await captureFunctionMessage('Resend guest copy failed', {
+          functionName: FUNCTION_NAME,
+          req,
+          extra: { stage: 'guest-copy', status: guestRes.status, errorBody: errText },
+        });
       }
     } catch (err) {
       console.error('Guest copy send failure', err);
+      await captureFunctionException(err, {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'guest-copy' },
+      });
     }
 
     return Response.json({ ok: true });
   } catch (err) {
     console.error('planner-send failure', err);
+    await captureFunctionException(err, {
+      functionName: FUNCTION_NAME,
+      req,
+      extra: { stage: 'send-email' },
+    });
     return errorResponse('We could not send the draft just now. Please try again in a moment.', 502);
   }
 };

--- a/netlify/functions/planner.mjs
+++ b/netlify/functions/planner.mjs
@@ -8,7 +8,9 @@ import { destinationParadisePackages } from '../../src/data/destinationParadiseP
 import { nextLevelSafariProducts } from '../../src/data/nextLevelSafariProducts.js';
 import { destinationParadiseSafariPricing } from '../../src/data/safariPricing.js';
 import { createRateLimiter, rateLimitKey } from './_shared.mjs';
+import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
 
+const FUNCTION_NAME = 'planner';
 const PLANNER_MODEL = 'claude-haiku-4-5-20251001';
 const MAX_REQUEST_BYTES = 20_000;
 const MAX_HISTORY_MESSAGES = 16;
@@ -201,6 +203,11 @@ export default async (req) => {
 
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
+    await captureFunctionMessage('Missing ANTHROPIC_API_KEY', {
+      functionName: FUNCTION_NAME,
+      req,
+      level: 'warning',
+    });
     return Response.json({
       reply: "The planner isn't configured yet — set ANTHROPIC_API_KEY on Netlify and I'll start chatting. In the meantime, message the team on WhatsApp.",
     }, { status: 200 });
@@ -243,6 +250,11 @@ export default async (req) => {
     if (!r.ok) {
       const errText = await r.text().catch(() => '');
       console.error('Anthropic error', r.status, errText);
+      await captureFunctionMessage('Anthropic planner request failed', {
+        functionName: FUNCTION_NAME,
+        req,
+        extra: { stage: 'anthropic-request', status: r.status, errorBody: errText },
+      });
       return Response.json({
         reply: "Pole sana — I couldn't reach the planner just now. Try again in a moment, or message the team directly.",
       }, { status: 200 });
@@ -258,6 +270,11 @@ export default async (req) => {
     return Response.json({ reply }, { status: 200 });
   } catch (err) {
     console.error('planner function error', err);
+    await captureFunctionException(err, {
+      functionName: FUNCTION_NAME,
+      req,
+      extra: { stage: 'planner-request' },
+    });
     return Response.json({
       reply: "Pole sana — something went wrong on my end. Try again in a moment.",
     }, { status: 200 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "destination-paradise",
       "version": "3.2.0",
       "dependencies": {
+        "@sentry/node": "^10.63.0",
+        "@sentry/react": "^10.63.0",
         "i18next": "^23.16.8",
         "i18next-browser-languagedetector": "^8.2.1",
         "leaflet": "^1.9.4",
@@ -32,6 +34,58 @@
         "vite": "^8.0.13",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.6"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
+      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
+      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz",
+      "integrity": "sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1889,7 +1943,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1920,6 +1973,119 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2764,6 +2930,201 @@
         "win32"
       ]
     },
+    "node_modules/@sentry/browser": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.63.0.tgz",
+      "integrity": "sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0",
+        "@sentry/feedback": "10.63.0",
+        "@sentry/replay": "10.63.0",
+        "@sentry/replay-canvas": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.63.0.tgz",
+      "integrity": "sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.12.0.tgz",
+      "integrity": "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.63.0.tgz",
+      "integrity": "sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.63.0.tgz",
+      "integrity": "sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.63.0.tgz",
+      "integrity": "sha512-E+JfDTdUDGQPRsAfCTR2YgmQgxYdoxk4ks6niHN+ByW8alEZL+nXlcN9vI57qj1LsS4v2jjfLxJf1/cMMt84YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.63.0",
+        "@sentry/node-core": "10.63.0",
+        "@sentry/opentelemetry": "10.63.0",
+        "@sentry/server-utils": "10.63.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.63.0.tgz",
+      "integrity": "sha512-TaNtkGDRNxH3SjOea2PDtaebkNjMbAH8ZFsEcwlqmadpS7nqSR7z6slZy/iu7y1nLiUdbmcM5JmXwxksy52WRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.63.0",
+        "@sentry/opentelemetry": "10.63.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.63.0.tgz",
+      "integrity": "sha512-8yqi8+Ej/anmMn82blXA0BNMeAMs4av6nx0DzhxDrFya28ZaYOn19PChd3erMidfU0HnLLFNqWiFlYxBKq+/KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.63.0.tgz",
+      "integrity": "sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.63.0",
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.63.0.tgz",
+      "integrity": "sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.63.0",
+        "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.63.0.tgz",
+      "integrity": "sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.63.0",
+        "@sentry/replay": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.63.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.63.0.tgz",
+      "integrity": "sha512-7NN//DG9Yak8t2+6WiEcNmN269iHRVdtZtZIwucEd0OXyZ3FEBBDaBF+bT9V6H/kPtUvVMkHQ72Bn2Xs5JYGxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+        "@apm-js-collab/tracing-hooks": "^0.10.0",
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.63.0",
+        "magic-string": "~0.30.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sparticuz/chromium": {
       "version": "149.0.0",
       "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
@@ -3063,13 +3424,21 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3296,6 +3665,15 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3771,6 +4149,12 @@
       "peerDependencies": {
         "devtools-protocol": "*"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -4266,7 +4650,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -4574,7 +4957,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -4600,7 +4982,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -5368,6 +5749,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -6505,7 +6901,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6672,6 +7067,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromark": {
@@ -7155,6 +7559,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -7956,6 +8366,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -8130,6 +8553,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@sentry/node": "^10.63.0",
+    "@sentry/react": "^10.63.0",
     "i18next": "^23.16.8",
     "i18next-browser-languagedetector": "^8.2.1",
     "leaflet": "^1.9.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Route, Routes as RouterRoutes } from 'react-router-dom';
 import SiteLayout from './components/SiteLayout.jsx';
+import { SentryRoutes } from './utils/sentry.js';
+
+const Routes = SentryRoutes(RouterRoutes);
 
 function lazyWithRetry(factory) {
   return lazy(async () => {

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { useLocation } from 'react-router-dom';
 import ErrorBoundaryPage from '../pages/ErrorBoundaryPage.jsx';
+import { captureSentryException } from '../utils/sentry.js';
 
 const RELOAD_FLAG = 'dp-chunk-reload';
 
@@ -44,6 +45,16 @@ class ErrorBoundaryFrame extends Component {
 
   componentDidCatch(error, errorInfo) {
     console.error('Destination Paradise error boundary caught an error:', error, errorInfo);
+    captureSentryException(error, {
+      contexts: {
+        react: {
+          componentStack: errorInfo?.componentStack,
+        },
+      },
+      tags: {
+        errorBoundary: 'root',
+      },
+    });
     tryAutoRecover(error);
   }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import './utils/sentry.js';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/react';
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+
+function readSampleRate(value, fallback) {
+  const parsed = Number.parseFloat(value);
+  if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) return parsed;
+  return fallback;
+}
+
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
+const sentryEnvironment =
+  import.meta.env.VITE_SENTRY_ENVIRONMENT ||
+  (import.meta.env.PROD ? 'production' : import.meta.env.MODE);
+const sentryRelease = import.meta.env.VITE_SENTRY_RELEASE || undefined;
+
+export const isSentryEnabled = Boolean(sentryDsn);
+
+if (isSentryEnabled) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: sentryEnvironment,
+    release: sentryRelease,
+    sendDefaultPii: false,
+    tracesSampleRate: readSampleRate(
+      import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE,
+      import.meta.env.PROD ? 0.1 : 1.0,
+    ),
+    tracePropagationTargets: [/^\//, /^https:\/\/(www\.)?yournexttriptoparadise\.com\/api/],
+    integrations: [
+      Sentry.reactRouterV6BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    ],
+  });
+}
+
+export function captureSentryException(error, context) {
+  if (!isSentryEnabled) return;
+  Sentry.captureException(error, context);
+}
+
+export const SentryRoutes = Sentry.withSentryReactRouterV6Routing;


### PR DESCRIPTION
## Summary
- Add `@sentry/react` (frontend) and `@sentry/node` (Netlify Functions) error monitoring
- Initialize Sentry in `src/main.jsx` / `src/utils/sentry.js`, gated behind `VITE_SENTRY_DSN`
- Hook into the existing `ErrorBoundary.jsx` and `App.jsx`
- Add `netlify/functions/_sentry.mjs` and wire it into `booking-send`, `contact-send`, `planner-send`, and `planner` functions, gated behind `SENTRY_DSN`
- Document the new env vars in `README.md` / `.env.development`

## Verified (already done on `development`)
- [x] Live bundle contains the Sentry config
- [x] Sentry accepted a smoke-test event (visible as `DESTINATIONPARADISE-1`)
- [x] `lint`, `typecheck`, `test`, and production `build` pass (lint has only pre-existing warnings)

Commit: 5763634 · Deploy: 6a46e2a7d1192f20725740df


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx9muxkuj9XMhrPJgBPG7E)_