### PR TITLE
Center cookie consent banner

### DIFF
--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -1,6 +1,7 @@
 .cookie-banner {
   position: fixed;
-  right: clamp(1rem, 3vw, 2rem);
+  left: 50%;
+  transform: translateX(-50%);
   bottom: clamp(1rem, 3vw, 2rem);
   z-index: 1200;
   display: grid;
@@ -148,6 +149,7 @@ html[data-theme="dark"] .cookie-banner {
     left: 1rem;
     right: 1rem;
     bottom: 1rem;
+    transform: none;
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Moves the cookie consent banner from bottom-right to bottom-center.

`left: 50%` + `transform: translateX(-50%)` on the base rule; the mobile breakpoint (≤720px) resets `transform: none` so its full-width `left:1rem/right:1rem` layout is unchanged. Verified centered at 1440px and full-width at 375px in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)