### PR TITLE
Site audit: GDPR, SEO, accessibility, backend hardening, perf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - development
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default [
   {
-    ignores: ['dist/**', 'dev-dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'dev-dist/**', 'node_modules/**', '.claude/**'],
   },
   {
     files: ['**/*.{js,jsx}'],

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#1A4D6E" />
     <meta name="description" content="Destination Paradise offers bespoke excursions, luxury safaris, and unforgettable packages in Zanzibar & Tanzania." />
-    <link rel="canonical" href="https://destinationparadisezanzibar.netlify.app/" />
+    <link rel="canonical" href="https://yournexttriptoparadise.com/" />
     <meta property="og:site_name" content="Destination Paradise" />
     <meta property="og:title" content="Destination Paradise — your next trip to paradise" />
     <meta property="og:description" content="Destination Paradise offers bespoke excursions, luxury safaris, and unforgettable packages in Zanzibar & Tanzania." />
-    <meta property="og:url" content="https://destinationparadisezanzibar.netlify.app/" />
-    <meta property="og:image" content="https://destinationparadisezanzibar.netlify.app/assets/brand/og-card.jpg" />
+    <meta property="og:url" content="https://yournexttriptoparadise.com/" />
+    <meta property="og:image" content="https://yournexttriptoparadise.com/assets/brand/og-card.jpg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Stone Town waterfront, Zanzibar" />
@@ -19,11 +19,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Destination Paradise — your next trip to paradise" />
     <meta name="twitter:description" content="Destination Paradise offers bespoke excursions, luxury safaris, and unforgettable packages in Zanzibar & Tanzania." />
-    <meta name="twitter:image" content="https://destinationparadisezanzibar.netlify.app/assets/brand/og-card.jpg" />
+    <meta name="twitter:image" content="https://yournexttriptoparadise.com/assets/brand/og-card.jpg" />
     <link rel="icon" type="image/webp" href="/assets/brand/destination-paradise-logo-96.webp" />
     <link rel="apple-touch-icon" sizes="192x192" href="/assets/brand/destination-paradise-logo-192.png" />
     <link rel="preload" href="/assets/fonts/kaushan-script-regular.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="/assets/images/home/aerial-boats-turquoise-water.webp" as="image" fetchpriority="high" />
+    <link rel="preload" href="/assets/images/home/stone-town-waterfront.webp" as="image" fetchpriority="high" />
     <link rel="manifest" href="/manifest.json" />
     <title>Destination Paradise — your next trip to paradise</title>
     <script type="application/ld+json">
@@ -31,9 +31,9 @@
         "@context": "https://schema.org",
         "@type": "TravelAgency",
         "name": "Destination Paradise",
-        "url": "https://destinationparadisezanzibar.netlify.app/",
-        "logo": "https://destinationparadisezanzibar.netlify.app/assets/brand/destination-paradise-logo-512.png",
-        "image": "https://destinationparadisezanzibar.netlify.app/assets/brand/og-card.jpg",
+        "url": "https://yournexttriptoparadise.com/",
+        "logo": "https://yournexttriptoparadise.com/assets/brand/destination-paradise-logo-512.png",
+        "image": "https://yournexttriptoparadise.com/assets/brand/og-card.jpg",
         "description": "Bespoke excursions, luxury safaris, and complete travel packages in Zanzibar & Tanzania.",
         "areaServed": ["Zanzibar", "Tanzania"],
         "knowsLanguage": ["en", "de", "pl"]
@@ -49,31 +49,6 @@
          /api/booking-send). -->
     <form name="newsletter" data-netlify="true" hidden>
       <input type="email" name="email" />
-    </form>
-    <form name="booking-request" data-netlify="true" netlify-honeypot="bot-field" hidden>
-      <input type="text" name="serviceType" />
-      <input type="text" name="product" />
-      <input type="text" name="productLabel" />
-      <input type="text" name="estimatedPrice" />
-      <input type="text" name="name" />
-      <input type="email" name="email" />
-      <input type="tel" name="phone" />
-      <input type="tel" name="whatsapp" />
-      <input type="date" name="startDate" />
-      <input type="date" name="endDate" />
-      <input type="text" name="guests" />
-      <input type="text" name="transferTier" />
-      <input type="text" name="pickupLocation" />
-      <input type="text" name="dropoffLocation" />
-      <input type="text" name="flightNumber" />
-      <input type="text" name="transferTime" />
-      <input type="text" name="budget" />
-      <input type="text" name="accommodationLevel" />
-      <input type="text" name="paymentPreference" />
-      <textarea name="message"></textarea>
-      <input type="text" name="source" />
-      <textarea name="plannerDraft"></textarea>
-      <input type="text" name="bot-field" />
     </form>
 
     <script type="module" src="/src/main.jsx"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,9 +16,30 @@
 # (e.g. planner.mjs -> path: '/api/planner'), which takes precedence over the SPA
 # catch-all below — no per-function rewrite is needed here.
 
-# SPA fallback. Static files in dist/ (sitemap.xml, robots.txt, assets) are served
-# ahead of this catch-all, so only unmatched app routes fall through to index.html.
 [[redirects]]
-  from = "/*"
+  from = "https://destinationparadisezanzibar.netlify.app/*"
+  to = "https://yournexttriptoparadise.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/book-now"
   to = "/index.html"
   status = 200
+
+[[redirects]]
+  from = "/booking"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/trip-planner"
+  to = "/index.html"
+  status = 200
+
+# SPA fallback. Static files in dist/ (sitemap.xml, robots.txt, assets) are served
+# ahead of this catch-all, so unknown URLs return the prerendered 404 page.
+[[redirects]]
+  from = "/*"
+  to = "/404.html"
+  status = 404

--- a/netlify/functions/_shared.mjs
+++ b/netlify/functions/_shared.mjs
@@ -16,6 +16,14 @@ export const escapeHtml = (text) =>
 
 export const trimField = (value, max = 400) => String(value || '').trim().slice(0, max);
 
+export function normalizeLanguage(value) {
+  const lang = String(value || '').slice(0, 2).toLowerCase();
+  return ['de', 'pl'].includes(lang) ? lang : 'en';
+}
+
+export const sanitizeHeaderLine = (value, max = 400) =>
+  trimField(value, max).replace(/[\r\n]+/g, ' ').replace(/\s{2,}/g, ' ');
+
 export const errorResponse = (message, status = 400) =>
   Response.json({ ok: false, error: message }, { status });
 
@@ -53,13 +61,22 @@ export function createRateLimiter({ windowMs, max }) {
 }
 
 // ---- Resend ----
-export function createResendSender(apiKey) {
+export function fetchWithTimeout(url, options = {}, timeoutMs = 10_000) {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+
+  return fetch(url, { ...options, signal });
+}
+
+export function createResendSender(apiKey, timeoutMs = 10_000) {
   return (payload) =>
-    fetch('https://api.resend.com/emails', {
+    fetchWithTimeout('https://api.resend.com/emails', {
       method: 'POST',
       headers: { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' },
       body: JSON.stringify(payload),
-    });
+    }, timeoutMs);
 }
 
 // ---- Email validation (syntax + DNS deliverability) ----

--- a/netlify/functions/booking-send.mjs
+++ b/netlify/functions/booking-send.mjs
@@ -5,7 +5,9 @@ import {
   createResendSender,
   errorResponse,
   escapeHtml,
+  normalizeLanguage,
   rateLimitKey,
+  sanitizeHeaderLine,
   trimField,
   validateEmailAddress,
 } from './_shared.mjs';
@@ -25,6 +27,87 @@ const MAX_MESSAGE = 8_000;
 const MAX_DRAFT = 8_000;
 
 const checkRateLimit = createRateLimiter({ windowMs: 10 * 60_000, max: 4 });
+
+const BOOKING_GUEST_COPY = {
+  en: {
+    subject: 'We got your booking request — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — your request is in!`,
+    intro: "We got your booking request and our team is on it. You'll hear back within a day with availability, a final price, and (if you asked for it) a secure online payment link.",
+    copyNote: "Here's a copy of what you sent us, just for your records.",
+    tripRequest: 'Trip request',
+    noteHeading: 'Your note',
+    draftHeading: 'AI planner draft',
+    needSooner: 'Need us sooner? Just reply to this email,',
+    reachUs: 'or reach us on:',
+    labels: {
+      service: 'Service',
+      product: 'Product',
+      estimatedPrice: 'Estimated price',
+      dates: 'Dates',
+      guests: 'Guests',
+      transferTier: 'Transfer tier',
+      pickup: 'Pickup',
+      dropoff: 'Drop-off',
+      flight: 'Flight / ferry',
+      pickupTime: 'Pickup time',
+      budget: 'Budget',
+      comfort: 'Comfort',
+      payment: 'Payment',
+    },
+  },
+  de: {
+    subject: 'Wir haben deine Buchungsanfrage erhalten — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — deine Anfrage ist angekommen!`,
+    intro: 'Wir haben deine Buchungsanfrage erhalten und unser Team kümmert sich darum. Du hörst innerhalb eines Tages von uns mit Verfügbarkeit, finalem Preis und, falls gewünscht, einem sicheren Zahlungslink.',
+    copyNote: 'Hier ist eine Kopie deiner Angaben für deine Unterlagen.',
+    tripRequest: 'Reiseanfrage',
+    noteHeading: 'Deine Nachricht',
+    draftHeading: 'KI-Planer-Entwurf',
+    needSooner: 'Soll es schneller gehen? Antworte einfach auf diese E-Mail,',
+    reachUs: 'oder kontaktiere uns über:',
+    labels: {
+      service: 'Leistung',
+      product: 'Produkt',
+      estimatedPrice: 'Geschätzter Preis',
+      dates: 'Daten',
+      guests: 'Gäste',
+      transferTier: 'Transferklasse',
+      pickup: 'Abholung',
+      dropoff: 'Ziel',
+      flight: 'Flug / Fähre',
+      pickupTime: 'Abholzeit',
+      budget: 'Budget',
+      comfort: 'Komfort',
+      payment: 'Zahlung',
+    },
+  },
+  pl: {
+    subject: 'Otrzymaliśmy Twoje zapytanie rezerwacyjne — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — Twoje zapytanie jest u nas!`,
+    intro: 'Otrzymaliśmy Twoje zapytanie rezerwacyjne i nasz zespół już się nim zajmuje. Odpowiemy w ciągu jednego dnia z dostępnością, finalną ceną oraz, jeśli prosisz o płatność online, bezpiecznym linkiem.',
+    copyNote: 'Poniżej znajdziesz kopię przesłanych informacji.',
+    tripRequest: 'Zapytanie o podróż',
+    noteHeading: 'Twoja wiadomość',
+    draftHeading: 'Szkic z planera AI',
+    needSooner: 'Potrzebujesz nas szybciej? Po prostu odpowiedz na ten e-mail,',
+    reachUs: 'albo skontaktuj się z nami przez:',
+    labels: {
+      service: 'Usługa',
+      product: 'Produkt',
+      estimatedPrice: 'Szacowana cena',
+      dates: 'Daty',
+      guests: 'Goście',
+      transferTier: 'Klasa transferu',
+      pickup: 'Odbiór',
+      dropoff: 'Miejsce docelowe',
+      flight: 'Lot / prom',
+      pickupTime: 'Godzina odbioru',
+      budget: 'Budżet',
+      comfort: 'Komfort',
+      payment: 'Płatność',
+    },
+  },
+};
 
 function row(label, value) {
   if (!value) return '';
@@ -62,14 +145,14 @@ export default async (req) => {
     return Response.json({ ok: true });
   }
 
-  const name = trimField(body?.name, 120);
+  const name = sanitizeHeaderLine(body?.name, 120);
   let email = trimField(body?.email, 200);
   const phone = trimField(body?.phone, 60);
   const whatsapp = trimField(body?.whatsapp, 60);
-  const serviceType = trimField(body?.serviceType, 40);
-  const product = trimField(body?.product, 200);
-  const productLabel = trimField(body?.productLabel, 200);
-  const estimatedPrice = trimField(body?.estimatedPrice, 200);
+  const serviceType = sanitizeHeaderLine(body?.serviceType, 40);
+  const product = sanitizeHeaderLine(body?.product, 200);
+  const productLabel = sanitizeHeaderLine(body?.productLabel, 200);
+  const estimatedPrice = sanitizeHeaderLine(body?.estimatedPrice, 200);
   const startDate = trimField(body?.startDate, 40);
   const endDate = trimField(body?.endDate, 40);
   const guests = trimField(body?.guests, 40);
@@ -84,6 +167,9 @@ export default async (req) => {
   const message = String(body?.message || '').trim().slice(0, MAX_MESSAGE);
   const source = trimField(body?.source, 40) || 'booking';
   const plannerDraft = String(body?.plannerDraft || '').trim().slice(0, MAX_DRAFT);
+  const lang = normalizeLanguage(body?.lang);
+  const guestCopy = BOOKING_GUEST_COPY[lang];
+  const firstName = name.split(' ')[0];
 
   if (!name) return errorResponse('Please share your name.');
   const emailValidation = await validateEmailAddress(email);
@@ -127,6 +213,22 @@ export default async (req) => {
     row('Payment', paymentPreference),
   ].join('');
 
+  const guestSummaryRows = [
+    row(guestCopy.labels.service, serviceType),
+    row(guestCopy.labels.product, productLine),
+    row(guestCopy.labels.estimatedPrice, estimatedPrice),
+    row(guestCopy.labels.dates, datesLine),
+    row(guestCopy.labels.guests, guests),
+    row(guestCopy.labels.transferTier, transferTier),
+    row(guestCopy.labels.pickup, pickupLocation),
+    row(guestCopy.labels.dropoff, dropoffLocation),
+    row(guestCopy.labels.flight, flightNumber),
+    row(guestCopy.labels.pickupTime, transferTime),
+    row(guestCopy.labels.budget, budget),
+    row(guestCopy.labels.comfort, accommodationLevel),
+    row(guestCopy.labels.payment, paymentPreference),
+  ].join('');
+
   const contactRows = [
     row('Name', name),
     row('Email', email),
@@ -141,6 +243,14 @@ export default async (req) => {
 
   const draftBlock = plannerDraft
     ? `<h2 style="margin:24px 0 10px 0;font-size:13px;color:#4a6c82;font-weight:700;letter-spacing:.06em;text-transform:uppercase;">AI planner draft</h2>
+       <div style="padding:14px 16px;background:#FFF6F4;border-left:3px solid #FF6F61;border-radius:0 6px 6px 0;font-size:13px;line-height:1.6;color:#1a1a1a;white-space:pre-wrap;">${escapeHtml(plannerDraft)}</div>`
+    : '';
+  const guestMessageBlock = message
+    ? `<h2 style="margin:24px 0 10px 0;font-size:13px;color:#4a6c82;font-weight:700;letter-spacing:.06em;text-transform:uppercase;">${escapeHtml(guestCopy.noteHeading)}</h2>
+       <div style="padding:14px 16px;background:#fafbfd;border-left:3px solid #1A4D6E;border-radius:0 6px 6px 0;font-size:14px;line-height:1.55;color:#1a1a1a;white-space:pre-wrap;">${escapeHtml(message)}</div>`
+    : '';
+  const guestDraftBlock = plannerDraft
+    ? `<h2 style="margin:24px 0 10px 0;font-size:13px;color:#4a6c82;font-weight:700;letter-spacing:.06em;text-transform:uppercase;">${escapeHtml(guestCopy.draftHeading)}</h2>
        <div style="padding:14px 16px;background:#FFF6F4;border-left:3px solid #FF6F61;border-radius:0 6px 6px 0;font-size:13px;line-height:1.6;color:#1a1a1a;white-space:pre-wrap;">${escapeHtml(plannerDraft)}</div>`
     : '';
 
@@ -190,22 +300,22 @@ export default async (req) => {
     'Reply directly to this email to reach the guest.',
   ].filter(Boolean).join('\n');
 
-  const guestSubject = `We got your booking request — Destination Paradise`;
+  const guestSubject = guestCopy.subject;
   const guestHtml = `<!doctype html><html><body style="margin:0;padding:24px;background:#f4f7fa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
     <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:14px;overflow:hidden;box-shadow:0 4px 14px rgba(26,77,110,0.08);">
       <div style="padding:22px 24px;background:linear-gradient(120deg,#1A4D6E 0%,#FF6F61 100%);color:#fff;">
         <div style="font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;opacity:.85;">Destination Paradise</div>
-        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">Asante, ${escapeHtml(name.split(' ')[0])} — your request is in!</h1>
+        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">${escapeHtml(guestCopy.heading(firstName))}</h1>
       </div>
       <div style="padding:24px;">
-        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">We got your booking request and our team is on it. You'll hear back within a day with availability, a final price, and (if you asked for it) a secure online payment link.</p>
-        <p style="margin:0 0 18px 0;font-size:14px;color:#4a6c82;line-height:1.6;">Here's a copy of what you sent us, just for your records.</p>
-        <h2 style="margin:18px 0 10px 0;font-size:13px;color:#4a6c82;font-weight:700;letter-spacing:.06em;text-transform:uppercase;">Trip request</h2>
-        <table cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;background:#fafbfd;border-radius:8px;overflow:hidden;margin-bottom:18px;">${summaryRows}</table>
-        ${messageBlock}
-        ${draftBlock}
+        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">${escapeHtml(guestCopy.intro)}</p>
+        <p style="margin:0 0 18px 0;font-size:14px;color:#4a6c82;line-height:1.6;">${escapeHtml(guestCopy.copyNote)}</p>
+        <h2 style="margin:18px 0 10px 0;font-size:13px;color:#4a6c82;font-weight:700;letter-spacing:.06em;text-transform:uppercase;">${escapeHtml(guestCopy.tripRequest)}</h2>
+        <table cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;background:#fafbfd;border-radius:8px;overflow:hidden;margin-bottom:18px;">${guestSummaryRows}</table>
+        ${guestMessageBlock}
+        ${guestDraftBlock}
         <div style="margin:28px 0 0 0;padding:16px 18px;background:#fafbfd;border-radius:10px;font-size:13px;color:#4a6c82;line-height:1.6;">
-          <strong style="color:#1A4D6E;">Need us sooner? Just reply to this email,</strong> or reach us on:<br>
+          <strong style="color:#1A4D6E;">${escapeHtml(guestCopy.needSooner)}</strong> ${escapeHtml(guestCopy.reachUs)}<br>
           WhatsApp: <a href="https://wa.me/255768779517" style="color:#1A4D6E;">+255 768 779 517</a><br>
           Email: info@yournexttriptoparadise.com
         </div>
@@ -214,28 +324,28 @@ export default async (req) => {
   </body></html>`;
 
   const guestText = [
-    `Asante, ${name.split(' ')[0]} — your booking request is in.`,
+    guestCopy.heading(firstName),
     '',
-    "We got it and our team is on it. You'll hear back within a day with availability, a final price, and (if requested) a secure payment link.",
+    guestCopy.intro,
     '',
-    'Here is a copy of your request:',
-    `Service: ${serviceType}`,
-    `Product: ${productLine}`,
-    estimatedPrice ? `Estimated price: ${estimatedPrice}` : '',
-    `Dates: ${datesLine}`,
-    guests ? `Guests: ${guests}` : '',
-    transferTier ? `Transfer tier: ${transferTier}` : '',
-    pickupLocation ? `Pickup: ${pickupLocation}` : '',
-    dropoffLocation ? `Drop-off: ${dropoffLocation}` : '',
-    flightNumber ? `Flight / ferry: ${flightNumber}` : '',
-    transferTime ? `Pickup time: ${transferTime}` : '',
-    budget ? `Budget: ${budget}` : '',
-    accommodationLevel ? `Comfort: ${accommodationLevel}` : '',
-    paymentPreference ? `Payment: ${paymentPreference}` : '',
+    guestCopy.copyNote,
+    `${guestCopy.labels.service}: ${serviceType}`,
+    `${guestCopy.labels.product}: ${productLine}`,
+    estimatedPrice ? `${guestCopy.labels.estimatedPrice}: ${estimatedPrice}` : '',
+    `${guestCopy.labels.dates}: ${datesLine}`,
+    guests ? `${guestCopy.labels.guests}: ${guests}` : '',
+    transferTier ? `${guestCopy.labels.transferTier}: ${transferTier}` : '',
+    pickupLocation ? `${guestCopy.labels.pickup}: ${pickupLocation}` : '',
+    dropoffLocation ? `${guestCopy.labels.dropoff}: ${dropoffLocation}` : '',
+    flightNumber ? `${guestCopy.labels.flight}: ${flightNumber}` : '',
+    transferTime ? `${guestCopy.labels.pickupTime}: ${transferTime}` : '',
+    budget ? `${guestCopy.labels.budget}: ${budget}` : '',
+    accommodationLevel ? `${guestCopy.labels.comfort}: ${accommodationLevel}` : '',
+    paymentPreference ? `${guestCopy.labels.payment}: ${paymentPreference}` : '',
     '',
-    message ? `Your note:\n${message}` : '',
+    message ? `${guestCopy.noteHeading}:\n${message}` : '',
     '',
-    'Need us sooner? Just reply to this email, or:',
+    `${guestCopy.needSooner} ${guestCopy.reachUs}`,
     'WhatsApp: +255 768 779 517',
     'Email: info@yournexttriptoparadise.com',
   ].filter(Boolean).join('\n');

--- a/netlify/functions/contact-send.mjs
+++ b/netlify/functions/contact-send.mjs
@@ -5,7 +5,9 @@ import {
   createResendSender,
   errorResponse,
   escapeHtml,
+  normalizeLanguage,
   rateLimitKey,
+  sanitizeHeaderLine,
   validateEmailAddress,
 } from './_shared.mjs';
 import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
@@ -23,6 +25,30 @@ const MAX_SUBJECT = 200;
 const MAX_MESSAGE = 8_000;
 
 const checkRateLimit = createRateLimiter({ windowMs: 10 * 60_000, max: 4 });
+
+const CONTACT_GUEST_COPY = {
+  en: {
+    subject: 'We got your message — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — we got your message.`,
+    intro: 'Our team will read it and reply within a day. Below is the copy of what you sent us, just for your records.',
+    subjectLabel: 'Subject',
+    needSooner: 'Need us sooner?',
+  },
+  de: {
+    subject: 'Wir haben deine Nachricht erhalten — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — wir haben deine Nachricht erhalten.`,
+    intro: 'Unser Team liest sie und antwortet innerhalb eines Tages. Unten findest du eine Kopie deiner Nachricht für deine Unterlagen.',
+    subjectLabel: 'Betreff',
+    needSooner: 'Soll es schneller gehen?',
+  },
+  pl: {
+    subject: 'Otrzymaliśmy Twoją wiadomość — Destination Paradise',
+    heading: (firstName) => `Asante, ${firstName} — mamy Twoją wiadomość.`,
+    intro: 'Nasz zespół ją przeczyta i odpowie w ciągu jednego dnia. Poniżej znajdziesz kopię swojej wiadomości.',
+    subjectLabel: 'Temat',
+    needSooner: 'Potrzebujesz nas szybciej?',
+  },
+};
 
 export default async (req) => {
   if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
@@ -63,10 +89,13 @@ export default async (req) => {
     return Response.json({ ok: true });
   }
 
-  const name = String(body?.name || '').trim().slice(0, MAX_NAME);
+  const name = sanitizeHeaderLine(body?.name, MAX_NAME);
   let email = String(body?.email || '').trim().slice(0, MAX_EMAIL);
-  const subject = String(body?.subject || '').trim().slice(0, MAX_SUBJECT);
+  const subject = sanitizeHeaderLine(body?.subject, MAX_SUBJECT);
   const message = String(body?.message || '').trim().slice(0, MAX_MESSAGE);
+  const lang = normalizeLanguage(body?.lang);
+  const guestCopy = CONTACT_GUEST_COPY[lang];
+  const firstName = name.split(' ')[0];
 
   if (!name) return errorResponse('Please share your name.');
   if (!message) return errorResponse('Please add a short message so the team knows what you need.');
@@ -75,7 +104,7 @@ export default async (req) => {
   email = emailValidation.email;
 
   const teamSubject = subject ? `Contact form — ${subject}` : `Contact form — message from ${name}`;
-  const guestSubject = `We got your message — Destination Paradise`;
+  const guestSubject = guestCopy.subject;
   const messageBlockHtml = `<div style="padding:14px 16px;background:#fafbfd;border-left:3px solid #1A4D6E;border-radius:6px;font-size:14px;line-height:1.55;color:#1a1a1a;white-space:pre-wrap;">${escapeHtml(message)}</div>`;
 
   const teamHtml = `<!doctype html><html><body style="margin:0;padding:24px;background:#f4f7fa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
@@ -115,14 +144,14 @@ export default async (req) => {
     <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:14px;overflow:hidden;box-shadow:0 4px 14px rgba(26,77,110,0.08);">
       <div style="padding:22px 24px;background:linear-gradient(120deg,#1A4D6E 0%,#215A7C 100%);color:#fff;">
         <div style="font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;opacity:.85;">Destination Paradise</div>
-        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">Asante, ${escapeHtml(name.split(' ')[0])} — we got your message.</h1>
+        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">${escapeHtml(guestCopy.heading(firstName))}</h1>
       </div>
       <div style="padding:24px;">
-        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">Our team will read it and reply within a day. Below is the copy of what you sent us, just for your records.</p>
-        ${subject ? `<p style="margin:0 0 12px 0;font-size:13px;color:#4a6c82;"><strong style="color:#1A4D6E;">Subject:</strong> ${escapeHtml(subject)}</p>` : ''}
+        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">${escapeHtml(guestCopy.intro)}</p>
+        ${subject ? `<p style="margin:0 0 12px 0;font-size:13px;color:#4a6c82;"><strong style="color:#1A4D6E;">${escapeHtml(guestCopy.subjectLabel)}:</strong> ${escapeHtml(subject)}</p>` : ''}
         ${messageBlockHtml}
         <div style="margin:28px 0 0 0;padding:16px 18px;background:#fafbfd;border-radius:10px;font-size:13px;color:#4a6c82;line-height:1.6;">
-          <strong style="color:#1A4D6E;">Need us sooner?</strong><br>
+          <strong style="color:#1A4D6E;">${escapeHtml(guestCopy.needSooner)}</strong><br>
           WhatsApp: <a href="https://wa.me/255768779517" style="color:#1A4D6E;">+255 768 779 517</a><br>
           Email: info@yournexttriptoparadise.com
         </div>
@@ -131,15 +160,15 @@ export default async (req) => {
   </body></html>`;
 
   const guestText = [
-    `Asante, ${name.split(' ')[0]} — we got your message.`,
+    guestCopy.heading(firstName),
     '',
-    'Our team will read it and reply within a day. Below is the copy of what you sent us.',
+    guestCopy.intro,
     '',
-    subject ? `Subject: ${subject}` : '',
+    subject ? `${guestCopy.subjectLabel}: ${subject}` : '',
     '',
     message,
     '',
-    'Need us sooner?',
+    guestCopy.needSooner,
     'WhatsApp: +255 768 779 517',
     'Email: info@yournexttriptoparadise.com',
   ].filter(Boolean).join('\n');

--- a/netlify/functions/planner-send.mjs
+++ b/netlify/functions/planner-send.mjs
@@ -6,8 +6,10 @@ import {
   createResendSender,
   errorResponse,
   escapeHtml,
+  normalizeLanguage,
   normalizeEmailAddress,
   rateLimitKey,
+  sanitizeHeaderLine,
   validateEmailAddress,
 } from './_shared.mjs';
 import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
@@ -23,6 +25,39 @@ const MAX_HISTORY_MESSAGES = 40;
 const MAX_MESSAGE_CHARS = 4_000;
 
 const checkRateLimit = createRateLimiter({ windowMs: 10 * 60_000, max: 4 });
+
+const PLANNER_GUEST_COPY = {
+  en: {
+    draftSubject: 'Your trip plan from Destination Paradise',
+    updateSubject: 'Your trip plan update — Destination Paradise',
+    draftHeading: (firstName) => `Karibu, ${firstName} — your draft is in!`,
+    updateHeading: (firstName) => `Got the update, ${firstName}!`,
+    draftIntro: "Asante for using our AI planner. Here's a copy of the draft you built with us — keep it handy for reference.",
+    updateIntro: "We've sent your revised plan to the team. Here's the latest version for your records.",
+    reviewLine: "Our team is reviewing it now and will reply within a day with real availability and a final price. If you'd like to add anything in the meantime, just reply to this email.",
+    needSooner: 'Need us sooner?',
+  },
+  de: {
+    draftSubject: 'Dein Reiseplan von Destination Paradise',
+    updateSubject: 'Aktualisierung deines Reiseplans — Destination Paradise',
+    draftHeading: (firstName) => `Karibu, ${firstName} — dein Entwurf ist angekommen!`,
+    updateHeading: (firstName) => `Update erhalten, ${firstName}!`,
+    draftIntro: 'Asante, dass du unseren KI-Planer genutzt hast. Hier ist eine Kopie deines Entwurfs für deine Unterlagen.',
+    updateIntro: 'Wir haben deinen aktualisierten Plan ans Team geschickt. Hier ist die neueste Version für deine Unterlagen.',
+    reviewLine: 'Unser Team prüft ihn jetzt und antwortet innerhalb eines Tages mit echter Verfügbarkeit und finalem Preis. Wenn du in der Zwischenzeit etwas ergänzen möchtest, antworte einfach auf diese E-Mail.',
+    needSooner: 'Soll es schneller gehen?',
+  },
+  pl: {
+    draftSubject: 'Twój plan podróży od Destination Paradise',
+    updateSubject: 'Aktualizacja Twojego planu podróży — Destination Paradise',
+    draftHeading: (firstName) => `Karibu, ${firstName} — Twój szkic jest gotowy!`,
+    updateHeading: (firstName) => `Mamy aktualizację, ${firstName}!`,
+    draftIntro: 'Asante za skorzystanie z naszego planera AI. Poniżej znajdziesz kopię szkicu przygotowanego z nami.',
+    updateIntro: 'Wysłaliśmy zaktualizowany plan do zespołu. Oto najnowsza wersja do Twoich zapisów.',
+    reviewLine: 'Nasz zespół teraz go sprawdza i odpowie w ciągu jednego dnia z realną dostępnością oraz finalną ceną. Jeśli chcesz coś dodać, po prostu odpowiedz na ten e-mail.',
+    needSooner: 'Potrzebujesz nas szybciej?',
+  },
+};
 
 function stripMarkdown(text) {
   return text
@@ -250,9 +285,9 @@ function validateBody(body) {
   if (!body || typeof body !== 'object') return { ok: false, error: 'Invalid request body.' };
 
   const rawContact = (body.contact && typeof body.contact === 'object') ? body.contact : {};
-  let name = (rawContact.name || '').toString().trim().slice(0, 120);
+  let name = sanitizeHeaderLine(rawContact.name, 120);
   let email = (rawContact.email || '').toString().trim().slice(0, 200);
-  let phone = (rawContact.phone || '').toString().trim().slice(0, 60);
+  let phone = sanitizeHeaderLine(rawContact.phone, 60);
 
   if (!Array.isArray(body.history)) return { ok: false, error: 'Missing chat history.' };
 
@@ -301,6 +336,11 @@ export default async (req) => {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     console.error('planner-send: missing RESEND_API_KEY');
+    await captureFunctionMessage('Missing RESEND_API_KEY', {
+      functionName: FUNCTION_NAME,
+      req,
+      level: 'warning',
+    });
     return errorResponse('The team mailer is not configured yet. Please try the contact form, or message us on WhatsApp.', 503);
   }
 
@@ -311,6 +351,12 @@ export default async (req) => {
     return errorResponse('Could not read request body.');
   }
 
+  if (body && typeof body === 'object' && body.botField) {
+    return Response.json({ ok: true });
+  }
+
+  const lang = normalizeLanguage(body?.lang);
+  const guestCopy = PLANNER_GUEST_COPY[lang];
   const validated = validateBody(body);
   if (!validated.ok) return errorResponse(validated.error);
 
@@ -327,9 +373,7 @@ export default async (req) => {
   const teamSubject = isUpdate
     ? `Planner update #${updateCount} from ${contact.name}`
     : `New planner draft from ${contact.name}`;
-  const guestSubject = isUpdate
-    ? `Your trip plan update — Destination Paradise`
-    : `Your trip plan from Destination Paradise`;
+  const guestSubject = isUpdate ? guestCopy.updateSubject : guestCopy.draftSubject;
   const teamBodyHtml = isUpdate
     ? `${renderUpdateSummaryHtml(updateCount, contact, messages)}${hasStructuredHandoff(handoff) ? renderHandoffHtml(handoff) : ''}`
     : `${renderHandoffHtml(handoff)}
@@ -376,14 +420,14 @@ export default async (req) => {
     <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:14px;overflow:hidden;box-shadow:0 4px 14px rgba(26,77,110,0.08);">
       <div style="padding:22px 24px;background:linear-gradient(120deg,#1A4D6E 0%,#FF6F61 100%);color:#fff;">
         <div style="font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;opacity:.85;">Destination Paradise</div>
-        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">${isUpdate ? `Got the update, ${escapeHtml(contact.name.split(' ')[0])}!` : `Karibu, ${escapeHtml(contact.name.split(' ')[0])} — your draft is in!`}</h1>
+        <h1 style="margin:6px 0 0 0;font-size:22px;font-weight:700;">${escapeHtml(isUpdate ? guestCopy.updateHeading(contact.name.split(' ')[0]) : guestCopy.draftHeading(contact.name.split(' ')[0]))}</h1>
       </div>
       <div style="padding:24px;">
-        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">${isUpdate ? "We've sent your revised plan to the team. Here's the latest version for your records." : "Asante for using our AI planner. Here's a copy of the draft you built with us — keep it handy for reference."}</p>
-        <p style="margin:0 0 18px 0;font-size:14px;color:#4a6c82;line-height:1.6;">Our team is reviewing it now and will reply within a day with real availability and a final price. If you'd like to add anything in the meantime, just reply to this email.</p>
+        <p style="margin:0 0 14px 0;font-size:15px;color:#1a1a1a;line-height:1.6;">${escapeHtml(isUpdate ? guestCopy.updateIntro : guestCopy.draftIntro)}</p>
+        <p style="margin:0 0 18px 0;font-size:14px;color:#4a6c82;line-height:1.6;">${escapeHtml(guestCopy.reviewLine)}</p>
         ${renderHandoffHtml(handoff)}
         <div style="margin:28px 0 0 0;padding:16px 18px;background:#fafbfd;border-radius:10px;font-size:13px;color:#4a6c82;line-height:1.6;">
-          <strong style="color:#1A4D6E;">Need us sooner?</strong><br>
+          <strong style="color:#1A4D6E;">${escapeHtml(guestCopy.needSooner)}</strong><br>
           WhatsApp: <a href="https://wa.me/255768779517" style="color:#1A4D6E;">+255 768 779 517</a><br>
           Email: info@yournexttriptoparadise.com
         </div>
@@ -392,15 +436,14 @@ export default async (req) => {
   </body></html>`;
 
   const guestText = [
-    `Karibu, ${contact.name.split(' ')[0]} — your trip draft is in!`,
+    isUpdate ? guestCopy.updateHeading(contact.name.split(' ')[0]) : guestCopy.draftHeading(contact.name.split(' ')[0]),
     '',
-    "Asante for using our AI planner. Here's a copy of the draft you built with us.",
-    "Our team is reviewing it now and will reply within a day with real availability and a final price.",
-    'If you want to add anything in the meantime, just reply to this email.',
+    isUpdate ? guestCopy.updateIntro : guestCopy.draftIntro,
+    guestCopy.reviewLine,
     '',
     renderHandoffPlain(handoff),
     '',
-    'Need us sooner?',
+    guestCopy.needSooner,
     'WhatsApp: +255 768 779 517',
     'Email: info@yournexttriptoparadise.com',
   ].filter(Boolean).join('\n');

--- a/netlify/functions/planner.mjs
+++ b/netlify/functions/planner.mjs
@@ -7,7 +7,7 @@ import { EXCURSIONS } from '../../src/data/excursionsData.js';
 import { destinationParadisePackages } from '../../src/data/destinationParadisePackages.js';
 import { nextLevelSafariProducts } from '../../src/data/nextLevelSafariProducts.js';
 import { destinationParadiseSafariPricing } from '../../src/data/safariPricing.js';
-import { createRateLimiter, rateLimitKey } from './_shared.mjs';
+import { createRateLimiter, fetchWithTimeout, rateLimitKey } from './_shared.mjs';
 import { captureFunctionException, captureFunctionMessage } from './_sentry.mjs';
 
 const FUNCTION_NAME = 'planner';
@@ -16,6 +16,11 @@ const MAX_REQUEST_BYTES = 20_000;
 const MAX_HISTORY_MESSAGES = 16;
 const MAX_MESSAGE_CHARS = 1_200;
 const MAX_TOTAL_CHARS = 6_000;
+const LANGUAGE_NAMES = {
+  de: 'German',
+  en: 'English',
+  pl: 'Polish',
+};
 
 // Per-IP rate limit. In-memory: resets on cold start and isn't shared across
 // concurrent function instances, so it's a defense against burst abuse from a
@@ -140,6 +145,12 @@ Use the listed products as starting points when they fit. Never invent specific 
 const plannerError = (reply, status = 400) =>
   Response.json({ reply }, { status });
 
+function languageInstruction(rawLang) {
+  const lang = String(rawLang || '').slice(0, 2).toLowerCase();
+  const language = LANGUAGE_NAMES[lang] || LANGUAGE_NAMES.en;
+  return `Language:\n- Reply in ${language}, unless the guest clearly writes in another language. Keep the final handoff labels exactly as specified so the email parser can read them.`;
+}
+
 export function validateHistory(rawHistory) {
   if (!Array.isArray(rawHistory)) {
     return { ok: false, reply: 'Please send the planner history as a list of messages.' };
@@ -230,9 +241,10 @@ export default async (req) => {
   if (messages.length === 0 || messages[messages.length - 1].role !== 'user') {
     return Response.json({ reply: 'Tell me a bit about the trip you have in mind?' }, { status: 200 });
   }
+  const system = `${PLANNER_SYSTEM}\n\n${languageInstruction(body.lang)}`;
 
   try {
-    const r = await fetch('https://api.anthropic.com/v1/messages', {
+    const r = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -242,10 +254,10 @@ export default async (req) => {
       body: JSON.stringify({
         model: PLANNER_MODEL,
         max_tokens: 800,
-        system: PLANNER_SYSTEM,
+        system,
         messages,
       }),
-    });
+    }, 12_000);
 
     if (!r.ok) {
       const errText = await r.text().catch(() => '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
         "vite": "^8.0.13",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "3.2.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "node scripts/build-image-manifest.mjs && node scripts/build-sitemap.mjs && vite build && node scripts/prerender.mjs",

--- a/public/_headers
+++ b/public/_headers
@@ -6,5 +6,21 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Content-Security-Policy-Report-Only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: https://*.basemaps.cartocdn.com https://www.google-analytics.com https://www.googletagmanager.com; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://api.open-meteo.com https://marine-api.open-meteo.com https://open.er-api.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; worker-src 'self'
 
-/assets/*
+# Non-overlapping cache rules (Netlify merges headers from every matching rule,
+# so a broad /assets/* rule would double up Cache-Control on the overrides below).
+# :file matches a single path segment — i.e. Vite's hashed build output directly
+# under /assets/ — which is the only content that is safe to cache forever.
+/assets/:file
+  Cache-Control: public, max-age=31536000, immutable
+
+# Unhashed static files (replaced in place, e.g. optimized re-exports): short
+# max-age + stale-while-revalidate so returning visitors pick up replacements.
+/assets/images/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/assets/brand/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+# Font files are effectively versioned by filename; safe to pin.
+/assets/fonts/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://destinationparadisezanzibar.netlify.app/sitemap.xml
+Sitemap: https://yournexttriptoparadise.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,734 +1,734 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/retreats</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/retreats/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/transfers</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/transfers/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/explore</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/explore/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/trip-planner</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/trip-planner/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/book-now</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/book-now/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/aboutus</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/aboutus/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/cookies-policy</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/cookies-policy/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/privacy-policy</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/privacy-policy/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/terms-of-service</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/terms-of-service/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/spice-tour</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/spice-tour/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/stone-town</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/stone-town/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/prison-island</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/prison-island/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/jozani</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/jozani/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/dolphins</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/dolphins/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/sunset-rock</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/sunset-rock/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/snorkeling-tour</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/snorkeling-tour/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/village-tour</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/village-tour/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/mnemba</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/mnemba/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/safari-blue</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/safari-blue/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/fishing-kizimkazi</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/fishing-kizimkazi/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/local-fishing</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/local-fishing/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/mangrove</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/mangrove/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/sandbank-picnic</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/sandbank-picnic/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/cave</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/cave/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/north-nungwi</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/north-nungwi/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/cooking-coffee</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/cooking-coffee/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/street-food</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/street-food/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/healer-herbal</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/healer-herbal/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/village-workshop</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/village-workshop/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/private-sunset-dhow-dinner</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/private-sunset-dhow-dinner/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/nakupenda</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/nakupenda/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/mangrove-kayak</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/mangrove-kayak/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/chumbe</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/chumbe/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/seaweed-coop</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/seaweed-coop/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/turtle-conservation</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/turtle-conservation/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/butterfly-center</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/butterfly-center/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/stargazing</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/stargazing/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/organic-spice</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/organic-spice/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/turtle-nesting</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/turtle-nesting/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/kitesurfing</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/kitesurfing/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/horse-riding</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/horse-riding/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/quad-bike</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/quad-bike/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/jet-ski</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/jet-ski/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/parasailing</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/parasailing/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/skydive</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/skydive/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/dhow-building</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/dhow-building/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/advanced-diving</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/advanced-diving/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/transparent-kayak-sup</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/transparent-kayak-sup/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/ocean-sand-combo</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/ocean-sand-combo/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/historical-ruins</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/historical-ruins/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/hidden-alleys</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/hidden-alleys/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/persian-baths-sultan</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/persian-baths-sultan/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/mangapwani-cave</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/mangapwani-cave/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/dhow-heritage</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/dhow-heritage/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/sauti-busara</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/sauti-busara/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/ziff</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/ziff/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/water-sports-festival</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/water-sports-festival/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/private-vip-island</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/private-vip-island/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/wellness-yoga</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/wellness-yoga/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/mafia-whale-shark</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/mafia-whale-shark/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/forest-spice</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/full-stone-town-day</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/forest-spice/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/south-coast-nature</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/full-stone-town-day/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/tortoises-alleys</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/south-coast-nature/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/reef-mangrove</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/tortoises-alleys/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/excursions/combinations/north-coast-all-day</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/reef-mangrove/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/ngorongoro-tarangire</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/serengeti-migration</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/nyerere-selous</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/ruaha-big-cat</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/mahale-chimp</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/katavi-frontier</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/tarangire-ngorongoro-short</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/ngorongoro-overnight</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/tarangire-day-trip</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/lake-natron-expedition</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/olduvai-gorge</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/maasai-cultural-expedition</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/materuni-waterfalls-coffee</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/kilimanjaro-day-hike</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/luxury-honeymoon-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/private-photography-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/women-only-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/family-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/mikumi-flyin</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/saadani-beach-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/udzungwa-hiking-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/private-helicopter-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/presidential-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/chimpanzee-trekking</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/birdwatching-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/walking-bushcraft-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/migration-calving-safari</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/bush-to-beach</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/east-africa-grand-tour</loc>
-    <lastmod>2026-06-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/classic-game-drive</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/excursions/combinations/north-coast-all-day/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/fly-in</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/ngorongoro-tarangire/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/serengeti-migration/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/nyerere-selous/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/ruaha-big-cat/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/mahale-chimp/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/katavi-frontier/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/tarangire-ngorongoro-short/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/ngorongoro-overnight/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/tarangire-day-trip/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/lake-natron-expedition/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/olduvai-gorge/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/maasai-cultural-expedition/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/materuni-waterfalls-coffee/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/kilimanjaro-day-hike/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/luxury-honeymoon-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/private-photography-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/women-only-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/family-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/mikumi-flyin/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/saadani-beach-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/udzungwa-hiking-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/private-helicopter-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/presidential-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/chimpanzee-trekking/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/birdwatching-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/walking-bushcraft-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/migration-calving-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/bush-to-beach/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/east-africa-grand-tour/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/safaris/types/classic-game-drive/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/walking</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/fly-in/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/boat</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/walking/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/family</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/boat/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/luxury-lodge-tented</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/family/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/budget-camping</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/luxury-lodge-tented/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/safaris/types/bush-beach</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/budget-camping/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/six-day-safari-zanzibar-escape</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/safaris/types/bush-beach/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://yournexttriptoparadise.com/packages/six-day-safari-zanzibar-escape/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/seven-day-honeymoon-safari-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/seven-day-honeymoon-safari-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/eight-day-tanzania-parks-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/eight-day-tanzania-parks-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/nine-day-safari-zanzibar-culture</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/nine-day-safari-zanzibar-culture/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/ten-day-classic-safari-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/ten-day-classic-safari-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/twelve-day-serengeti-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/twelve-day-serengeti-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/fourteen-day-ultimate-tanzania-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/fourteen-day-ultimate-tanzania-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/two-day-fly-in-safari-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/two-day-fly-in-safari-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/three-day-serengeti-fly-in-safari</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/three-day-serengeti-fly-in-safari/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/kilimanjaro-safari-zanzibar-expedition</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/kilimanjaro-safari-zanzibar-expedition/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/luxury-family-safari-zanzibar</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/luxury-family-safari-zanzibar/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/great-migration-luxury-package</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/great-migration-luxury-package/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/zanzibar-adventure-marine-package</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/zanzibar-adventure-marine-package/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/stone-town-culture-experience</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/stone-town-culture-experience/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://destinationparadisezanzibar.netlify.app/packages/digital-nomad-zanzibar-stay</loc>
-    <lastmod>2026-06-21</lastmod>
+    <loc>https://yournexttriptoparadise.com/packages/digital-nomad-zanzibar-stay/</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -6,17 +6,18 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { getAllRoutes } from './routes.mjs';
 
-const SITE_URL = 'https://destinationparadisezanzibar.netlify.app';
+const SITE_URL = 'https://yournexttriptoparadise.com';
 const here = dirname(fileURLToPath(import.meta.url));
 
 const routes = await getAllRoutes();
 const lastmod = new Date().toISOString().slice(0, 10);
+const sitemapPath = (path) => (path === '/' ? '/' : `${path.replace(/\/+$/, '')}/`);
 
 const body = routes
   .map(
     (r) =>
       `  <url>\n` +
-      `    <loc>${SITE_URL}${r.path}</loc>\n` +
+      `    <loc>${SITE_URL}${sitemapPath(r.path)}</loc>\n` +
       `    <lastmod>${lastmod}</lastmod>\n` +
       `    <changefreq>${r.changefreq}</changefreq>\n` +
       `    <priority>${r.priority}</priority>\n` +

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -40,6 +40,7 @@ const USE_SPARTICUZ = process.env.PRERENDER_CHROMIUM
 const STRICT = process.env.PRERENDER_STRICT
   ? !['false', '0', 'no'].includes(process.env.PRERENDER_STRICT.toLowerCase())
   : ON_CI;
+const ROUTE_RETRIES = Math.max(0, Number(process.env.PRERENDER_ROUTE_RETRIES || 1));
 
 const BASE_ARGS = ['--no-sandbox', '--disable-setuid-sandbox'];
 
@@ -135,6 +136,23 @@ async function renderRoute(browser, port, path) {
   } finally {
     await page.close().catch(() => {});
   }
+}
+
+async function renderRouteWithRetry(browser, port, path) {
+  let lastErr;
+
+  for (let attempt = 0; attempt <= ROUTE_RETRIES; attempt += 1) {
+    try {
+      return await renderRoute(browser, port, path);
+    } catch (err) {
+      lastErr = err;
+      if (attempt < ROUTE_RETRIES) {
+        console.warn(`[prerender] retry ${attempt + 1}/${ROUTE_RETRIES} ${path} — ${err.message}`);
+      }
+    }
+  }
+
+  throw lastErr || new Error(`failed to prerender ${path}`);
 }
 
 // Launch Chromium, trying each viable strategy in order so a single broken
@@ -238,7 +256,7 @@ async function main() {
     while (next < paths.length) {
       const path = paths[next++];
       try {
-        const html = await renderRoute(browser, port, path);
+        const html = await renderRouteWithRetry(browser, port, path);
         results.push({ path, html });
         console.log(`[prerender] ✓ ${path}`);
       } catch (err) {
@@ -248,6 +266,15 @@ async function main() {
     }
   };
   await Promise.all(Array.from({ length: Math.min(concurrency, paths.length) }, worker));
+
+  let notFoundHtml = '';
+  try {
+    notFoundHtml = await renderRouteWithRetry(browser, port, '/404');
+    console.log('[prerender] ✓ /404');
+  } catch (err) {
+    failed += 1;
+    console.warn(`[prerender] ✗ /404 — ${err.message}`);
+  }
 
   await browser.close().catch(() => {});
   server.close();
@@ -259,6 +286,9 @@ async function main() {
     await mkdir(outDir, { recursive: true });
     await writeFile(join(outDir, 'index.html'), html, 'utf8');
   }
+  if (notFoundHtml) {
+    await writeFile(join(distDir, '404.html'), notFoundHtml, 'utf8');
+  }
 
   console.log(
     `[prerender] wrote ${results.length}/${paths.length} routes${failed ? ` (${failed} failed)` : ''}.`,
@@ -268,6 +298,12 @@ async function main() {
   // Treat that like a launch failure so it can't silently regress SEO.
   if (STRICT && results.length === 0 && paths.length > 0) {
     throw new Error(`prerendered 0/${paths.length} routes — refusing to ship a bare SPA shell.`);
+  }
+  if (STRICT && failed > 0) {
+    throw new Error(`prerender failed for ${failed} route${failed === 1 ? '' : 's'} — refusing to ship partial SEO output.`);
+  }
+  if (STRICT && !notFoundHtml) {
+    throw new Error('could not prerender 404.html — refusing to ship soft 404 fallback.');
   }
 }
 

--- a/src/components/CookieBanner.jsx
+++ b/src/components/CookieBanner.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 const STORAGE_KEY = 'dp_cookie_consent_v1';
+export const COOKIE_SETTINGS_EVENT = 'dp-cookie-settings';
 
 const defaultChoices = {
   essential: true,
@@ -53,6 +54,19 @@ export default function CookieBanner() {
     setIsReady(true);
   }, []);
 
+  useEffect(() => {
+    const openSettings = () => {
+      const stored = readStoredConsent();
+      setChoices(stored?.choices ? { ...defaultChoices, ...stored.choices, essential: true } : defaultChoices);
+      setIsCustomizing(true);
+      setIsVisible(true);
+      setIsReady(true);
+    };
+
+    window.addEventListener(COOKIE_SETTINGS_EVENT, openSettings);
+    return () => window.removeEventListener(COOKIE_SETTINGS_EVENT, openSettings);
+  }, []);
+
   const saveChoices = (nextChoices) => {
     const saved = writeStoredConsent(nextChoices);
     setChoices(saved.choices);
@@ -73,7 +87,7 @@ export default function CookieBanner() {
       {isCustomizing && (
         <div className="cookie-banner__choices">
           <label className="cookie-choice cookie-choice--locked">
-            <input type="checkbox" checked disabled />
+            <input type="checkbox" aria-label={t('cookies.essential_title')} checked disabled />
             <span>
               <strong>{t('cookies.essential_title')}</strong>
               <small>{t('cookies.essential_desc')}</small>
@@ -82,6 +96,7 @@ export default function CookieBanner() {
           <label className="cookie-choice">
             <input
               type="checkbox"
+              aria-label={t('cookies.analytics_title')}
               checked={choices.analytics}
               onChange={(event) => setChoices((current) => ({ ...current, analytics: event.target.checked }))}
             />

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -24,12 +24,14 @@ export default function LanguageSwitcher({ className = '' }) {
   const { i18n, t } = useTranslation();
   const [open, setOpen] = useState(false);
   const rootRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const toggleRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
 
   const resolvedLanguage = i18n.resolvedLanguage ?? 'en';
   const active = SUPPORTED_LANGUAGES.includes(resolvedLanguage) ? resolvedLanguage : 'en';
 
   const choose = (lang) => {
     setOpen(false);
+    window.requestAnimationFrame(() => toggleRef.current?.focus());
     if (lang === active) return;
     i18n.changeLanguage(lang);
   };
@@ -37,11 +39,15 @@ export default function LanguageSwitcher({ className = '' }) {
   // Close on outside click or Escape
   useEffect(() => {
     if (!open) return undefined;
+    const closeAndRestore = () => {
+      setOpen(false);
+      window.requestAnimationFrame(() => toggleRef.current?.focus());
+    };
     const handlePointer = (e) => {
-      if (rootRef.current && !rootRef.current.contains(e.target)) setOpen(false);
+      if (rootRef.current && !rootRef.current.contains(e.target)) closeAndRestore();
     };
     const handleKey = (e) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') closeAndRestore();
     };
     document.addEventListener('mousedown', handlePointer);
     document.addEventListener('keydown', handleKey);
@@ -57,6 +63,7 @@ export default function LanguageSwitcher({ className = '' }) {
       className={`lang-switcher${open ? ' is-open' : ''}${className ? ` ${className}` : ''}`}
     >
       <button
+        ref={toggleRef}
         type="button"
         className="lang-switcher__toggle"
         aria-haspopup="listbox"

--- a/src/components/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import imageManifest from '../data/imageManifest.json';
 
 const normalizeFetchPriority = (value) => (

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { CONTACT_INFO, SOCIAL_LINKS } from '../constants/contactInfo.js';
+import { COOKIE_SETTINGS_EVENT } from './CookieBanner.jsx';
 
 export const WHATSAPP_URL = CONTACT_INFO.whatsappUrl;
 
@@ -206,6 +207,9 @@ function TypedTagline() {
 
 export default function SiteFooter() {
   const { t } = useTranslation('footer');
+  const openCookieSettings = () => {
+    window.dispatchEvent(new Event(COOKIE_SETTINGS_EVENT));
+  };
   return (
     <footer className="footer">
       <div className="footer__inner">
@@ -259,7 +263,12 @@ export default function SiteFooter() {
       </div>
       <div className="footer__bottom">
         <span className="footer__copyright">© {new Date().getFullYear()} Destination Paradise · Zanzibar, Tanzania</span>
-        <span className="footer__policy-links"><Link to="/privacy-policy">{t('policy.privacy')}</Link> <Link to="/terms-of-service">{t('policy.terms')}</Link> <Link to="/cookies-policy">{t('policy.cookies')}</Link></span>
+        <span className="footer__policy-links">
+          <Link to="/privacy-policy">{t('policy.privacy')}</Link>
+          <Link to="/terms-of-service">{t('policy.terms')}</Link>
+          <Link to="/cookies-policy">{t('policy.cookies')}</Link>
+          <button type="button" onClick={openCookieSettings}>{t('policy.cookie_settings')}</button>
+        </span>
       </div>
     </footer>
   );

--- a/src/components/SiteLayout.jsx
+++ b/src/components/SiteLayout.jsx
@@ -6,7 +6,8 @@ import SiteFooter, { WhatsAppFab } from './SiteFooter.jsx';
 import PageScrollCue from './PageScrollCue.jsx';
 import FloatingBackButton from './FloatingBackButton.jsx';
 import CookieBanner from './CookieBanner.jsx';
-import { loadGoogleAnalytics, trackPageView } from '../utils/analytics.js';
+import { loadGoogleAnalytics, revokeGoogleAnalytics, trackPageView } from '../utils/analytics.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 import {
   announceTheme,
   applyTheme,
@@ -65,7 +66,10 @@ export default function SiteLayout() {
 
   useEffect(() => {
     const handleConsentChange = (event) => {
-      if (!event.detail?.choices?.analytics) return;
+      if (!event.detail?.choices?.analytics) {
+        revokeGoogleAnalytics();
+        return;
+      }
       const path = `${location.pathname}${location.search}${location.hash}`;
       trackPageView(path);
     };
@@ -86,7 +90,7 @@ export default function SiteLayout() {
     const scrollToHash = () => {
       const target = document.getElementById(hash);
       if (target) {
-        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
       }
     };
 

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -35,14 +35,6 @@ const NavIcon = ({ name }) => (
   </svg>
 );
 
-const BookingIcon = (p) => (
-  <svg width={p.size || 16} height={p.size || 16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
-    <line x1="3" y1="6" x2="21" y2="6" />
-    <path d="M16 10a4 4 0 0 1-8 0" />
-  </svg>
-);
-
 const ArrowRight = ({ size = 16 }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <path d="M5 12h14" />
@@ -101,7 +93,7 @@ const MM_BGS = [
 
 const MOBILE_NAV_QUERY = '(max-width: 960px)';
 
-export default function SiteNav({ theme = 'light', themeMode = 'auto', onThemeModeChange }) {
+export default function SiteNav({ theme = 'light', themeMode: _themeMode = 'auto', onThemeModeChange }) {
   const { t } = useTranslation('nav');
   const { t: tFooter } = useTranslation('footer');
   const [navOpen, setNavOpen] = useState(false);

--- a/src/components/SiteSearch.jsx
+++ b/src/components/SiteSearch.jsx
@@ -66,6 +66,8 @@ export default function SiteSearch({ open, onClose }) {
   const [searchIndex, setSearchIndex] = useState(/** @type {any[]} */ ([]));
   const [popularSearches, setPopularSearches] = useState(FALLBACK_POPULAR);
   const inputRef = useRef(/** @type {HTMLInputElement | null} */ (null));
+  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const restoreFocusRef = useRef(/** @type {Element | null} */ (null));
 
   const results = useMemo(() => {
     if (!searchIndex.length) return [];
@@ -89,17 +91,40 @@ export default function SiteSearch({ open, onClose }) {
     if (!open) return undefined;
 
     const previousBodyOverflow = document.body.style.overflow;
+    restoreFocusRef.current = document.activeElement;
     document.body.style.overflow = 'hidden';
     window.setTimeout(() => inputRef.current?.focus(), 30);
 
     const handleKey = (event) => {
-      if (event.key === 'Escape') onClose?.();
+      if (event.key === 'Escape') {
+        onClose?.();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const focusable = Array.from(
+        panelRef.current?.querySelectorAll('a[href], button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])') || [],
+      ).filter((element) => element instanceof HTMLElement && element.offsetParent !== null);
+
+      if (!focusable.length) return;
+      const first = /** @type {HTMLElement} */ (focusable[0]);
+      const last = /** @type {HTMLElement} */ (focusable[focusable.length - 1]);
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
 
     document.addEventListener('keydown', handleKey);
     return () => {
       document.body.style.overflow = previousBodyOverflow;
       document.removeEventListener('keydown', handleKey);
+      if (restoreFocusRef.current instanceof HTMLElement) {
+        restoreFocusRef.current.focus();
+      }
     };
   }, [open, onClose]);
 
@@ -127,7 +152,7 @@ export default function SiteSearch({ open, onClose }) {
   return (
     <div className="site-search" role="dialog" aria-modal="true" aria-label={t('search.dialog_label')}>
       <button className="site-search__backdrop" type="button" aria-label={t('search.close_backdrop')} onClick={onClose} />
-      <div className="site-search__panel">
+      <div className="site-search__panel" ref={panelRef}>
         <div className="site-search__field">
           <SearchIcon size={22} />
           <input
@@ -162,6 +187,11 @@ export default function SiteSearch({ open, onClose }) {
         )}
 
         <div className="site-search__results" aria-label={t('search.results_label')}>
+          <div className="visually-hidden" role="status" aria-live="polite">
+            {query.trim()
+              ? t('search.results_count', { count: results.length, defaultValue: `${results.length} search results` })
+              : ''}
+          </div>
           {!searchIndex.length && (
             <div className="site-search__loading">{t('search.loading')}</div>
           )}

--- a/src/components/booking/BookingForm.jsx
+++ b/src/components/booking/BookingForm.jsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 export default function BookingForm({
   budgetOptions,
@@ -197,6 +198,12 @@ export default function BookingForm({
           {errorMessage || t('form.status_error', { defaultValue: 'That did not go through. Please try again or message us on WhatsApp.' })}
         </p>
       )}
+
+      <p className="booking-privacy">
+        {t('form.privacy_prefix')}{' '}
+        <Link to="/privacy-policy">{t('form.privacy_link')}</Link>{' '}
+        {t('form.privacy_suffix')}
+      </p>
 
       <button className="btn btn--lg booking-submit" type="submit" disabled={status === 'sending' || status === 'sent'}>
         {status === 'sending'

--- a/src/components/excursions/ExcursionsGrid.jsx
+++ b/src/components/excursions/ExcursionsGrid.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../data/excursionsPageContent.js';
 import { useCurrency } from '../../context/useCurrency.js';
 import { textFromTranslation } from '../../utils/translationValues.js';
+import { preferredScrollBehavior } from '../../utils/motion.js';
 
 export default function ExcursionsGrid({
   filter,
@@ -110,7 +111,7 @@ export default function ExcursionsGrid({
               className="btn btn--ghost btn--lg"
               onClick={() => {
                 setVisibleCount(INITIAL_EXCURSION_COUNT);
-                document.getElementById('list')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                document.getElementById('list')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
               }}
             >
               {t('grid.show_fewer')}

--- a/src/components/homepage/ContactSection.jsx
+++ b/src/components/homepage/ContactSection.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import '../../styles/homepage/contact.css';
 import { CONTACT_INFO } from '../../constants/contactInfo.js';
@@ -6,7 +7,7 @@ import { ArrowIcon } from './Icons.jsx';
 import { clearPlannerHandoff, isPlannerHandoffMessage, PLANNER_HANDOFF_EVENT, readPlannerHandoff } from '../../utils/plannerHandoff.js';
 
 export default function ContactSection() {
-  const { t } = useTranslation('home');
+  const { t, i18n } = useTranslation('home');
   const [form, setForm] = useState({ name: '', email: '', subject: '', message: '' });
   const [plannerHandoff, setPlannerHandoff] = useState(
     /** @type {import('../../utils/plannerHandoff.js').PlannerHandoff | null} */ (null),
@@ -66,6 +67,7 @@ export default function ContactSection() {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           ...form,
+          lang: i18n.resolvedLanguage || i18n.language || 'en',
           source: plannerHandoff ? 'planner' : 'contact',
           plannerDraft: plannerHandoff?.transcript || '',
         }),
@@ -171,6 +173,12 @@ export default function ContactSection() {
           {status === 'error' && (
             <p className="contact__status contact__status--err" role="alert">{t('contact.form.status_err_prefix')} {CONTACT_INFO.email} {t('contact.form.status_err_suffix')}</p>
           )}
+
+          <p className="contact__privacy">
+            {t('contact.form.privacy_prefix')}{' '}
+            <Link to="/privacy-policy">{t('contact.form.privacy_link')}</Link>{' '}
+            {t('contact.form.privacy_suffix')}
+          </p>
 
           <button
             type="submit"

--- a/src/components/homepage/HeroSection.jsx
+++ b/src/components/homepage/HeroSection.jsx
@@ -6,6 +6,7 @@ import ResponsiveImage from '../ResponsiveImage.jsx';
 import { arrayFromTranslation } from '../../utils/translationValues.js';
 
 const HERO_SLIDES = [
+  '/assets/images/home/stone-town-waterfront.webp',
   '/assets/images/home/aerial-boats-turquoise-water.webp',
   '/assets/images/safaris/lion-cub-in-grass.webp',
   '/assets/images/safaris/crowned-crane-close.webp',

--- a/src/components/homepage/NewsletterSection.jsx
+++ b/src/components/homepage/NewsletterSection.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import '../../styles/homepage/newsletter.css';
 
@@ -79,6 +80,11 @@ export default function NewsletterSection() {
           {t('newsletter.error')}
         </p>
       )}
+      <p className="newsletter__note newsletter__privacy">
+        {t('newsletter.privacy_prefix')}{' '}
+        <Link to="/privacy-policy">{t('newsletter.privacy_link')}</Link>{' '}
+        {t('newsletter.privacy_suffix')}
+      </p>
     </section>
   );
 }

--- a/src/components/homepage/PlannerSection.jsx
+++ b/src/components/homepage/PlannerSection.jsx
@@ -1,17 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { useTranslation } from 'react-i18next';
 import '../../styles/homepage/planner.css';
 import { extractContact } from '../../utils/plannerHandoff.js';
 import { arrayFromTranslation } from '../../utils/translationValues.js';
 
-const HANDOFF_TOKEN = '[[PLANNER_HANDOFF_READY]]';
 const HANDOFF_TOKEN_REGEX = /\[\[\s*PLANNER_HANDOFF_READY\s*\]\]/g;
 
 const stripToken = (text = '') => text.replace(HANDOFF_TOKEN_REGEX, '').trim();
 
 export default function PlannerSection({ initialPrompt }) {
-  const { t } = useTranslation('home');
+  const { t, i18n } = useTranslation('home');
+  const activeLanguage = i18n.resolvedLanguage || i18n.language || 'en';
   const plannerTitle = t('planner.title');
   const quickReplies = useMemo(() => arrayFromTranslation(t('planner.quick_replies', { returnObjects: true })), [t]);
   const thinkingMessages = useMemo(() => arrayFromTranslation(t('planner.thinking_messages', { returnObjects: true })), [t]);
@@ -111,7 +112,12 @@ export default function PlannerSection({ initialPrompt }) {
       const res = await fetch('/api/planner-send', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ history: finalHistory, contact, updateCount: updateIndex }),
+        body: JSON.stringify({
+          history: finalHistory,
+          contact,
+          updateCount: updateIndex,
+          lang: activeLanguage,
+        }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || !data.ok) {
@@ -130,7 +136,7 @@ export default function PlannerSection({ initialPrompt }) {
     } finally {
       handoffInflightRef.current = false;
     }
-  }, [t]);
+  }, [activeLanguage, t]);
 
   const send = useCallback(async (text) => {
     if (!text || sending) return;
@@ -143,7 +149,7 @@ export default function PlannerSection({ initialPrompt }) {
       const res = await fetch('/api/planner', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ history: next }),
+        body: JSON.stringify({ history: next, lang: activeLanguage }),
       });
       const data = await res.json();
       const rawReply = data.reply || t('planner.fallbacks.reply_blank');
@@ -152,13 +158,13 @@ export default function PlannerSection({ initialPrompt }) {
       const updated = [...next, { role: 'assistant', content: cleaned }];
       setHistory(updated);
       if (ready) submitHandoff(updated);
-    } catch (err) {
+    } catch {
       setHistory((h) => [...h, { role: 'assistant', content: t('planner.fallbacks.network_error') }]);
     } finally {
       setSending(false);
       if (inputRef.current) inputRef.current.focus();
     }
-  }, [history, sending, submitHandoff, t]);
+  }, [activeLanguage, history, sending, submitHandoff, t]);
 
   useEffect(() => {
     if (!initialPrompt || handledPromptRef.current === initialPrompt.id || sending) return;
@@ -328,6 +334,11 @@ export default function PlannerSection({ initialPrompt }) {
           </form>
           <footer className="planner__foot">
             <span className="planner__foot-note">{t('planner.foot.note')}</span>
+            <span className="planner__privacy">
+              {t('planner.foot.privacy_prefix')}{' '}
+              <Link to="/privacy-policy">{t('planner.foot.privacy_link')}</Link>
+              {t('planner.foot.privacy_suffix')}
+            </span>
             <button
               type="button"
               className="planner__handoff"

--- a/src/components/safaris/SafariItineraries.jsx
+++ b/src/components/safaris/SafariItineraries.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { INITIAL_SAFARI_COUNT, SAFARI_BATCH_COUNT } from '../../data/safarisPageContent.js';
 import { useCurrency } from '../../context/useCurrency.js';
 import { textFromTranslation } from '../../utils/translationValues.js';
+import { preferredScrollBehavior } from '../../utils/motion.js';
 
 export default function SafariItineraries({
   filteredSafaris,
@@ -97,7 +98,7 @@ export default function SafariItineraries({
               className="btn btn--ghost btn--lg"
               onClick={() => {
                 setVisibleCount(INITIAL_SAFARI_COUNT);
-                document.getElementById('itineraries')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                document.getElementById('itineraries')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
               }}
             >
               {t('itineraries.show_fewer')}

--- a/src/hooks/usePageMeta.js
+++ b/src/hooks/usePageMeta.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { isPrerender } from '../utils/prerender.js';
 
-export const SITE_URL = 'https://destinationparadisezanzibar.netlify.app';
+export const SITE_URL = 'https://yournexttriptoparadise.com';
 export const SITE_NAME = 'Destination Paradise';
 const DEFAULT_DESCRIPTION =
   'Destination Paradise offers bespoke excursions, luxury safaris, and unforgettable packages in Zanzibar & Tanzania.';
@@ -57,8 +57,7 @@ function upsertLink(rel, href) {
 
 function canonicalFor(pathname) {
   let path = pathname || '/';
-  // Drop trailing slashes (keep root) so /booking and /booking/ canonicalize together.
-  if (path.length > 1) path = path.replace(/\/+$/, '');
+  if (path.length > 1) path = `${path.replace(/\/+$/, '')}/`;
   return `${SITE_URL}${path}`;
 }
 
@@ -101,7 +100,7 @@ export function usePageMeta(options = {}, legacyDescription) {
     const url = canonical
       ? /^https?:\/\//.test(canonical)
         ? canonical
-        : `${SITE_URL}${canonical}`
+        : canonicalFor(canonical)
       : canonicalFor(window.location.pathname);
     const ogTitle = title || `${SITE_NAME} — your next trip to paradise`;
 

--- a/src/locales/de/booking.json
+++ b/src/locales/de/booking.json
@@ -168,7 +168,10 @@
     "message_placeholder_transfer": "Ankunftshinweise, Gepäckanzahl, Kindersitze, Hotelname, VIP-Wünsche oder Uhrzeitdetails.",
     "message_placeholder_excursion": "Gewünschter Abholbereich, Hotelname, privat/geteilt, Alter der Kinder, Ernährung oder Zeitwünsche.",
     "message_placeholder_default": "Hotels, die du magst, Tempo, besonderer Anlass, Alter der Kinder, Ernährung, Flugdaten oder was du vermeiden möchtest.",
-    "unmatched_message": "Ich interessiere mich für {{title}}. {{message}}"
+    "unmatched_message": "Ich interessiere mich für {{title}}. {{message}}",
+    "privacy_prefix": "Wir nutzen deine Buchungsdaten, um Verfügbarkeit, Preis und nächste Zahlungsschritte vorzubereiten. Details stehen in unserer",
+    "privacy_link": "Datenschutzerklärung",
+    "privacy_suffix": "."
   },
   "budget_options": [
     {

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -15,6 +15,14 @@
     "label": "Zurück",
     "aria": "Zurück zur vorherigen Seite"
   },
+  "not_found": {
+    "meta_title": "Seite nicht gefunden · Destination Paradise",
+    "meta_description": "Diese Seite liegt nicht auf der Karte. Kehre zur Startseite zurück und wähle eine Route durch Sansibar und Tansania.",
+    "eyebrow": "404",
+    "title": "Auf See verirrt",
+    "body": "Diese Seite liegt nicht auf der Karte. Kehre zur Startseite zurück und wähle eine Route.",
+    "cta": "← Zurück zur Startseite"
+  },
   "cookies": {
     "aria_label": "Cookie-Einwilligung",
     "eyebrow": "Cookie-Einstellungen",
@@ -40,6 +48,7 @@
     "close": "Schließen",
     "popular_label": "Beliebte Suchen",
     "results_label": "Suchergebnisse",
+    "results_count": "{{count}} Suchergebnisse",
     "loading": "Seitenindex wird vorbereitet...",
     "empty_title": "Noch kein genauer Treffer.",
     "empty_body": "Versuchen Sie ein Reiseziel, eine Aktivität, einen Pakettyp, einen Safari-Park oder eine Transferstrecke – oder senden Sie uns eine individuelle Anfrage.",

--- a/src/locales/de/footer.json
+++ b/src/locales/de/footer.json
@@ -45,7 +45,8 @@
   "policy": {
     "privacy": "Datenschutz",
     "terms": "AGB",
-    "cookies": "Cookies"
+    "cookies": "Cookies",
+    "cookie_settings": "Cookie-Einstellungen"
   },
   "fab": {
     "aria": "Mit dem Team auf WhatsApp chatten",

--- a/src/locales/de/home.json
+++ b/src/locales/de/home.json
@@ -236,7 +236,10 @@
     "submit": "Abonnieren",
     "submit_pending": "Wird gesendet…",
     "submit_done": "Gesendet",
-    "error": "Das hat nicht geklappt. Bitte versuch es gleich noch einmal."
+    "error": "Das hat nicht geklappt. Bitte versuch es gleich noch einmal.",
+    "privacy_prefix": "Mit dem Abonnieren erlaubst du uns, deine E-Mail für Updates von Destination Paradise zu speichern. Details stehen in unserer",
+    "privacy_link": "Datenschutzerklärung",
+    "privacy_suffix": "."
   },
   "planner": {
     "eyebrow": "KI-Reiseplaner",
@@ -310,7 +313,10 @@
     "foot": {
       "note": "Reiserouten sind Entwürfe. Vor der Buchung prüft und kalkuliert ein Mensch alles.",
       "handoff_idle": "Ans Team senden",
-      "handoff_done": "Ans Team gesendet ✓"
+      "handoff_done": "Ans Team gesendet ✓",
+      "privacy_prefix": "Planer-Nachrichten können von Anthropic verarbeitet und beim Senden eines Entwurfs über Resend per E-Mail verschickt werden. Details stehen in unserer",
+      "privacy_link": "Datenschutzerklärung",
+      "privacy_suffix": "."
     }
   },
   "weather": {
@@ -363,10 +369,24 @@
     "title_suffix": "auf ihrer ersten Reise.",
     "lead": "Destination Paradise wurde aus einem Traum geboren — Menschen mit der Schönheit, Kultur und Seele Tansanias zu verbinden. Nach Jahren der Vorbereitung starten wir offiziell auf Unguja, Sansibar.",
     "highlights": [
-      { "value": "Jetzt", "label": "Unguja", "em": true },
-      { "value": "Jetzt", "label": "Festland", "em": true },
-      { "value": "Bald", "label": "Pemba" },
-      { "value": "Bald", "label": "Mafia Island" }
+      {
+        "value": "Jetzt",
+        "label": "Unguja",
+        "em": true
+      },
+      {
+        "value": "Jetzt",
+        "label": "Festland",
+        "em": true
+      },
+      {
+        "value": "Bald",
+        "label": "Pemba"
+      },
+      {
+        "value": "Bald",
+        "label": "Mafia Island"
+      }
     ],
     "cta": "Unsere Geschichte lesen"
   },
@@ -393,7 +413,10 @@
       "submit_done": "Gesendet",
       "status_ok": "✓ Asante — wir haben deine Nachricht. Wir melden uns innerhalb eines Tages.",
       "status_err_prefix": "Pole sana — das hat nicht geklappt. Schreib uns direkt an",
-      "status_err_suffix": "oder versuch es erneut."
+      "status_err_suffix": "oder versuch es erneut.",
+      "privacy_prefix": "Wir nutzen diese Angaben, um deine Anfrage zu beantworten. Details stehen in unserer",
+      "privacy_link": "Datenschutzerklärung",
+      "privacy_suffix": "."
     }
   }
 }

--- a/src/locales/de/packages.json
+++ b/src/locales/de/packages.json
@@ -238,10 +238,12 @@
         "Romantisches Strandresort",
         "Private Transfers",
         "Sunset-Dhow-Cruise",
-        "Romantisches Dinner",
-        "Blumendekoration",
-        "Safari-Guide",
-        "Inlandsflüge"
+        "Dinner bei Kerzenschein am Strand",
+        "Bush Breakfast",
+        "Safari-Pirschfahrten",
+        "Inlandsflüge",
+        "Professioneller Guide",
+        "Spa-Optionen"
       ],
       "pricing": {
         "unit": "pro Person"
@@ -358,10 +360,9 @@
         "Inlandsflüge",
         "Privates Safarifahrzeug",
         "Strandresort",
-        "Professioneller Safari-Guide",
-        "Parkgebühren",
-        "Private Transfers",
-        "Ausgewählte Mahlzeiten"
+        "Stone-Town-Tour",
+        "Flughafentransfers",
+        "Vollpension während der Safari"
       ],
       "pricing": {
         "unit": "pro Person"

--- a/src/locales/de/policy.json
+++ b/src/locales/de/policy.json
@@ -3,47 +3,66 @@
   "meta": {
     "aria_label": "Richtliniendetails",
     "last_updated": "Zuletzt aktualisiert",
-    "last_updated_value": "13. Mai 2026",
+    "last_updated_value": "5. Juli 2026",
     "contact": "Kontakt"
   },
   "policies": {
     "privacy": {
       "eyebrow": "Datenschutz",
       "title": "Datenschutzerklärung",
-      "intro": "Diese Datenschutzerklärung erklärt, wie Destination Paradise mit den Angaben umgeht, die du teilst, wenn du Reisen anfragst, Erlebnisse buchst oder unser Team kontaktierst.",
+      "intro": "Diese Erklärung beschreibt, wie Destination Paradise Daten verarbeitet, die du beim Besuch der Website, bei Anfragen, im KI-Reiseplaner, bei Buchungen oder im Kontakt mit unserem Team teilst.",
       "sections": [
         {
-          "title": "Welche Informationen Wir Erheben",
+          "title": "Welche Informationen Wir Erfassen",
           "items": [
             "Kontaktdaten wie Name, E-Mail-Adresse, Telefonnummer, WhatsApp-Kontakt und Land.",
-            "Reisedetails wie Wunschdaten, Gruppengröße, Budget, Interessen, Hotel oder Abholort und besondere Wünsche.",
-            "Nachrichten, die du über unsere Formulare, WhatsApp, E-Mail oder Social-Media-Kanäle sendest.",
-            "Grundlegende technische Informationen wie Browsertyp, Geräteinformationen, besuchte Seiten und ungefährer Standort aus Analyse-Tools."
+            "Reisedaten wie gewünschte Termine, Gruppengröße, Budget, Interessen, Hotel oder Abholort und besondere Wünsche.",
+            "Nachrichten, die du über Formulare, WhatsApp, E-Mail oder Social-Media-Kanäle sendest.",
+            "Chatverlauf und Übergabedetails aus dem KI-Reiseplaner, wenn du einen Entwurf an unser Team senden lässt.",
+            "Technische Basisdaten wie Browsertyp, Geräteinformationen, besuchte Seiten, Spracheinstellung, Cookie-Auswahl und ungefähre Standortdaten aus Analyse-Tools, wenn du einwilligst."
           ]
         },
         {
           "title": "Wie Wir Deine Informationen Nutzen",
           "items": [
-            "Um Anfragen zu beantworten und Reisevorschläge, Angebote, Buchungen und Reisepläne vorzubereiten.",
-            "Um Guides, Fahrer, Unterkunftspartner, Bootsbetreiber, Safari-Anbieter und andere Partner zu koordinieren, die für deine Reise gebraucht werden.",
-            "Um unsere Website, den Kundenservice, Pakete, Ausflüge und die Safari-Planung zu verbessern.",
-            "Um Buchungsupdates, Service-Nachrichten und Folgeinformationen zu deiner Anfrage zu senden."
+            "Um Anfragen zu beantworten und Reisevorschläge, Angebote, Buchungen und Reiserouten vorzubereiten.",
+            "Um Guides, Fahrer, Unterkünfte, Bootsbetreiber, Safari-Anbieter und andere Partner zu koordinieren, die für deine Reise nötig sind.",
+            "Um den KI-Reiseplaner zu betreiben, deinen Entwurf lokal zu speichern und das Team per E-Mail zu informieren, wenn du eine Übergabe wünschst.",
+            "Um Website, Service, Pakete, Ausflüge und Safari-Planung zu verbessern.",
+            "Um Buchungsupdates, Servicenachrichten und Folgeinformationen zu deiner Anfrage zu senden."
           ]
         },
         {
-          "title": "Weitergabe Deiner Informationen",
+          "title": "Dienstleister Und Weitergabe",
           "items": [
-            "Wir teilen nur die Angaben, die nötig sind, um deine Reise mit vertrauenswürdigen lokalen Partnern, Zahlungsanbietern oder Dienstleistern zu organisieren.",
-            "Wir können Informationen weitergeben, wenn dies durch Gesetze, Sicherheitsanforderungen, Grenzbestimmungen oder offizielle Reiseverfahren erforderlich ist.",
-            "Wir verkaufen deine persönlichen Informationen nicht."
+            "Netlify hostet die Website und Netlify Functions, die Kontakt-, Buchungs-, Planer- und Newsletter-Anfragen empfangen.",
+            "Resend versendet Team-Benachrichtigungen und Bestätigungen an Gäste aus Kontakt-, Buchungs- und Planer-Workflows.",
+            "Anthropic betreibt den KI-Reiseplaner. Prompts und aktuelle Chatverläufe werden nur für diese Funktion an Anthropic gesendet.",
+            "Google Analytics misst Seitenbesuche erst, nachdem du Analyse-Cookies akzeptiert hast. Google kann dafür _ga-Cookies setzen.",
+            "Sentry sammelt technische Fehlerberichte, damit wir defekte Seiten und fehlerhafte Funktionen diagnostizieren können.",
+            "Open-Meteo, CARTO-Kartenkacheln und open.er-api.com liefern Wetter-, Karten- und Wechselkursdaten für öffentliche Website-Funktionen.",
+            "Wir teilen nur die Details, die zur Organisation deiner Reise nötig sind, mit vertrauenswürdigen lokalen Guides, Fahrern, Unterkünften, Bootsbetreibern, Safari-Anbietern, Zahlungsdienstleistern oder offiziellen Stellen, wenn es erforderlich ist.",
+            "Wir können Informationen weitergeben, wenn Gesetze, Sicherheitsanforderungen, Grenzregeln oder offizielle Reiseprozesse dies verlangen.",
+            "Wir verkaufen deine personenbezogenen Daten nicht."
+          ]
+        },
+        {
+          "title": "Speicherung, Aufbewahrung Und Sicherheit",
+          "items": [
+            "Wir behalten Anfragen und Buchungsdaten nur so lange, wie es für Antwort, Reiseorganisation, Buchhaltung, rechtliche Pflichten und Servicequalität nötig ist.",
+            "Lokaler Browserspeicher kann Sprache, Design, Cookie-Auswahl, Wechselkurs-Cache, Planerverlauf und Planer-Übergabe speichern, damit die Website reibungslos funktioniert.",
+            "Wir nutzen angemessene technische Schutzmaßnahmen wie HTTPS, Anbieter-Zugriffskontrollen, Größenlimits, Validierung, Rate-Limiting und Fehlerüberwachung.",
+            "Keine Website und kein E-Mail-System ist perfekt sicher. Bitte sende keine Passkopien, Kartendaten oder besonders sensiblen Gesundheitsdaten über offene Textfelder."
           ]
         },
         {
           "title": "Deine Wahlmöglichkeiten",
           "items": [
-            "Du kannst uns bitten, deine persönlichen Angaben zu korrigieren, zu aktualisieren oder zu löschen, wenn wir sie nicht mehr für Buchung, Buchhaltung, Sicherheit oder rechtliche Gründe benötigen.",
-            "Du kannst optionale Angaben weglassen, auch wenn dies einschränken kann, wie genau wir deine Reise planen können.",
-            "Du kannst Marketing-Nachrichten jederzeit abbestellen, indem du uns kontaktierst."
+            "Du kannst uns bitten, personenbezogene Daten zu korrigieren, zu aktualisieren oder zu löschen, wenn wir sie nicht mehr für Buchung, Buchhaltung, Sicherheit oder rechtliche Gründe benötigen.",
+            "Du kannst optionale Angaben weglassen; dadurch können wir deine Reise eventuell weniger genau planen.",
+            "Du kannst Cookie-Einstellungen im Footer jederzeit öffnen und deine Analyse-Einwilligung widerrufen. Wenn Analyse deaktiviert wird, schalten wir Google Analytics ab und entfernen dessen Analyse-Cookies aus diesem Browser.",
+            "Du kannst lokalen Browserspeicher wie Planerverlauf, Sprache, Design und gecachte Wechselkurse in deinen Browser-Einstellungen löschen.",
+            "Du kannst Marketingnachrichten jederzeit abbestellen, indem du uns kontaktierst."
           ]
         }
       ]
@@ -90,36 +109,46 @@
     "cookies": {
       "eyebrow": "Cookies",
       "title": "Cookie-Richtlinie",
-      "intro": "Diese Richtlinie erklärt, wie Cookies und ähnliche Technologien genutzt werden können, damit die Website funktioniert, Besuche verstanden werden und die Reiseplanung verbessert wird.",
+      "intro": "Diese Richtlinie erklärt, welche Cookies, lokalen Speicher und ähnlichen Technologien Destination Paradise verwendet.",
       "sections": [
         {
-          "title": "Was Cookies Sind",
+          "title": "Essenzielle Speicherung",
           "items": [
-            "Cookies sind kleine Dateien, die auf deinem Gerät gespeichert werden, wenn du eine Website besuchst.",
-            "Ähnliche Technologien wie lokaler Speicher, Pixel und Analyse-Tags können helfen, Einstellungen zu merken oder zu messen, wie Seiten genutzt werden."
+            "dp_cookie_consent_v1 speichert deine Cookie-Auswahl, damit wir wissen, ob Analyse erlaubt ist.",
+            "dp_tweaks speichert Design- und Anzeigeeinstellungen wie hellen oder dunklen Modus.",
+            "dp_lang speichert deine Sprache, und dp_fx_rates kann Wechselkurse für Preisangaben zwischenspeichern.",
+            "plannerHistory und dp_planner_handoff speichern KI-Planer-Chat und Übergabeentwürfe in deinem Browser, damit du einen Plan fortsetzen oder senden kannst."
           ]
         },
         {
-          "title": "Wie Wir Cookies Nutzen",
+          "title": "Analyse-Cookies",
           "items": [
-            "Notwendige Cookies und Speicher helfen der Website beim Laden, merken Design-Einstellungen, unterstützen Formulare und halten die Nutzung stabil.",
-            "Analyse-Cookies können uns helfen zu verstehen, welche Seiten nützlich sind, wo Besucher uns finden und wie wir die Website verbessern können.",
-            "Marketing- oder Social-Plattform-Tools können genutzt werden, wenn du mit eingebetteten Inhalten, Social Links oder Kampagnenlinks interagierst."
+            "Google Analytics lädt erst, nachdem du Analyse im Cookie-Banner oder in den Cookie-Einstellungen akzeptiert hast.",
+            "Analyse hilft uns zu verstehen, welche Seiten nützlich sind, wo Besucher uns finden und wo die Reiseplanung besser werden kann.",
+            "Google Analytics kann _ga und verwandte Cookies setzen. Wenn du Analyse später ausschaltest, deaktiviert die Website Analyse und versucht, diese Cookies aus diesem Browser zu löschen."
           ]
         },
         {
-          "title": "Cookies Verwalten",
+          "title": "Anfragen An Dritte",
           "items": [
-            "Du kannst Cookies in deinen Browser-Einstellungen blockieren, löschen oder einschränken.",
-            "Einige Funktionen funktionieren eventuell nicht wie erwartet, wenn notwendige Cookies oder lokaler Speicher deaktiviert sind.",
-            "Drittanbieter können eigene Datenschutz- und Cookie-Einstellungen über ihre Websites oder Kontoeinstellungen anbieten."
+            "Sentry kann technische Fehlerdaten erhalten, wenn eine Seite oder Funktion ausfällt.",
+            "Open-Meteo, CARTO-Kartenkacheln und open.er-api.com können Basis-Anfragedaten erhalten, wenn Wetter, Karten oder Wechselkurse geladen werden.",
+            "Resend und Anthropic erhalten Daten nur, wenn du ein Formular, eine Buchungsanfrage oder eine KI-Planer-Nachricht sendest, die diese Dienste nutzt."
+          ]
+        },
+        {
+          "title": "Auswahl Verwalten",
+          "items": [
+            "Du kannst Cookie-Einstellungen jederzeit im Footer öffnen und Analyse ein- oder ausschalten.",
+            "Du kannst Cookies und lokalen Speicher auch in deinen Browser-Einstellungen blockieren, löschen oder einschränken.",
+            "Einige Funktionen funktionieren eventuell nicht wie erwartet, wenn essenzieller lokaler Speicher deaktiviert ist."
           ]
         },
         {
           "title": "Aktualisierungen",
           "items": [
-            "Wir können diese Richtlinie aktualisieren, wenn sich Website-Tools, Analyse-Einstellungen oder Buchungsabläufe ändern.",
-            "Die aktuelle Version wird mit dem aktualisierten Datum auf dieser Seite veröffentlicht."
+            "Wir können diese Richtlinie aktualisieren, wenn sich Website-Tools, Analyse-Setup oder Buchungsabläufe ändern.",
+            "Die neueste Version wird mit aktualisiertem Datum auf dieser Seite veröffentlicht."
           ]
         }
       ]

--- a/src/locales/en/booking.json
+++ b/src/locales/en/booking.json
@@ -168,7 +168,10 @@
     "message_placeholder_transfer": "Arrival notes, luggage count, child seats, hotel room name, VIP preferences, or timing details.",
     "message_placeholder_excursion": "Preferred pickup area, hotel name, private/shared preference, kids ages, dietary needs, or timing notes.",
     "message_placeholder_default": "Hotels you like, pace, special occasion, kids' ages, dietary needs, flight details, or what you want to avoid.",
-    "unmatched_message": "I am interested in {{title}}. {{message}}"
+    "unmatched_message": "I am interested in {{title}}. {{message}}",
+    "privacy_prefix": "We use your booking details to prepare availability, pricing, and payment next steps. See our",
+    "privacy_link": "Privacy Policy",
+    "privacy_suffix": "for details."
   },
   "budget_options": [
     {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -15,6 +15,14 @@
     "label": "Back",
     "aria": "Go back to previous page"
   },
+  "not_found": {
+    "meta_title": "Page Not Found · Destination Paradise",
+    "meta_description": "That page isn't on the map. Head back to the homepage and pick a route through Zanzibar and Tanzania.",
+    "eyebrow": "404",
+    "title": "Lost at sea",
+    "body": "That page isn't on the map. Head back to the homepage and pick a route.",
+    "cta": "← Back to home"
+  },
   "cookies": {
     "aria_label": "Cookie consent",
     "eyebrow": "Cookie preferences",
@@ -40,6 +48,7 @@
     "close": "Close",
     "popular_label": "Popular searches",
     "results_label": "Search results",
+    "results_count": "{{count}} search results",
     "loading": "Preparing the site index...",
     "empty_title": "No exact match yet.",
     "empty_body": "Try a destination, activity, package style, safari park, transfer route, or send us a custom request.",

--- a/src/locales/en/footer.json
+++ b/src/locales/en/footer.json
@@ -45,7 +45,8 @@
   "policy": {
     "privacy": "Privacy",
     "terms": "Terms",
-    "cookies": "Cookies"
+    "cookies": "Cookies",
+    "cookie_settings": "Cookie settings"
   },
   "fab": {
     "aria": "Chat with the team on WhatsApp",

--- a/src/locales/en/home.json
+++ b/src/locales/en/home.json
@@ -236,7 +236,10 @@
     "submit": "Subscribe",
     "submit_pending": "Sending…",
     "submit_done": "Sent",
-    "error": "That did not go through. Please try again in a moment."
+    "error": "That did not go through. Please try again in a moment.",
+    "privacy_prefix": "By subscribing, you agree that we may store your email for Destination Paradise updates. See our",
+    "privacy_link": "Privacy Policy",
+    "privacy_suffix": "for details."
   },
   "planner": {
     "eyebrow": "AI Trip Planner",
@@ -310,7 +313,10 @@
     "foot": {
       "note": "Itineraries are drafts. A human reviews and prices everything before you book.",
       "handoff_idle": "Send to team",
-      "handoff_done": "Sent to team ✓"
+      "handoff_done": "Sent to team ✓",
+      "privacy_prefix": "Planner messages may be processed by Anthropic and emailed via Resend when you send a draft. See our",
+      "privacy_link": "Privacy Policy",
+      "privacy_suffix": "."
     }
   },
   "weather": {
@@ -363,10 +369,24 @@
     "title_suffix": "taking its first journey.",
     "lead": "Destination Paradise was born from a dream — to connect people to the beauty, culture and spirit of Tanzania. After years of preparation, we are officially launching from Unguja, Zanzibar.",
     "highlights": [
-      { "value": "Now", "label": "Unguja", "em": true },
-      { "value": "Now", "label": "Mainland", "em": true },
-      { "value": "Next", "label": "Pemba" },
-      { "value": "Next", "label": "Mafia Island" }
+      {
+        "value": "Now",
+        "label": "Unguja",
+        "em": true
+      },
+      {
+        "value": "Now",
+        "label": "Mainland",
+        "em": true
+      },
+      {
+        "value": "Next",
+        "label": "Pemba"
+      },
+      {
+        "value": "Next",
+        "label": "Mafia Island"
+      }
     ],
     "cta": "Read our story"
   },
@@ -393,7 +413,10 @@
       "submit_done": "Sent",
       "status_ok": "✓ Asante — we got it. We'll come back to you within a day.",
       "status_err_prefix": "Pole sana — that didn't go through. Email us directly at",
-      "status_err_suffix": "or try again."
+      "status_err_suffix": "or try again.",
+      "privacy_prefix": "We use these details to reply to your request. See our",
+      "privacy_link": "Privacy Policy",
+      "privacy_suffix": "for details."
     }
   }
 }

--- a/src/locales/en/policy.json
+++ b/src/locales/en/policy.json
@@ -3,14 +3,14 @@
   "meta": {
     "aria_label": "Policy details",
     "last_updated": "Last updated",
-    "last_updated_value": "May 13, 2026",
+    "last_updated_value": "July 5, 2026",
     "contact": "Contact"
   },
   "policies": {
     "privacy": {
       "eyebrow": "Privacy",
       "title": "Privacy Policy",
-      "intro": "This policy explains how Destination Paradise handles the details you share when you ask about trips, book experiences, or contact our team.",
+      "intro": "This policy explains how Destination Paradise handles the details you share when you browse the site, ask about trips, use the AI planner, book experiences, or contact our team.",
       "sections": [
         {
           "title": "Information We Collect",
@@ -18,7 +18,8 @@
             "Contact details such as your name, email address, phone number, WhatsApp contact, and country.",
             "Trip details such as preferred dates, group size, budget, interests, hotel or pickup location, and special requests.",
             "Messages you send through our forms, WhatsApp, email, or social channels.",
-            "Basic technical information such as browser type, device information, pages visited, and approximate location from analytics tools."
+            "Planner chat history and handoff details when you use the AI trip planner or ask us to send a draft to the team.",
+            "Basic technical information such as browser type, device information, pages visited, language choice, cookie choice, and approximate location from analytics tools when you consent."
           ]
         },
         {
@@ -26,16 +27,32 @@
           "items": [
             "To respond to enquiries and prepare trip suggestions, quotes, bookings, and itineraries.",
             "To coordinate guides, drivers, accommodation partners, boat operators, safari providers, and other suppliers needed for your trip.",
+            "To run the AI planner, remember your draft locally, and email the team when you choose to hand off a plan.",
             "To improve our website, customer service, packages, excursions, and safari planning experience.",
             "To send booking updates, service messages, and follow-up information connected to your request."
           ]
         },
         {
-          "title": "Sharing Your Information",
+          "title": "Service Providers And Data Sharing",
           "items": [
-            "We share only the details needed to arrange your trip with trusted local partners, payment providers, or service providers.",
+            "Netlify hosts the website and Netlify Functions that receive contact, booking, planner, and newsletter submissions.",
+            "Resend sends team notification emails and guest confirmation emails from the contact, booking, and planner workflows.",
+            "Anthropic powers the AI trip planner when you chat with it. Planner prompts and recent chat history are sent to Anthropic only for that feature.",
+            "Google Analytics measures page visits only after you accept analytics cookies. Google may set _ga cookies for measurement.",
+            "Sentry collects technical error reports so we can diagnose broken pages and failed functions.",
+            "Open-Meteo, CARTO map tiles, and open.er-api.com provide weather, map, and currency-rate data used by public site features.",
+            "We share only the details needed to arrange your trip with trusted local guides, drivers, accommodation partners, boat operators, safari providers, payment providers, or official authorities when required.",
             "We may share information when required by law, safety requirements, border rules, or official travel procedures.",
             "We do not sell your personal information."
+          ]
+        },
+        {
+          "title": "Storage, Retention, And Security",
+          "items": [
+            "We keep enquiries and booking details only as long as needed to reply, arrange the trip, handle accounting or legal duties, and improve service quality.",
+            "Local browser storage may hold your language, theme, cookie choice, currency-rate cache, planner history, and planner handoff draft so the site works smoothly.",
+            "We use reasonable technical safeguards such as HTTPS, provider access controls, request size limits, validation, rate limiting, and error monitoring.",
+            "No website or email system is perfectly secure, so avoid sending passport scans, payment card details, or highly sensitive health information through open text fields."
           ]
         },
         {
@@ -43,6 +60,8 @@
           "items": [
             "You can ask us to correct, update, or delete your personal details when we no longer need them for booking, accounting, safety, or legal reasons.",
             "You can choose not to provide optional details, although this may limit how accurately we can plan your trip.",
+            "You can reopen Cookie settings in the footer at any time to withdraw analytics consent. When analytics is turned off, we disable Google Analytics and remove its analytics cookies from this browser.",
+            "You can clear local browser storage such as planner history, language, theme, and cached currency rates in your browser settings.",
             "You can unsubscribe from marketing messages at any time by contacting us."
           ]
         }
@@ -90,29 +109,39 @@
     "cookies": {
       "eyebrow": "Cookies",
       "title": "Cookies Policy",
-      "intro": "This policy explains how cookies and similar technologies may be used to keep the website working, understand visits, and improve the planning experience.",
+      "intro": "This policy explains the cookies, local storage, and similar technologies used by Destination Paradise.",
       "sections": [
         {
-          "title": "What Cookies Are",
+          "title": "Essential Storage",
           "items": [
-            "Cookies are small files stored on your device when you visit a website.",
-            "Similar technologies such as local storage, pixels, and analytics tags can help remember settings or measure how pages are used."
+            "dp_cookie_consent_v1 stores your cookie choice so we know whether analytics is allowed.",
+            "dp_tweaks stores theme and display preferences such as light or dark mode.",
+            "dp_lang stores your language choice, and dp_fx_rates may cache currency rates for price display.",
+            "plannerHistory and dp_planner_handoff store AI planner chat and handoff drafts in your browser so you can continue or send a plan."
           ]
         },
         {
-          "title": "How We Use Cookies",
+          "title": "Analytics Cookies",
           "items": [
-            "Essential cookies and storage help the website load, remember theme preferences, support forms, and keep the experience stable.",
-            "Analytics cookies may help us understand which pages are useful, where visitors find us, and how we can improve the site.",
-            "Marketing or social platform tools may be used when you interact with embedded content, social links, or campaign links."
+            "Google Analytics loads only after you accept analytics in the cookie banner or Cookie settings.",
+            "Analytics helps us understand which pages are useful, where visitors find us, and where trip planning can improve.",
+            "Google Analytics may set _ga and related cookies. If you later turn analytics off, the site disables analytics and attempts to delete those cookies from this browser."
           ]
         },
         {
-          "title": "Managing Cookies",
+          "title": "Third-Party Requests",
           "items": [
-            "You can block, delete, or limit cookies in your browser settings.",
-            "Some features may not work as expected if essential cookies or local storage are disabled.",
-            "Third-party services may provide their own privacy and cookie controls through their websites or account settings."
+            "Sentry may receive technical error data when a page or function fails.",
+            "Open-Meteo, CARTO map tiles, and open.er-api.com may receive basic request data when weather, maps, or currency rates load.",
+            "Resend and Anthropic receive data only when you submit a form, booking request, or AI planner message that uses those services."
+          ]
+        },
+        {
+          "title": "Managing Your Choice",
+          "items": [
+            "You can reopen Cookie settings from the footer at any time and switch analytics on or off.",
+            "You can also block, delete, or limit cookies and local storage in your browser settings.",
+            "Some features may not work as expected if essential local storage is disabled."
           ]
         },
         {

--- a/src/locales/pl/booking.json
+++ b/src/locales/pl/booking.json
@@ -168,7 +168,10 @@
     "message_placeholder_transfer": "Informacje o przylocie, liczba bagaży, foteliki dziecięce, nazwa hotelu, preferencje VIP albo szczegóły godzin.",
     "message_placeholder_excursion": "Preferowana okolica odbioru, nazwa hotelu, prywatnie albo w grupie, wiek dzieci, dieta albo szczegóły godzin.",
     "message_placeholder_default": "Hotele, które lubisz, tempo, specjalna okazja, wiek dzieci, dieta, loty albo to, czego chcesz uniknąć.",
-    "unmatched_message": "Interesuje mnie: {{title}}. {{message}}"
+    "unmatched_message": "Interesuje mnie: {{title}}. {{message}}",
+    "privacy_prefix": "Używamy danych rezerwacyjnych, aby przygotować dostępność, wycenę i kolejne kroki płatności. Szczegóły znajdziesz w naszej",
+    "privacy_link": "Polityce prywatności",
+    "privacy_suffix": "."
   },
   "budget_options": [
     {

--- a/src/locales/pl/common.json
+++ b/src/locales/pl/common.json
@@ -15,6 +15,14 @@
     "label": "Wstecz",
     "aria": "Wróć do poprzedniej strony"
   },
+  "not_found": {
+    "meta_title": "Nie znaleziono strony · Destination Paradise",
+    "meta_description": "Tej strony nie ma na mapie. Wróć na stronę główną i wybierz trasę przez Zanzibar i Tanzanię.",
+    "eyebrow": "404",
+    "title": "Zgubieni na morzu",
+    "body": "Tej strony nie ma na mapie. Wróć na stronę główną i wybierz trasę.",
+    "cta": "← Wróć na stronę główną"
+  },
   "cookies": {
     "aria_label": "Zgoda na pliki cookie",
     "eyebrow": "Preferencje plików cookie",
@@ -40,6 +48,7 @@
     "close": "Zamknij",
     "popular_label": "Popularne wyszukiwania",
     "results_label": "Wyniki wyszukiwania",
+    "results_count": "{{count}} wyników wyszukiwania",
     "loading": "Przygotowywanie indeksu strony...",
     "empty_title": "Brak dokładnego dopasowania.",
     "empty_body": "Wypróbuj miejsce, aktywność, typ pakietu, park safari lub trasę transferu – albo wyślij nam indywidualne zapytanie.",

--- a/src/locales/pl/footer.json
+++ b/src/locales/pl/footer.json
@@ -45,7 +45,8 @@
   "policy": {
     "privacy": "Prywatność",
     "terms": "Regulamin",
-    "cookies": "Cookies"
+    "cookies": "Cookies",
+    "cookie_settings": "Ustawienia cookie"
   },
   "fab": {
     "aria": "Napisz do zespołu na WhatsApp",

--- a/src/locales/pl/home.json
+++ b/src/locales/pl/home.json
@@ -236,7 +236,10 @@
     "submit": "Zapisz się",
     "submit_pending": "Wysyłanie…",
     "submit_done": "Wysłano",
-    "error": "Nie udało się wysłać. Spróbuj ponownie za chwilę."
+    "error": "Nie udało się wysłać. Spróbuj ponownie za chwilę.",
+    "privacy_prefix": "Zapisując się, zgadzasz się, że możemy przechowywać Twój email na potrzeby aktualizacji Destination Paradise. Szczegóły znajdziesz w naszej",
+    "privacy_link": "Polityce prywatności",
+    "privacy_suffix": "."
   },
   "planner": {
     "eyebrow": "Planer podróży AI",
@@ -310,7 +313,10 @@
     "foot": {
       "note": "Plany są szkicami. Przed rezerwacją człowiek sprawdza i wycenia wszystko dokładnie.",
       "handoff_idle": "Wyślij do zespołu",
-      "handoff_done": "Wysłano do zespołu ✓"
+      "handoff_done": "Wysłano do zespołu ✓",
+      "privacy_prefix": "Wiadomości planera mogą być przetwarzane przez Anthropic i wysyłane e-mailem przez Resend, gdy przekazujesz szkic. Szczegóły znajdziesz w naszej",
+      "privacy_link": "Polityce prywatności",
+      "privacy_suffix": "."
     }
   },
   "weather": {
@@ -363,10 +369,24 @@
     "title_suffix": "rusza w pierwszą podróż.",
     "lead": "Destination Paradise narodziło się z marzenia — by łączyć ludzi z pięknem, kulturą i duchem Tanzanii. Po latach przygotowań oficjalnie startujemy z Ungui na Zanzibarze.",
     "highlights": [
-      { "value": "Teraz", "label": "Unguja", "em": true },
-      { "value": "Teraz", "label": "Kontynent", "em": true },
-      { "value": "Wkrótce", "label": "Pemba" },
-      { "value": "Wkrótce", "label": "Mafia Island" }
+      {
+        "value": "Teraz",
+        "label": "Unguja",
+        "em": true
+      },
+      {
+        "value": "Teraz",
+        "label": "Kontynent",
+        "em": true
+      },
+      {
+        "value": "Wkrótce",
+        "label": "Pemba"
+      },
+      {
+        "value": "Wkrótce",
+        "label": "Mafia Island"
+      }
     ],
     "cta": "Poznaj naszą historię"
   },
@@ -393,7 +413,10 @@
       "submit_done": "Wysłano",
       "status_ok": "✓ Asante — mamy Twoją wiadomość. Odpowiemy w ciągu dnia.",
       "status_err_prefix": "Pole sana — nie udało się wysłać. Napisz bezpośrednio na",
-      "status_err_suffix": "albo spróbuj ponownie."
+      "status_err_suffix": "albo spróbuj ponownie.",
+      "privacy_prefix": "Używamy tych danych, aby odpowiedzieć na Twoje zapytanie. Szczegóły znajdziesz w naszej",
+      "privacy_link": "Polityce prywatności",
+      "privacy_suffix": "."
     }
   }
 }

--- a/src/locales/pl/policy.json
+++ b/src/locales/pl/policy.json
@@ -3,47 +3,66 @@
   "meta": {
     "aria_label": "Szczegoly zasad",
     "last_updated": "Ostatnia aktualizacja",
-    "last_updated_value": "13 maja 2026",
+    "last_updated_value": "5 lipca 2026",
     "contact": "Kontakt"
   },
   "policies": {
     "privacy": {
-      "eyebrow": "Prywatnosc",
-      "title": "Polityka prywatnosci",
-      "intro": "Ta polityka wyjasnia, jak Destination Paradise obchodzi sie z danymi, ktore przekazujesz, gdy pytasz o wyjazdy, rezerwujesz atrakcje lub kontaktujesz sie z naszym zespolem.",
+      "eyebrow": "Prywatność",
+      "title": "Polityka prywatności",
+      "intro": "Ta polityka wyjaśnia, jak Destination Paradise przetwarza dane udostępniane podczas korzystania ze strony, wysyłania zapytań, używania planera AI, rezerwacji lub kontaktu z zespołem.",
       "sections": [
         {
           "title": "Jakie Informacje Zbieramy",
           "items": [
-            "Dane kontaktowe, takie jak imie i nazwisko, adres e-mail, numer telefonu, kontakt WhatsApp i kraj.",
-            "Szczegoly podrozy, takie jak preferowane daty, wielkosc grupy, budzet, zainteresowania, hotel lub miejsce odbioru oraz specjalne prosby.",
-            "Wiadomosci wysylane przez formularze, WhatsApp, e-mail lub kanaly spolecznosciowe.",
-            "Podstawowe informacje techniczne, takie jak typ przegladarki, informacje o urzadzeniu, odwiedzone strony i przyblizona lokalizacja z narzedzi analitycznych."
+            "Dane kontaktowe, takie jak imię i nazwisko, adres e-mail, numer telefonu, kontakt WhatsApp i kraj.",
+            "Szczegóły podróży, takie jak preferowane daty, liczba osób, budżet, zainteresowania, hotel lub miejsce odbioru oraz specjalne prośby.",
+            "Wiadomości wysyłane przez formularze, WhatsApp, e-mail lub kanały społecznościowe.",
+            "Historię czatu i szczegóły przekazania z planera AI, gdy używasz planera lub prosisz o wysłanie szkicu do zespołu.",
+            "Podstawowe dane techniczne, takie jak typ przeglądarki, informacje o urządzeniu, odwiedzane strony, wybór języka, wybór cookie oraz przybliżona lokalizacja z narzędzi analitycznych, jeśli wyrazisz zgodę."
           ]
         },
         {
-          "title": "Jak Wykorzystujemy Twoje Informacje",
+          "title": "Jak Używamy Informacji",
           "items": [
-            "Aby odpowiadac na zapytania oraz przygotowywac propozycje podrozy, wyceny, rezerwacje i plany wyjazdu.",
-            "Aby koordynowac przewodnikow, kierowcow, partnerow noclegowych, operatorow lodzi, dostawcow safari i innych partnerow potrzebnych do realizacji wyjazdu.",
-            "Aby ulepszac nasza strone, obsluge klienta, pakiety, wycieczki i planowanie safari.",
-            "Aby wysylac aktualizacje rezerwacji, wiadomosci serwisowe i informacje powiazane z Twoja prosba."
+            "Aby odpowiadać na zapytania oraz przygotowywać propozycje podróży, wyceny, rezerwacje i plany.",
+            "Aby koordynować przewodników, kierowców, partnerów noclegowych, operatorów łodzi, dostawców safari i innych partnerów potrzebnych do realizacji podróży.",
+            "Aby obsługiwać planer AI, zapamiętać szkic lokalnie i wysłać wiadomość do zespołu, gdy wybierzesz przekazanie planu.",
+            "Aby ulepszać stronę, obsługę klienta, pakiety, wycieczki i doświadczenie planowania safari.",
+            "Aby wysyłać aktualizacje rezerwacji, wiadomości serwisowe i informacje związane z Twoim zapytaniem."
           ]
         },
         {
-          "title": "Udostepnianie Informacji",
+          "title": "Usługodawcy I Udostępnianie Danych",
           "items": [
-            "Udostepniamy tylko te dane, ktore sa potrzebne do zorganizowania podrozy z zaufanymi lokalnymi partnerami, dostawcami platnosci lub uslug.",
-            "Mozemy udostepnic informacje, gdy wymagaja tego przepisy, zasady bezpieczenstwa, procedury graniczne lub oficjalne procedury podrozne.",
+            "Netlify hostuje stronę oraz Netlify Functions, które odbierają formularze kontaktowe, rezerwacyjne, planera i newslettera.",
+            "Resend wysyła powiadomienia do zespołu oraz potwierdzenia do gości z przepływów kontaktu, rezerwacji i planera.",
+            "Anthropic obsługuje planer podróży AI. Prompty i ostatnia historia czatu są wysyłane do Anthropic wyłącznie dla tej funkcji.",
+            "Google Analytics mierzy wizyty na stronach dopiero po zaakceptowaniu cookie analitycznych. Google może ustawiać cookie _ga do pomiaru.",
+            "Sentry zbiera techniczne raporty błędów, abyśmy mogli diagnozować uszkodzone strony i funkcje.",
+            "Open-Meteo, kafelki map CARTO i open.er-api.com dostarczają dane pogodowe, mapowe i kursów walut dla publicznych funkcji strony.",
+            "Udostępniamy tylko dane potrzebne do organizacji podróży zaufanym lokalnym przewodnikom, kierowcom, partnerom noclegowym, operatorom łodzi, dostawcom safari, dostawcom płatności lub urzędom, jeśli jest to wymagane.",
+            "Możemy udostępniać informacje, gdy wymagają tego przepisy prawa, bezpieczeństwo, zasady graniczne lub oficjalne procedury podróży.",
             "Nie sprzedajemy Twoich danych osobowych."
           ]
         },
         {
-          "title": "Twoje Mozliwosci",
+          "title": "Przechowywanie, Retencja I Bezpieczeństwo",
           "items": [
-            "Mozesz poprosic nas o poprawienie, zaktualizowanie lub usuniecie danych osobowych, gdy nie sa juz potrzebne do rezerwacji, ksiegowosci, bezpieczenstwa lub z powodow prawnych.",
-            "Mozesz nie podawac opcjonalnych danych, chociaz moze to ograniczyc dokladnosc planowania Twojej podrozy.",
-            "Mozesz w kazdej chwili zrezygnowac z wiadomosci marketingowych, kontaktujac sie z nami."
+            "Przechowujemy zapytania i dane rezerwacyjne tylko tak długo, jak jest to potrzebne do odpowiedzi, organizacji podróży, księgowości, obowiązków prawnych i poprawy jakości usług.",
+            "Lokalna pamięć przeglądarki może przechowywać język, motyw, wybór cookie, cache kursów walut, historię planera i szkic przekazania, aby strona działała sprawnie.",
+            "Stosujemy rozsądne zabezpieczenia techniczne, takie jak HTTPS, kontrole dostępu u dostawców, limity rozmiaru zapytań, walidację, rate limiting i monitorowanie błędów.",
+            "Żadna strona ani system e-mail nie są idealnie bezpieczne, dlatego nie wysyłaj skanów paszportu, danych kart płatniczych ani bardzo wrażliwych danych zdrowotnych przez otwarte pola tekstowe."
+          ]
+        },
+        {
+          "title": "Twoje Wybory",
+          "items": [
+            "Możesz poprosić nas o poprawienie, aktualizację lub usunięcie danych osobowych, gdy nie są już potrzebne do rezerwacji, księgowości, bezpieczeństwa lub celów prawnych.",
+            "Możesz nie podawać danych opcjonalnych, choć może to ograniczyć dokładność przygotowania planu podróży.",
+            "Możesz w każdej chwili otworzyć Ustawienia cookie w stopce i wycofać zgodę analityczną. Po wyłączeniu analityki wyłączamy Google Analytics i usuwamy jego cookie analityczne z tej przeglądarki.",
+            "Możesz wyczyścić lokalną pamięć przeglądarki, taką jak historia planera, język, motyw i cache kursów walut, w ustawieniach przeglądarki.",
+            "Możesz w każdej chwili zrezygnować z wiadomości marketingowych, kontaktując się z nami."
           ]
         }
       ]
@@ -89,37 +108,47 @@
     },
     "cookies": {
       "eyebrow": "Cookies",
-      "title": "Polityka cookies",
-      "intro": "Ta polityka wyjasnia, jak cookies i podobne technologie moga byc uzywane, aby strona dzialala, aby rozumiec wizyty i ulepszac planowanie podrozy.",
+      "title": "Polityka cookie",
+      "intro": "Ta polityka wyjaśnia, jakich cookie, pamięci lokalnej i podobnych technologii używa Destination Paradise.",
       "sections": [
         {
-          "title": "Czym Sa Cookies",
+          "title": "Niezbędna Pamięć",
           "items": [
-            "Cookies to male pliki zapisywane na Twoim urzadzeniu podczas odwiedzania strony internetowej.",
-            "Podobne technologie, takie jak pamiec lokalna, piksele i tagi analityczne, moga pomagac zapamietywac ustawienia lub mierzyc sposob korzystania ze stron."
+            "dp_cookie_consent_v1 zapisuje wybór cookie, abyśmy wiedzieli, czy analityka jest dozwolona.",
+            "dp_tweaks zapisuje preferencje motywu i wyglądu, takie jak tryb jasny lub ciemny.",
+            "dp_lang zapisuje wybór języka, a dp_fx_rates może przechowywać kursy walut do wyświetlania cen.",
+            "plannerHistory i dp_planner_handoff zapisują czat planera AI oraz szkice przekazania w przeglądarce, aby można było kontynuować lub wysłać plan."
           ]
         },
         {
-          "title": "Jak Uzywamy Cookies",
+          "title": "Cookie Analityczne",
           "items": [
-            "Niezbedne cookies i pamiec pomagaja stronie sie ladowac, zapamietywac preferencje motywu, obslugiwac formularze i utrzymywac stabilne dzialanie.",
-            "Cookies analityczne moga pomoc nam zrozumiec, ktore strony sa przydatne, skad trafiaja odwiedzajacy i jak mozemy ulepszyc strone.",
-            "Narzedzia marketingowe lub platform spolecznosciowych moga byc uzywane, gdy korzystasz z tresci osadzonych, linkow spolecznosciowych lub linkow kampanii."
+            "Google Analytics ładuje się dopiero po zaakceptowaniu analityki w banerze cookie lub Ustawieniach cookie.",
+            "Analityka pomaga nam zrozumieć, które strony są przydatne, skąd trafiają odwiedzający i gdzie można ulepszyć planowanie podróży.",
+            "Google Analytics może ustawiać _ga i powiązane cookie. Jeśli później wyłączysz analitykę, strona wyłączy analitykę i spróbuje usunąć te cookie z tej przeglądarki."
           ]
         },
         {
-          "title": "Zarzadzanie Cookies",
+          "title": "Żądania Do Usług Zewnętrznych",
           "items": [
-            "Mozesz blokowac, usuwac lub ograniczac cookies w ustawieniach przegladarki.",
-            "Niektore funkcje moga nie dzialac zgodnie z oczekiwaniami, jesli niezbedne cookies lub pamiec lokalna sa wylaczone.",
-            "Uslugi zewnetrzne moga udostepniac wlasne ustawienia prywatnosci i cookies na swoich stronach lub w ustawieniach konta."
+            "Sentry może otrzymywać techniczne dane błędów, gdy strona lub funkcja nie działa poprawnie.",
+            "Open-Meteo, kafelki map CARTO i open.er-api.com mogą otrzymywać podstawowe dane zapytań, gdy ładowana jest pogoda, mapy lub kursy walut.",
+            "Resend i Anthropic otrzymują dane tylko wtedy, gdy wysyłasz formularz, zapytanie rezerwacyjne lub wiadomość planera AI korzystającą z tych usług."
+          ]
+        },
+        {
+          "title": "Zarządzanie Wyborem",
+          "items": [
+            "Możesz w każdej chwili otworzyć Ustawienia cookie w stopce i włączyć lub wyłączyć analitykę.",
+            "Możesz też blokować, usuwać lub ograniczać cookie i pamięć lokalną w ustawieniach przeglądarki.",
+            "Niektóre funkcje mogą nie działać zgodnie z oczekiwaniami, jeśli niezbędna pamięć lokalna jest wyłączona."
           ]
         },
         {
           "title": "Aktualizacje",
           "items": [
-            "Mozemy aktualizowac te polityke, gdy zmieniaja sie narzedzia strony, konfiguracja analityki lub procesy rezerwacji.",
-            "Najnowsza wersja bedzie opublikowana na tej stronie z data aktualizacji."
+            "Możemy aktualizować tę politykę, gdy zmienią się narzędzia strony, konfiguracja analityki lub procesy rezerwacji.",
+            "Najnowsza wersja będzie opublikowana na tej stronie z aktualną datą."
           ]
         }
       ]

--- a/src/pages/Booking.jsx
+++ b/src/pages/Booking.jsx
@@ -22,6 +22,7 @@ import { useFloatingBookingSummary } from '../hooks/useFloatingBookingSummary.js
 import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import usePageMeta from '../hooks/usePageMeta.js';
 import { buildPlannerHandoff, clearPlannerHandoff, isPlannerHandoffMessage, readPlannerHandoff } from '../utils/plannerHandoff.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 import { useCurrency } from '../context/useCurrency.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
@@ -141,7 +142,7 @@ export default function Booking() {
     }));
 
     const timeoutId = window.setTimeout(() => {
-      document.getElementById('booking-form')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById('booking-form')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
     }, 120);
 
     return () => window.clearTimeout(timeoutId);
@@ -255,6 +256,7 @@ export default function Booking() {
       transferTime: isTransferRequest ? form.transferTime : '',
       productLabel: selectedProduct?.label || t('common.not_selected', { defaultValue: 'Not selected' }),
       estimatedPrice: bookingPriceLabel(selectedProduct, t, format),
+      lang: i18n.resolvedLanguage || i18n.language || 'en',
       source: plannerHandoff ? 'planner' : 'booking',
       plannerDraft: plannerHandoff?.transcript || '',
     };

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, lazy, Suspense } from 'react';
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import '../styles/homepage.css';
 import { EXCURSIONS } from '../data/excursionsData.js';
@@ -22,6 +21,7 @@ const AboutSection = lazy(() => import('../components/homepage/AboutSection.jsx'
 const ContactSection = lazy(() => import('../components/homepage/ContactSection.jsx'));
 const NewsletterSection = lazy(() => import('../components/homepage/NewsletterSection.jsx'));
 import { readStoredTheme, readStoredThemeMode, readStoredTweaks } from '../utils/theme.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 
 const PINS = DESTINATION_MAP_PINS;
 
@@ -75,7 +75,7 @@ export default function Homepage() {
 
   // Persist design-preview tweaks. The active theme is managed globally.
   useEffect(() => {
-    try { localStorage.setItem('dp_tweaks', JSON.stringify(tweaks)); } catch (e) { /* noop */ }
+    try { localStorage.setItem('dp_tweaks', JSON.stringify(tweaks)); } catch { /* noop */ }
   }, [tweaks]);
 
   useEffect(() => {
@@ -145,7 +145,7 @@ export default function Homepage() {
       }
     };
     window.addEventListener('message', onMsg);
-    try { window.parent.postMessage({ type: '__edit_mode_available' }, '*'); } catch (e) { /* noop */ }
+    try { window.parent.postMessage({ type: '__edit_mode_available' }, '*'); } catch { /* noop */ }
     return () => window.removeEventListener('message', onMsg);
   }, []);
 
@@ -177,7 +177,7 @@ export default function Homepage() {
       text: `I'm looking for ${experienceText}${dateText} for ${guests}. Can you suggest the best fit and ask me anything else you need?`,
     });
     const target = document.getElementById('planner-chat') || document.getElementById('planner');
-    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    target?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
   };
 
   const islandPins = PINS.filter((p) => p.region === 'Zanzibar');

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,16 +1,18 @@
 import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import usePageMeta from '../hooks/usePageMeta.js';
 import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
 import '../styles/homepage.css';
 
 export default function NotFound() {
+  const { t } = useTranslation('common');
   const pageRef = useRef(null);
   useRevealOnScroll(pageRef, '.reveal:not(.is-visible)', 1);
 
   usePageMeta({
-    title: 'Page Not Found · Destination Paradise',
-    description: "That page isn't on the map. Head back to the homepage and pick a route through Zanzibar and Tanzania.",
+    title: t('not_found.meta_title'),
+    description: t('not_found.meta_description'),
     noindex: true,
   });
 
@@ -27,12 +29,12 @@ export default function NotFound() {
       }}
     >
       <div style={{ maxWidth: 640, textAlign: 'center' }}>
-        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>404</span>
-        <h1 className="section-title reveal" style={{ marginTop: '1rem', '--reveal-index': 1 }}>Lost at sea</h1>
+        <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('not_found.eyebrow')}</span>
+        <h1 className="section-title reveal" style={{ marginTop: '1rem', '--reveal-index': 1 }}>{t('not_found.title')}</h1>
         <p className="section-lead reveal" style={{ marginBottom: '2rem', '--reveal-index': 2 }}>
-          That page isn&apos;t on the map. Head back to the homepage and pick a route.
+          {t('not_found.body')}
         </p>
-        <Link className="btn reveal" to="/" style={{ '--reveal-index': 3 }}>← Back to home</Link>
+        <Link className="btn reveal" to="/" style={{ '--reveal-index': 3 }}>{t('not_found.cta')}</Link>
       </div>
     </main>
   );

--- a/src/pages/Packages.jsx
+++ b/src/pages/Packages.jsx
@@ -6,6 +6,7 @@ import { useCurrency } from '../context/useCurrency.js';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
 import usePageMeta from '../hooks/usePageMeta.js';
 import { arrayFromTranslation } from '../utils/translationValues.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
 import '../styles/safaris.css';
@@ -168,7 +169,7 @@ export default function Packages() {
                 className="btn btn--ghost btn--lg"
                 onClick={() => {
                   setVisibleCount(INITIAL_PACKAGE_COUNT);
-                  document.getElementById('packages')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  document.getElementById('packages')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
                 }}
               >
                 {t('grid.show_fewer')}

--- a/src/pages/TripPlannerPage.jsx
+++ b/src/pages/TripPlannerPage.jsx
@@ -5,6 +5,7 @@ import PlannerSection from '../components/homepage/PlannerSection.jsx';
 import ResponsiveImage from '../components/ResponsiveImage.jsx';
 import usePageMeta from '../hooks/usePageMeta.js';
 import { arrayFromTranslation } from '../utils/translationValues.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
 
@@ -85,7 +86,7 @@ export default function TripPlannerPage() {
 
     if (scrollTimeoutRef.current) window.clearTimeout(scrollTimeoutRef.current);
     scrollTimeoutRef.current = window.setTimeout(() => {
-      document.getElementById('planner')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById('planner')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
     }, 140);
   }, [ready, searchParams, t]);
 
@@ -94,7 +95,7 @@ export default function TripPlannerPage() {
     setInitialPrompt({ id: Date.now(), text: prompt.text });
     if (scrollTimeoutRef.current) window.clearTimeout(scrollTimeoutRef.current);
     scrollTimeoutRef.current = window.setTimeout(() => {
-      document.getElementById('planner')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById('planner')?.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
     }, 80);
   };
 

--- a/src/styles/booking/form.css
+++ b/src/styles/booking/form.css
@@ -147,6 +147,20 @@
   margin-top: .25rem;
 }
 
+.booking-privacy {
+  margin: -.25rem 0 0;
+  color: var(--text-muted);
+  font-family: var(--dp-font-sans);
+  font-size: .8rem;
+  line-height: 1.5;
+}
+.booking-privacy a {
+  color: var(--dp-accent-text);
+  font-weight: 800;
+  text-decoration: none;
+}
+.booking-privacy a:hover { text-decoration: underline; }
+
 .booking-status {
   margin: 0;
   padding: .75rem .9rem;
@@ -164,4 +178,3 @@
   color: var(--dp-error);
   background: var(--dp-error-bg);
 }
-

--- a/src/styles/components/lang-switcher.css
+++ b/src/styles/components/lang-switcher.css
@@ -39,7 +39,7 @@
 }
 
 .lang-switcher__toggle:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--dp-accent) 50%, transparent);
+  outline: 2px solid var(--dp-focus-ring);
   outline-offset: 2px;
 }
 
@@ -84,7 +84,7 @@
 }
 
 .lang-switcher__option:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--dp-accent) 50%, transparent);
+  outline: 2px solid var(--dp-focus-ring);
   outline-offset: -2px;
 }
 

--- a/src/styles/homepage/buttons.css
+++ b/src/styles/homepage/buttons.css
@@ -7,8 +7,7 @@
   border: 1px solid rgba(255,255,255,.08);
   border-radius: 14px;
   padding: .95rem 1.75rem;
-  background:
-    linear-gradient(135deg, rgba(26,77,110,.74) 0%, rgba(255,111,97,.84) 100%);
+  background: var(--dp-gradient-button);
   color: #fff;
   cursor: pointer;
   display: inline-flex;
@@ -21,22 +20,19 @@
   transition: transform .3s ease, box-shadow .3s ease, background .3s ease, border-color .3s ease, color .3s ease;
 }
 .btn:hover {
-  background:
-    linear-gradient(135deg, rgba(26,77,110,.86) 0%, rgba(255,111,97,.95) 100%);
+  background: var(--dp-gradient-button-hover);
   color: #fff;
   transform: translateY(-2px);
   box-shadow: 0 22px 42px -26px rgba(0,0,0,.55);
 }
 .btn--lg { padding: 1.05rem 2rem; font-size: 15px; }
 .btn--accent {
-  background:
-    linear-gradient(135deg, rgba(26,77,110,.74) 0%, rgba(255,111,97,.84) 100%);
+  background: var(--dp-gradient-button);
   color: #fff;
   border-color: rgba(255,255,255,.08);
 }
 .btn--accent:hover {
-  background:
-    linear-gradient(135deg, rgba(26,77,110,.86) 0%, rgba(255,111,97,.95) 100%);
+  background: var(--dp-gradient-button-hover);
   color: #fff;
 }
 .btn--ghost,
@@ -58,14 +54,14 @@
 
 /* Light theme: ghost button on page body backgrounds */
 html[data-theme="light"] .btn--ghost {
-  background: linear-gradient(135deg, var(--dp-primary) 0%, var(--dp-accent) 100%);
+  background: var(--dp-gradient-button);
   color: #fff;
   border: 1px solid transparent;
   box-shadow: 0 6px 22px rgba(255, 111, 97, .28), 0 2px 8px rgba(26, 77, 110, .18);
   backdrop-filter: none;
 }
 html[data-theme="light"] .btn--ghost:hover {
-  background: linear-gradient(135deg, #133a53 0%, #e85a4d 100%);
+  background: var(--dp-gradient-button-hover);
   color: #fff;
   border-color: transparent;
   box-shadow: 0 10px 30px rgba(255, 111, 97, .38), 0 4px 12px rgba(26, 77, 110, .2);
@@ -74,14 +70,14 @@ html[data-theme="light"] .btn--ghost:hover {
 
 /* Dark theme: show-more / show-fewer buttons on page body */
 html[data-theme="dark"] .exc-grid__actions .btn--ghost {
-  background: linear-gradient(135deg, rgba(26,77,110,.82) 0%, rgba(255,111,97,.82) 100%);
+  background: var(--dp-gradient-button);
   color: #fff;
   border: 1px solid rgba(255,255,255,.12);
   box-shadow: 0 6px 22px rgba(255, 111, 97, .18), 0 2px 8px rgba(0, 0, 0, .28);
   backdrop-filter: none;
 }
 html[data-theme="dark"] .exc-grid__actions .btn--ghost:hover {
-  background: linear-gradient(135deg, rgba(26,77,110,.96) 0%, rgba(232,90,77,.95) 100%);
+  background: var(--dp-gradient-button-hover);
   color: #fff;
   border-color: rgba(255,255,255,.2);
   box-shadow: 0 10px 30px rgba(255, 111, 97, .28), 0 4px 12px rgba(0, 0, 0, .35);

--- a/src/styles/homepage/contact.css
+++ b/src/styles/homepage/contact.css
@@ -80,6 +80,20 @@ a.contact__detail-value:hover { color: var(--dp-accent); }
 .contact__field textarea { resize: vertical; min-height: 120px; line-height: 1.55; }
 .contact__submit { align-self: flex-start; margin-top: .25rem; }
 
+.contact__privacy {
+  margin: -.15rem 0 0;
+  color: var(--text-muted);
+  font-family: var(--dp-font-sans);
+  font-size: .78rem;
+  line-height: 1.5;
+}
+.contact__privacy a {
+  color: var(--dp-accent-text);
+  font-weight: 800;
+  text-decoration: none;
+}
+.contact__privacy a:hover { text-decoration: underline; }
+
 .contact__status {
   font-family: var(--dp-font-sans);
   font-size: 13px;

--- a/src/styles/homepage/footer.css
+++ b/src/styles/homepage/footer.css
@@ -103,5 +103,25 @@
 }
 .footer__copyright { min-width: 0; }
 .footer__policy-links { min-width: 0; }
-.footer__bottom a { color: var(--text-soft); text-decoration: none; margin-left: 1rem; }
-.footer__bottom a:hover { color: var(--dp-accent); }
+.footer__bottom a,
+.footer__bottom button {
+  color: var(--text-soft);
+  text-decoration: none;
+  margin-left: 1rem;
+}
+.footer__bottom button {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+.footer__bottom a:hover,
+.footer__bottom button:hover {
+  color: var(--dp-accent-text);
+}
+.footer__bottom button:focus-visible {
+  outline: 2px solid var(--dp-accent-text);
+  outline-offset: 3px;
+}

--- a/src/styles/homepage/newsletter.css
+++ b/src/styles/homepage/newsletter.css
@@ -45,9 +45,21 @@
   cursor: pointer; display: inline-flex; align-items: center; gap: .5rem;
   transition: all .3s ease;
 }
-.newsletter__submit:hover { background-image: var(--dp-gradient-button-hover); color: var(--dp-hover); }
+.newsletter__submit:hover { background-image: var(--dp-gradient-button-hover); color: #fff; }
 .newsletter__note { font-family: var(--dp-font-sans); font-size: 11px; opacity: .7; letter-spacing: .08em; margin-top: .85rem; }
-.newsletter__note--error { opacity: 1; color: #ffd1cd; }
+.newsletter__note--error { opacity: 1; color: var(--dp-error); }
+.newsletter__privacy {
+  max-width: 44rem;
+  opacity: .82;
+  line-height: 1.55;
+  letter-spacing: 0;
+}
+.newsletter__privacy a {
+  color: var(--dp-accent-text);
+  font-weight: 800;
+  text-decoration: none;
+}
+.newsletter__privacy a:hover { text-decoration: underline; }
 
 @media (max-width: 720px) {
   .newsletter {
@@ -107,6 +119,14 @@ html[data-theme="dark"] .newsletter__title {
 html[data-theme="dark"] .newsletter__form {
   background: rgba(17,44,63,.9);
   border-color: rgba(255,255,255,.1);
+}
+
+html[data-theme="dark"] .newsletter__privacy a {
+  color: #ffb1a8;
+}
+
+html[data-theme="dark"] .newsletter__note--error {
+  color: #ffb1a8;
 }
 
 @media (max-width: 720px) {

--- a/src/styles/homepage/planner.css
+++ b/src/styles/homepage/planner.css
@@ -554,6 +554,7 @@
 .planner__foot {
   padding: .85rem 1rem;
   display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
   font-size: .86rem;
   line-height: 1.45;
@@ -561,6 +562,7 @@
   border-top: 1px solid var(--divider);
 }
 [data-theme="dark"] .planner__foot { border-top-color: rgba(255,255,255,.16); }
+[data-theme="dark"] .planner__privacy a { color: #ffb1a8; }
 .planner__foot--simple {
   justify-content: center;
   text-align: center;
@@ -569,6 +571,19 @@
   flex: 1 1 auto;
   min-width: 0;
 }
+.planner__privacy {
+  flex: 1 1 100%;
+  margin-top: -.45rem;
+  color: var(--text-muted);
+  font-size: .74rem;
+  line-height: 1.45;
+}
+.planner__privacy a {
+  color: var(--dp-accent-text);
+  font-weight: 800;
+  text-decoration: none;
+}
+.planner__privacy a:hover { text-decoration: underline; }
 .planner__handoff {
   flex-shrink: 0;
   display: inline-flex;

--- a/src/styles/homepage/site-search.css
+++ b/src/styles/homepage/site-search.css
@@ -43,7 +43,7 @@
 }
 /* Visible keyboard focus for the borderless search input (WCAG 2.4.7). */
 .site-search__field:focus-within {
-  outline: 2px solid var(--dp-accent);
+  outline: 2px solid var(--dp-focus-ring);
   outline-offset: 2px;
   border-radius: 6px;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -58,8 +58,9 @@
   --dp-bg-2: var(--dp-background-lt);
   --dp-bg-3: var(--dp-background-dk);
 
-  --dp-gradient-button: linear-gradient(120deg, rgba(26, 77, 110, 0.8) 0%, rgba(255, 111, 97, 0.8) 100%);
-  --dp-gradient-button-hover: linear-gradient(120deg, rgba(19, 58, 83, 0.8) 0%, rgba(255, 79, 62, 0.8) 100%);
+  --dp-gradient-button: linear-gradient(120deg, #16445F 0%, #B43A2A 100%);
+  --dp-gradient-button-hover: linear-gradient(120deg, #11364B 0%, #942B1F 100%);
+  --dp-focus-ring: #9F341F;
   --dp-gradient-accent-bar: linear-gradient(90deg, var(--dp-accent), #2B6F93);
   --dp-gradient-hero-scrim: linear-gradient(180deg, transparent 40%, rgba(26, 77, 110, 0.28));
 

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -19,6 +19,7 @@ export function hasAnalyticsConsent() {
 
 export function loadGoogleAnalytics() {
   if (typeof window === 'undefined' || analyticsReady || !hasAnalyticsConsent()) return false;
+  window[`ga-disable-${GOOGLE_ANALYTICS_ID}`] = false;
 
   const dataLayer = (window.dataLayer = window.dataLayer || []);
   window.gtag = window.gtag || function gtag() {
@@ -36,6 +37,39 @@ export function loadGoogleAnalytics() {
   window.gtag('config', GOOGLE_ANALYTICS_ID, { send_page_view: false });
   analyticsReady = true;
   return true;
+}
+
+function deleteCookie(name, domain) {
+  const domainPart = domain ? `; domain=${domain}` : '';
+  document.cookie = `${name}=; Max-Age=0; path=/${domainPart}; SameSite=Lax`;
+}
+
+function deleteAnalyticsCookies() {
+  const hostParts = window.location.hostname.split('.');
+  const domains = new Set(['']);
+
+  for (let index = 0; index < hostParts.length - 1; index += 1) {
+    domains.add(`.${hostParts.slice(index).join('.')}`);
+  }
+
+  const cookieNames = document.cookie
+    .split(';')
+    .map((cookie) => cookie.trim().split('=')[0])
+    .filter((name) => name === '_ga' || name.startsWith('_ga_') || name === '_gid' || name === '_gat');
+
+  cookieNames.forEach((name) => {
+    domains.forEach((domain) => deleteCookie(name, domain));
+  });
+}
+
+export function revokeGoogleAnalytics() {
+  if (typeof window === 'undefined') return;
+  window[`ga-disable-${GOOGLE_ANALYTICS_ID}`] = true;
+  analyticsReady = false;
+  if (typeof window.gtag === 'function') {
+    window.gtag('consent', 'update', { analytics_storage: 'denied' });
+  }
+  deleteAnalyticsCookies();
 }
 
 export function trackPageView(path) {

--- a/src/utils/motion.js
+++ b/src/utils/motion.js
@@ -1,0 +1,4 @@
+export function preferredScrollBehavior() {
+  if (typeof window === 'undefined') return 'smooth';
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+}

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -19,7 +19,7 @@ export function readStoredTweaks() {
   try {
     const saved = JSON.parse(localStorage.getItem(THEME_STORAGE_KEY) || 'null');
     return saved && typeof saved === 'object' ? saved : null;
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -44,7 +44,7 @@ export function persistThemeMode(mode, theme = resolveThemeForMode(mode)) {
   try {
     const saved = readStoredTweaks() || {};
     localStorage.setItem(THEME_STORAGE_KEY, JSON.stringify({ ...saved, themeMode: nextMode, theme: nextTheme }));
-  } catch (e) {
+  } catch {
     /* noop */
   }
 
@@ -55,7 +55,7 @@ function getThemeQuery(query) {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
   try {
     return window.matchMedia(query);
-  } catch (e) {
+  } catch {
     return null;
   }
 }

--- a/test/i18n/locale-parity.test.mjs
+++ b/test/i18n/locale-parity.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const LOCALE_ROOT = new URL('../../src/locales/', import.meta.url);
+const BASE_LANG = 'en';
+const OTHER_LANGS = ['de', 'pl'];
+
+function readNamespace(lang, file) {
+  return JSON.parse(readFileSync(join(LOCALE_ROOT.pathname, lang, file), 'utf8'));
+}
+
+function collectShapeMismatches(baseValue, otherValue, path = []) {
+  if (Array.isArray(baseValue)) {
+    if (!Array.isArray(otherValue)) return [`${path.join('.')} expected array`];
+    if (baseValue.length !== otherValue.length) {
+      return [`${path.join('.')} expected ${baseValue.length} items, got ${otherValue.length}`];
+    }
+    return [];
+  }
+
+  if (!baseValue || typeof baseValue !== 'object') return [];
+  if (!otherValue || typeof otherValue !== 'object' || Array.isArray(otherValue)) {
+    return [`${path.join('.')} expected object`];
+  }
+
+  const baseKeys = Object.keys(baseValue);
+  const otherKeys = Object.keys(otherValue);
+  const missing = baseKeys
+    .filter((key) => !otherKeys.includes(key))
+    .map((key) => `${[...path, key].join('.')} missing`);
+  const extra = otherKeys
+    .filter((key) => !baseKeys.includes(key))
+    .map((key) => `${[...path, key].join('.')} extra`);
+  const nested = baseKeys.flatMap((key) =>
+    collectShapeMismatches(baseValue[key], otherValue[key], [...path, key]));
+
+  return [...missing, ...extra, ...nested];
+}
+
+describe('locale namespace parity', () => {
+  const files = readdirSync(join(LOCALE_ROOT.pathname, BASE_LANG)).filter((file) => file.endsWith('.json'));
+
+  for (const file of files) {
+    it(`${file} keeps matching keys and array lengths`, () => {
+      const base = readNamespace(BASE_LANG, file);
+      const mismatches = OTHER_LANGS.flatMap((lang) =>
+        collectShapeMismatches(base, readNamespace(lang, file)).map((message) => `${lang}: ${message}`));
+
+      expect(mismatches).toEqual([]);
+    });
+  }
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,10 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         injectRegister: 'script-defer',
+        workbox: {
+          clientsClaim: true,
+          skipWaiting: true,
+        },
         devOptions: {
           enabled: false
         },


### PR DESCRIPTION
## What this is

A comprehensive site audit (8 dimensions, findings adversarially verified against the code before fixing) and the resulting fixes. Everything below is verified: lint clean (0 warnings), typecheck clean, **52/52 tests** (locale-parity + function tests added), full build green with **120/120 routes + /404 prerendered**.

## Legal / GDPR (was the biggest gap)
- **Consent withdrawal is now as easy as consent** (Art. 7(3)): "Cookie settings" in the footer reopens the banner with stored choices; revoking analytics sets the `ga-disable` flag, sends `gtag consent denied`, and deletes `_ga*` cookies.
- **Privacy + cookies policies rewritten (en/de/pl)** naming every actual processor — GA4, Sentry, Resend, **Anthropic (trip-planner chat)**, Netlify (+ the `/api/geo` IP lookup), CARTO/Open-Meteo/ExchangeRate-API — plus the real storage keys (`dp_cookie_consent_v1`, `dp_lang`, `dp_tweaks`), rights catalog, and transfer language. The Polish policy file had been ASCII-transliterated (zero diacritics on legal pages) — restored.
- Privacy notice + link near every form submit.

## SEO / sharing
- **Canonical domain**: everything pointed at the netlify.app subdomain while `yournexttriptoparadise.com` is live production → all canonicals/og/JSON-LD/sitemap/robots switched, plus a forced 301 off the subdomain (kills the duplicate-content split).
- **Real 404s**: unknown URLs used to serve the prerendered homepage with `index, follow` (soft-404 farm). Now: prerendered `404.html` (noindex) + catch-all `status 404`; prerender **fails the CI build** if 404.html can't render, so the catch-all can't ship unbacked.
- **Trailing-slash alignment**: every non-root sitemap/canonical URL previously 301-redirected (Netlify directory serving). Sitemap + canonicals now emit the served form.
- OG image already ideal (1200×630, 91KB) — no change needed.

## Accessibility (ratios computed, not eyeballed)
- CTA button gradients: white label contrast was **2.37:1** on the coral end → new token gradient ends at **5.87:1** worst-case (slight visual darkening of primary buttons — please eyeball and confirm you're happy).
- Coral accent (`#FF6F61`, 2.6:1) swapped to the existing `--dp-accent-text` token in all small-text uses; newsletter error message was 1.33:1 → fixed.
- Search overlay: real focus trap + focus restore (was `aria-modal` with no trap); results count announced; focus rings ≥3:1; `scrollIntoView` respects reduced motion; language switcher restores focus.

## Backend hardening
- Timeouts on Resend + Anthropic fetches (hangs previously rode into the platform kill, risking duplicate emails on retry).
- CR/LF stripped from subject-line fields; planner-send gets the honeypot + Sentry capture the other functions had.
- **Guest confirmation emails localized (en/de/pl)** — the frontend now sends the user's language; the AI planner replies in the guest's language.

## Perf / hygiene
- Service worker `autoUpdate` didn't actually update (no skipWaiting/clientsClaim in the compiled SW) → fixed; returning visitors no longer run a full deploy behind.
- Cache rules made **non-overlapping** (Netlify merges duplicate headers across matching rules): hashed build files stay immutable, unhashed images/brand get 1d + stale-while-revalidate — this is what previously made in-place image replacements invisible to returning visitors.
- LCP hero was a 360×640 image upscaled ~5× → properly sized 1195×800 slide is now first.
- GitHub Actions CI (lint/typecheck/test/build on `development` pushes + PRs) — nothing ran automatically before; `engines: node >=22`; locale-parity test locks translation key drift; dead `booking-request` Netlify form stub removed.

## Needs your decision (not code)
1. **Impressum**: none exists. Site actively targets Germany (geo auto-switch). Needs your legal entity name/address to add one.
2. **Product catalog is English-only in de/pl**: all 51 excursions + 18 safaris render English body copy under translated chrome. ~69 products × 2 languages is a translation project — machine-translate, professional translation, or accept?
3. **Guest-copy emails echo user text to any address** (branded phishing-relay surface). Real fix is Turnstile/CAPTCHA — worth the UX cost?
4. **Newsletter has no double-opt-in** — a UWG §7 exposure for German recipients (Netlify Forms can't do DOI; needs a provider or a small function).
5. Verify **Anthropic + Resend spend caps** are set (rate limiting is per-instance best-effort by design).
6. Stale `underconstruction` branch (818 behind) — delete?
7. In Netlify domain settings, consider making `yournexttriptoparadise.com` the primary domain if it isn't (the new 301 rule covers it either way).

## Known accepted limitations (flagged, not fixed)
- de/pl content is client-side only (no `/de/` URLs) — invisible to crawlers; a localized-URL structure is a separate project.
- `/book-now`, `/booking`, `/trip-planner` still serve the homepage-prerendered shell until JS runs (client-only by design).
- Deferred small items: og:locale, per-product og:images (webp risk for WhatsApp), sitemap lastmod is build-dated, README/SECURITY.md staleness, 17 English cross-link labels in pl explore.json, lazy-loading Sentry/locales out of the main bundle, recompressing 5 heavy retreats images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)