### PR TITLE
Expand retreats into a multi-product collection

### DIFF
--- a/src/components/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage.jsx
@@ -14,9 +14,10 @@ const normalizeFetchPriority = (value) => (
  */
 export default function ResponsiveImage({ src, alt = '', fetchpriority, fetchPriority, sizes, width, height, ...imageProps }) {
   const resolvedFetchPriority = fetchPriority ?? normalizeFetchPriority(fetchpriority);
+  const fetchPriorityAttr = resolvedFetchPriority ? { fetchpriority: resolvedFetchPriority } : {};
 
   if (typeof src !== 'string' || !src.endsWith('.webp')) {
-    return <img {...imageProps} src={src} alt={alt} fetchPriority={resolvedFetchPriority} width={width} height={height} />;
+    return <img {...imageProps} {...fetchPriorityAttr} src={src} alt={alt} width={width} height={height} />;
   }
 
   const meta = imageManifest[src];
@@ -37,9 +38,9 @@ export default function ResponsiveImage({ src, alt = '', fetchpriority, fetchPri
   return (
     <img
       {...imageProps}
+      {...fetchPriorityAttr}
       src={src}
       alt={alt}
-      fetchPriority={resolvedFetchPriority}
       width={width ?? fullWidth}
       height={height ?? fullHeight}
       srcSet={srcSetParts.join(', ')}

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -121,6 +121,16 @@ export default function SiteNav({ theme = 'light', themeMode: _themeMode = 'auto
   }, [navOpen]);
 
   useEffect(() => {
+    const menu = mmRef.current;
+    if (!menu) return;
+    if (navOpen) {
+      menu.removeAttribute('inert');
+    } else {
+      menu.setAttribute('inert', '');
+    }
+  }, [navOpen]);
+
+  useEffect(() => {
     const mediaQuery = window.matchMedia(MOBILE_NAV_QUERY);
     let previousBodyOverflow;
 
@@ -252,7 +262,6 @@ export default function SiteNav({ theme = 'light', themeMode: _themeMode = 'auto
         role="dialog"
         aria-modal="true"
         aria-label={t('menu.site_nav_label')}
-        {...(navOpen ? {} : { inert: true })}
       >
         <div className="mm-menu__bg" style={navOpen ? { backgroundImage: `url('${MM_BGS[bgIndex]}')` } : undefined} />
         <div className="mm-menu__scrim" />

--- a/src/components/booking/BookingForm.jsx
+++ b/src/components/booking/BookingForm.jsx
@@ -76,7 +76,7 @@ export default function BookingForm({
       </div>
 
       <div className={`booking-row${showDateRange && !isRetreatRequest ? ' booking-row--thirds' : ''}`}>
-        {isRetreatRequest ? (
+        {isRetreatRequest && retreatDepartures.length > 0 ? (
           <label className="booking-field">
             <span>{t('form.retreat_departure', { defaultValue: 'Retreat departure' })}</span>
             <select name="retreatDeparture" value={form.startDate} onChange={onDepartureChange}>

--- a/src/data/bookingPageData.js
+++ b/src/data/bookingPageData.js
@@ -4,7 +4,7 @@ export const SERVICE_TYPES = [
   { value: 'safari', label: 'Safari', text: 'Mainland wildlife routes, fly-in safaris, migration, southern parks, and custom circuits.' },
   { value: 'transfer', label: 'Transfer', text: 'Private airport, hotel-to-hotel, group, premium SUV, or VIP concierge transfer.' },
   { value: 'custom', label: 'Custom plan', text: 'Not sure yet? Tell us the shape and we will build a route around you.' },
-  { value: 'retreat', label: 'Retreat', text: '14-day yoga & safari retreat on Zanzibar — sunrise vinyasa, yin evenings, meditation, and a mainland safari.' },
+  { value: 'retreat', label: 'Retreat', text: 'Yoga, bodywork, coastal reset weeks, private teacher-led retreats, and safari journeys.' },
 ];
 
 export const PAYMENT_OPTIONS = [

--- a/src/data/retreatProducts.js
+++ b/src/data/retreatProducts.js
@@ -1,7 +1,7 @@
-// The yoga & safari retreat offered on /retreats, exposed to the booking flow
-// as a selectable product. Prices are authored in USD (converted/formatted for
-// EUR/PLN at display time). `departures` are the fixed 14-day start/end dates
-// guests choose from instead of an open date picker.
+// Retreats offered on /retreats and exposed to the booking flow as selectable
+// products. Prices are authored in USD (converted/formatted for EUR/PLN at
+// display time). `departures` are fixed start/end dates when the product uses
+// scheduled groups; flexible products can be requested without a fixed date.
 export const RETREAT_PRODUCTS = [
   {
     slug: 'yoga-safari-retreat',
@@ -18,5 +18,25 @@ export const RETREAT_PRODUCTS = [
       { start: '2027-09-04', end: '2027-09-17' },
       { start: '2027-12-01', end: '2027-12-14' },
     ],
+  },
+  {
+    slug: 'coastal-reset-week',
+    title: 'Coastal Reset Week',
+    duration: '7 days · Zanzibar coast',
+    price: 1890,
+    priceSub: 'per person',
+    departures: [
+      { start: '2026-10-04', end: '2026-10-10' },
+      { start: '2027-03-07', end: '2027-03-13' },
+      { start: '2027-08-08', end: '2027-08-14' },
+    ],
+  },
+  {
+    slug: 'private-teacher-led-retreat',
+    title: 'Private Teacher-Led Retreat',
+    duration: '3 - 10 days · custom dates',
+    price: 390,
+    priceSub: 'from per day',
+    departures: [],
   },
 ];

--- a/src/data/siteSearchIndex.js
+++ b/src/data/siteSearchIndex.js
@@ -34,11 +34,11 @@ const pageItems = [
     keywords: ['holiday package', 'honeymoon', 'family', 'bush and beach', 'safari zanzibar'],
   },
   {
-    title: 'Yoga Retreat',
+    title: 'Yoga & Wellness Retreats',
     category: 'Page',
-    description: 'A 7-night small-group yoga retreat on the Zanzibar coast — sunrise vinyasa, yin evenings, meditation, breathwork, and spa.',
+    description: 'Teacher-led yoga, bodywork, coastal reset weeks, private retreats, and yoga safari journeys on Zanzibar.',
     to: '/retreats',
-    keywords: ['wellness', 'yoga', 'meditation', 'vinyasa', 'yin', 'hatha', 'spa', 'breathwork', 'mindfulness', 'retreat'],
+    keywords: ['wellness', 'yoga', 'meditation', 'vinyasa', 'yin', 'hatha', 'bodywork', 'thaivedic', 'mindfulness', 'retreat'],
   },
   {
     title: 'Transfers',

--- a/src/locales/de/booking.json
+++ b/src/locales/de/booking.json
@@ -82,7 +82,7 @@
     {
       "value": "retreat",
       "label": "Retreat",
-      "text": "14-tägiges Yoga- & Safari-Retreat auf Sansibar — Vinyasa bei Sonnenaufgang, Yin am Abend, Meditation und eine Safari auf dem Festland."
+      "text": "Yoga, Bodywork, Coastal-Reset-Wochen, private lehrergeführte Retreats und Reisen mit Safari."
     }
   ],
   "payment_options": [
@@ -631,8 +631,16 @@
     },
     "retreat": {
       "yoga-safari-retreat": {
-        "label": "Yoga- & Safari-Retreat",
+        "label": "Yoga- & Safari-Reise",
         "category": "14 Tage · Sansibar + Safari"
+      },
+      "coastal-reset-week": {
+        "label": "Coastal Reset Week",
+        "category": "7 Tage · Sansibar-Küste"
+      },
+      "private-teacher-led-retreat": {
+        "label": "Privates lehrergeführtes Retreat",
+        "category": "3 - 10 Tage · Wunschdaten"
       }
     }
   }

--- a/src/locales/de/retreats.json
+++ b/src/locales/de/retreats.json
@@ -1,79 +1,134 @@
 {
-  "page_title": "14-tägiges Yoga- & Safari-Retreat · Sansibar · Destination Paradise",
+  "page_title": "Yoga- & Wellness-Retreats · Sansibar · Destination Paradise",
+  "meta_description": "Lehrergeführte Yoga-, Bodywork-, Coastal-Reset- und Yoga-Safari-Retreats auf Sansibar mit Destination Paradise.",
   "hero": {
-    "eyebrow": "14 Tage · Yoga-Retreat · 5-tägige Safari inklusive",
-    "title_prefix": "Mehr als nur",
-    "title_em": "Bewegung.",
-    "subtitle": "Vierzehn Tage Yoga, Atem, Stille und Safari.",
-    "lead": "Eine einzige, intime Reise mit Nina — Vinyasa bei Sonnenaufgang, ruhige Yin-Abende, Meditation, lange, entschleunigte Tage an der Gewürzküste und eine fünftägige Tansania-Safari als fester Teil des Erlebnisses.",
-    "see_day": "Einen Tag ansehen",
-    "reserve": "Platz reservieren →",
-    "stat_nights_value": "14",
-    "stat_nights": "Tage",
-    "stat_guests_value": "5",
-    "stat_guests": "Safari-Tage",
-    "stat_practices_value": "2",
-    "stat_practices": "Praktiken täglich",
-    "stat_levels_value": "12",
-    "stat_levels": "Gäste max."
+    "eyebrow": "Wellness-Retreats auf Sansibar",
+    "title_prefix": "Retreats für jeden",
+    "title_em": "Körper und jede Reise.",
+    "subtitle": "Lehrergeführtes Yoga, Thaivedic Bodywork, Coastal-Reset-Wochen und Reisen mit Safari.",
+    "lead": "Wähle ein festes Gruppenretreat oder lass uns ein privates Programm rund um deine Daten, dein Tempo und deine Praxis gestalten.",
+    "see_day": "Retreats entdecken",
+    "reserve": "Retreat planen →",
+    "stat_nights_value": "3",
+    "stat_nights": "Retreat-Arten",
+    "stat_guests_value": "Team",
+    "stat_guests": "Lehrer-Mix",
+    "stat_practices_value": "Täglich",
+    "stat_practices": "Praxis-Rhythmus",
+    "stat_levels_value": "Alle",
+    "stat_levels": "Level willkommen"
   },
   "intention": {
     "eyebrow": "Die Intention",
-    "text": "Yoga ist viel mehr als eine körperliche Praxis. Es ist ein Weg, Achtsamkeit zu kultivieren, innere Ruhe zu finden und sich wieder mit Dankbarkeit zu verbinden — zu lernen, <em>langsamer zu werden, zuzuhören und Balance zu schaffen</em> in Körper und Geist."
+    "text": "Ein Retreat kann ein Reset sein, eine tiefe Praxiswoche, ein sanfter Abschluss nach der Safari oder das Herz einer längeren Sansibar-Reise. Wir gestalten jedes Retreat rund um <em>echte Lehrer, großzügige Zeit und Inseltage, die wieder Luft zum Atmen geben</em>."
   },
-  "teacher": {
-    "kicker": "Nina · Lehrerin & Gastgeberin",
-    "eyebrow": "Lerne Nina kennen",
-    "title": "Eine Praxis, geboren aus Heilung.",
-    "p1": "Meine Reise mit Yoga begann in einer der schwierigsten Phasen meines Lebens. Nach einer schweren Knieverletzung, fünf Operationen und scheinbar wenig Hoffnung auf Genesung wurde Yoga zu einem Weg zurück zu Stabilität, Kraft und Frieden — es heilte mich nicht nur körperlich, sondern auch mental und emotional und veränderte die Art, wie ich den Herausforderungen des Lebens begegnete.",
-    "p2": "Meine Ausbildung zur Yogalehrerin absolvierte ich in Portugal, wo ich mein Verständnis sowohl der Praxis als auch der Philosophie des Yoga vertiefte. Dabei hatte ich das Privileg, inspirierende Lehrer zu treffen, die meine Sichtweise tiefgreifend prägten, und seither habe ich in Studios in Marokko und Deutschland unterrichtet und diese Praxis mit Menschen aus allen Lebensbereichen geteilt.",
-    "p3": "Jede Begegnung, jede Lektion und jede Erfahrung ist Teil meines Unterrichtsstils geworden — authentisch, achtsam und verwurzelt in einer echten Leidenschaft für das, was Yoga wirklich bedeutet.",
-    "signoff": "— mit Liebe, Nina"
+  "retreat_types": {
+    "eyebrow": "Retreat-Arten",
+    "title": "Wähle den Rhythmus, der passt.",
+    "lead": "Starte mit einem unserer bewährten Retreat-Formate, dann stimmen wir Daten, Lehrer, Ausflüge, Zimmer und Safari-Verlängerungen auf deine Gruppe ab.",
+    "price_from": "Ab",
+    "items": [
+      {
+        "slug": "yoga-safari-retreat",
+        "title": "Yoga- & Safari-Reise",
+        "duration": "14 Tage · feste Termine",
+        "text": "Die komplette Reise von Sansibar aufs Festland: Praxis bei Sonnenaufgang, ruhige Küstentage und eine fünftägige Tansania-Safari in der Mitte.",
+        "highlights": ["Vinyasa, Yin, Meditation", "5-tägige Safari inklusive", "Kleine Gruppentermine"],
+        "cta": "Diese Reise reservieren",
+        "image_alt": "Yoga-Praxis über der Küste Sansibars"
+      },
+      {
+        "slug": "coastal-reset-week",
+        "title": "Coastal Reset Week",
+        "duration": "7 Tage · Sansibar-Küste",
+        "text": "Eine leichtere Wellnesswoche für Reisende, die tägliche Praxis, Meerzeit, Bodywork, nährende Mahlzeiten und optionale Insel-Erlebnisse möchten.",
+        "highlights": ["Tägliche Praxis am Meer", "Optionale Bodywork-Sessions", "Strand, Riff und Stone Town als Add-ons"],
+        "cta": "Reset-Termine anfragen",
+        "image_alt": "Seitbeuge in einer Yoga-Pose auf einer warmen Küstenterrasse"
+      },
+      {
+        "slug": "private-teacher-led-retreat",
+        "title": "Privates lehrergeführtes Retreat",
+        "duration": "3 - 10 Tage · Wunschdaten",
+        "text": "Ein maßgeschneidertes Retreat für Paare, Freundesgruppen, Unternehmen oder Lehrer, die ihre eigene Gruppe nach Sansibar bringen.",
+        "highlights": ["Praxisleitung passend zur Gruppe", "Private Villa oder Boutique-Hotel", "Flexibler Praxis- und Ausflugsplan"],
+        "cta": "Privates Retreat bauen",
+        "image_alt": "Hands-on Bodywork-Session in Meeresnähe"
+      }
+    ]
+  },
+  "teachers": {
+    "eyebrow": "Faculty & Retreat-Team",
+    "title": "Ein Lehrer-Mix, der zum Retreat passt.",
+    "lead": "Das Programm steht im Mittelpunkt. Wir stimmen jedes Retreat auf passende Praxisleitung, Bodywork-Support, Gastpraktiker und lokale Hosts ab, statt alles von einer Person abhängig zu machen.",
+    "items": [
+      {
+        "name": "Mindful Flow & Stille",
+        "role": "Nina · Vinyasa, Yin, Atemarbeit",
+        "text": "Nina leitet warme, achtsame Praktiken, geprägt von ihrer Ausbildung in Portugal und Unterrichtserfahrung in Marokko und Deutschland. Ihre Sessions bringen Bewegung, Atem, Musik, Philosophie und stille Integration in den Retreat-Rhythmus.",
+        "specialties": ["Vinyasa Flow", "Hatha und Yin", "Meditation und Atemarbeit"],
+        "image_alt": "Gruppen-Yogapraxis mit einer leitenden Lehrerin"
+      },
+      {
+        "name": "Vinyasa für alle Level & Bodywork",
+        "role": "Awham Mohamed Al-Obaidy · @shela_yogi",
+        "text": "Awham ist in Lamu geboren und aufgewachsen, internationaler Yoga- und Thaivedic-Experte, Content Creator und Erzähler für Wellness und Hospitality. In Retreats bringt er Vinyasa, Hatha und Hands-on-Bodywork mit einem Gefühl für das Leben am Ozean ein.",
+        "specialties": ["Vinyasa für alle Level", "Hatha Yoga", "Thaivedic Bodywork", "Lamu-Wellness-Lifestyle"],
+        "image_alt": "Hands-on Bodywork-Session als Bild für Awham Yogas Thaivedic-Praxis"
+      },
+      {
+        "name": "Gastpraktiker & Insel-Hosts",
+        "role": "Klang, Meditation, Massage, Kultur",
+        "text": "Je nach Retreat kann das Team lokale Wellness-Praktiker, Guides, Köche, Massagetherapeuten, Safari-Planer und Insel-Hosts einbinden, die die Reise geerdet, praktisch und mit dem Ort verbunden halten.",
+        "specialties": ["Klang und Meditation", "Massage und Regeneration", "Insel- und Safari-Support"],
+        "image_alt": "Kleine Gruppe bei der Yogapraxis am Strand"
+      }
+    ]
   },
   "quote": {
-    "text": "Mein größter Wunsch ist, dass alle leichter, stärker, geerdeter und tief <em>mit sich selbst verbunden</em> nach Hause gehen — und diese Balance in den Alltag tragen."
+    "text": "Das beste Retreat verlangt nicht, dass alle sich gleich bewegen. Es schafft genug Struktur, um sich gehalten zu fühlen, und genug Raum, um <em>zu dir selbst zurückzukehren</em>."
   },
   "practice": {
-    "eyebrow": "Die Praxis",
-    "title": "Harmonie zwischen Bewegung und Stille.",
-    "lead": "Jede Stunde richtet sich nach den Menschen im Raum — einen Morgen ein energetisierender Flow, am nächsten eine sanfte, regenerative Praxis. Auch Musik gehört dazu: sorgfältig gewählte Klänge, die das Bewusstsein vertiefen und die Atmosphäre schaffen.",
+    "eyebrow": "Praxis-Menü",
+    "title": "Bewegung, Stille und Bodywork.",
+    "lead": "Das Retreat-Programm kann je nach Lehrer und Gruppe energetisch, regenerativ, therapeutisch oder reiseorientiert ausgerichtet werden.",
     "items": [
-      { "step": "01", "title": "Vinyasa Flow", "text": "Dynamische, energetisierende Sequenzen, die Kraft, Beweglichkeit und Fokus aufbauen — Atem verbunden mit Bewegung, während die Sonne aufgeht." },
-      { "step": "02", "title": "Hatha Yoga", "text": "Achtsame Ausrichtung, bewusstes Atmen und die Kultivierung innerer Stabilität und Achtsamkeit. Eine langsamere, bewusste Praxis." },
-      { "step": "03", "title": "Yin Yoga", "text": "Lang gehaltene Haltungen und tiefes Loslassen, mit Raum für Meditation, Philosophie und Selbstreflexion. Tiefe Entspannung." },
-      { "step": "04", "title": "Meditation & Atem", "text": "Bewusstes Dehnen, Pranayama und geführte Meditation, um Spannungen zu lösen, den Geist zu beruhigen und Balance wiederherzustellen." }
+      { "step": "01", "title": "Vinyasa für alle Level", "text": "Dynamische, atemgeführte Sequenzen mit Varianten für Anfänger, Wiedereinsteiger und erfahrene Praktizierende." },
+      { "step": "02", "title": "Hatha Yoga", "text": "Achtsame Ausrichtung, bewusster Atem und stabile Praxis, die Bewusstsein aufbaut, ohne den Körper zu drängen." },
+      { "step": "03", "title": "Yin & regenerative Abende", "text": "Lang gehaltene Haltungen, weiche Hilfsmittel, Meditation und tiefes Loslassen nach Ozeantagen oder Safari-Reisen." },
+      { "step": "04", "title": "Thaivedic Bodywork", "text": "Therapeutische Hands-on-Sessions, die Regeneration, Ruhe im Nervensystem und ein geerdetes Retreat-Erlebnis unterstützen." }
     ]
   },
   "journey": {
-    "eyebrow": "Die Reise",
-    "title": "Vierzehn Tage, ganz ohne Eile.",
-    "lead": "Tage der Praxis an der Küste Sansibars, eine fünftägige Safari im Landesinneren und dann zurück ans Meer zum Ausklang — das Wilde liegt genau in der Mitte.",
+    "eyebrow": "Möglicher Ablauf",
+    "title": "Von einer Woche bis zur großen Reise.",
+    "lead": "Nutze diese Formate als Ausgangspunkt. Wir halten das Retreat schlicht und küstennah, bauen es um Safari herum oder gestalten ein privates Programm für deine Daten.",
     "items": [
-      { "days": "Tag 1–2", "title": "Ankunft an der Küste", "text": "An der Küste Sansibars landen, durchatmen und mit einer Abendpraxis sanft beginnen." },
-      { "days": "Tag 3–6", "title": "Praxis & Gewürzküste", "text": "Vinyasa bei Sonnenaufgang, Yin am Abend, lange Frühstücke und freie Nachmittage am Meer." },
-      { "days": "Tag 7–11", "title": "Flug zur Safari", "text": "Flug nach Arusha — Flüge inklusive — für fünf Tage Tierwelt in Tansania: Pirschfahrten, weiter Himmel und Nächte unter Sternen." },
-      { "days": "Tag 12–14", "title": "Zurück an die Küste", "text": "Rückflug nach Sansibar für abschließende Tage voller Praxis und Ruhe und einen uneiligen Abschied." }
+      { "days": "3-4 Tage", "title": "Privater Coastal Reset", "text": "Ein kompaktes Programm mit Morgenpraxis, Bodywork, nährenden Mahlzeiten und langsamen Nachmittagen am Meer." },
+      { "days": "7 Tage", "title": "Reset-Woche", "text": "Tägliche Praxis, ein bis zwei Workshops, optionale Ausflüge und genug leere Zeit, um wirklich zu ruhen." },
+      { "days": "10 Tage", "title": "Praxis + Insel-Eintauchen", "text": "Eine tiefere Woche mit Stone Town, Gewürzfarmen, Rifftagen oder Dorfbegegnungen, sanft in den Rhythmus gefaltet." },
+      { "days": "14 Tage", "title": "Yoga- & Safari-Reise", "text": "Die Flagship-Route: Praxistage auf Sansibar, fünf Tage Tansania-Safari, dann zurück ans Meer zum Abschluss." }
     ],
-    "note": "Unser erstes Retreat startet <strong>Anfang Dezember 2026</strong> — warm, ruhig und kurz vor der Hochsaison."
+    "note": "Unsere erste Yoga- & Safari-Reise startet <strong>Anfang Dezember 2026</strong>; private und Coastal-Reset-Formate können wir um deine Daten herum gestalten."
   },
   "day": {
     "eyebrow": "Ein Tag im Retreat",
-    "title": "Kein Wecker außer den Vögeln.",
-    "lead": "Ein typischer Yogatag an der Küste, bevor die Reise in fünf Safari-Tage übergeht. Alles nach dem Frühstück ist ganz unverbindlich — das sicherste Zeichen, dass du wirklich ausruhst.",
+    "title": "Gehaltene Struktur, offener Raum.",
+    "lead": "Ein typischer Küsten-Retreat-Tag. Safari-Tage und private Programme verschieben den Rhythmus, aber die Balance bleibt: Praxis, Nahrung und unbeschwerte Zeit.",
     "items": [
-      { "time": "6:15", "title": "Meditation im Morgengrauen", "text": "Ein optionales Sitzen auf dem Deck, während sich der Himmel färbt. Tee, kein Reden." },
-      { "time": "7:00", "title": "Vinyasa bei Sonnenaufgang", "text": "90 Minuten Flow, solange es noch kühl ist, Atem verbunden mit Bewegung." },
-      { "time": "9:00", "title": "Langes Frühstück", "text": "Früchte der Gewürzküste, frischer Saft, guter Kaffee. Nirgendwo Eile." },
-      { "time": "10:30", "title": "Offener Nachmittag", "text": "Strand, Riff, ein Workshop oder eine Hängematte. Ganz dir überlassen." },
-      { "time": "13:00", "title": "Gemeinsames Mittagessen", "text": "Pflanzenbetont, im Familienstil, unter den Palmen." },
-      { "time": "17:30", "title": "Yin & Regeneration", "text": "Langsam, bei Kerzenlicht, atemgeführt. Die sanfte Landung des Tages." },
-      { "time": "19:30", "title": "Abendessen & Sterne", "text": "Eine lange Tafel, frischer Fisch und ein Himmel ohne Stadt darin." }
+      { "time": "6:15", "title": "Stille am Morgen", "text": "Optionale Meditation, Tee oder ein stiller Spaziergang, bevor die Insel erwacht." },
+      { "time": "7:00", "title": "Morgenpraxis", "text": "Vinyasa, Hatha oder atemgeführte Bewegung, solange die Luft noch kühl ist." },
+      { "time": "9:00", "title": "Langes Frühstück", "text": "Früchte, frischer Saft, guter Kaffee und Zeit, im Tag anzukommen." },
+      { "time": "10:30", "title": "Bodywork oder Workshop", "text": "Thaivedic Bodywork, Alignment, Journaling, Philosophie oder ein geführter Ausflug." },
+      { "time": "13:00", "title": "Gemeinsames Mittagessen", "text": "Pflanzenbetont, lokal und leicht an Ernährungswünsche anzupassen." },
+      { "time": "15:00", "title": "Ozeanzeit", "text": "Strand, Riff, Hängematte, Massage oder einfach weniger tun." },
+      { "time": "17:30", "title": "Abendliche Landung", "text": "Yin, Meditation, Klang oder eine weichere Praxis zum Abschluss des Tages." }
     ]
   },
   "gallery": {
     "eyebrow": "Aus der Praxis",
     "title": "Momente von der Matte.",
-    "lead": "Ein Einblick in die Praxis — aufgenommen entlang der Küste des Indischen Ozeans. Derselbe Atem, wo immer du deine Matte ausrollst.",
+    "lead": "Ein Einblick in die Praxis — Küste, Terrassen, warmer Stein, Hands-on-Unterstützung und die Stille nach der Bewegung.",
     "items": [
       { "caption": "Rückbeuge · offener Himmel" },
       { "caption": "Wurzeln schlagen · warmer Stein" },
@@ -87,20 +142,20 @@
   },
   "included": {
     "eyebrow": "Inklusive",
-    "title": "Ein Preis. Alles, was zählt.",
-    "lead": "Flüge ausgenommen, deckt der Preis die 14-tägige Yoga- und Safari-Reise ab — Praxis, Mahlzeiten, Unterkünfte, Safari-Planung und die kleinen Details, die sich von Anfang bis Ende umsorgt anfühlen.",
+    "title": "Das Retreat um die Menschen herum bauen.",
+    "lead": "Jedes Retreat-Angebot richtet sich nach Lehrer-Team, Gruppengröße, Zimmerstandard, Mahlzeiten, Ausflügen und der Frage, ob Safari Teil der Route ist.",
     "price_from": "Ab",
     "price_unit": "pro Person",
     "items": [
-      "14-tägiges Yoga- und Safari-Programm",
-      "5-tägige Tansania-Safari inklusive",
-      "Zwei tägliche Praktiken mit Nina an Retreat-Tagen",
-      "Alle Mahlzeiten & kaltgepresste Säfte",
-      "Matte, Hilfsmittel & gesamte Ausrüstung",
-      "Eine Signature-Spa-Behandlung",
-      "Klangbad- & Meditationsabende",
-      "Safari-Transport, Parkplanung & lokale Guides",
-      "Flughafentransfers & 24/7-Concierge"
+      "Lehrergeführtes Yoga- oder Bodywork-Programm",
+      "Vinyasa, Hatha, Yin, Meditation oder Thaivedic Bodywork",
+      "Suche nach Boutique-Hotel, Villa oder Strandbasis",
+      "Mahlzeitenplanung mit Unterstützung bei Ernährungswünschen",
+      "Matten, Hilfsmittel und Setup-Koordination",
+      "Optionale Ausflüge nach Stone Town, zum Riff, zu Gewürzen oder Dörfern",
+      "Optionale Tansania-Safari-Verlängerung",
+      "Flughafentransfers und lokale Transfers",
+      "Planung durch Destination Paradise und Support vor Ort"
     ]
   },
   "faqs": {
@@ -108,31 +163,31 @@
     "title": "Die Fragen, die alle stellen.",
     "items": [
       {
-        "q": "Ich bin absolute Anfängerin — ist das in Ordnung?",
-        "a": "Mehr als in Ordnung. Jede Stunde wird mit Feingefühl für die anwesenden Menschen gestaltet, und mit maximal zwölf Gästen kann Nina dich genau dort abholen, wo du stehst — ob der Tag nach einem energetisierenden Flow oder einer sanfteren, regenerativen Praxis verlangt."
+        "q": "Ist das noch ein Retreat oder sind es mehrere?",
+        "a": "Mehrere. Das Flagship ist die 14-tägige Yoga- & Safari-Reise, aber wir gestalten jetzt auch Coastal-Reset-Wochen und private lehrergeführte Retreats für Wunschdaten."
       },
       {
-        "q": "Kann ich allein kommen?",
-        "a": "Absolut — die meisten unserer Gäste reisen allein an. Eine kleine Gruppe von zwölf macht es leicht, bei gemeinsamen Mahlzeiten und der Praxis in Kontakt zu kommen, während du so viel Ruhezeit behältst, wie du möchtest. Zimmer gibt es als Einzel- oder Doppelbelegung."
+        "q": "Können Anfänger mitkommen?",
+        "a": "Ja. Awham unterrichtet ausdrücklich Vinyasa für alle Level, und Ninas Programme können zu sanftem Hatha, Yin und Atemarbeit angepasst werden, wenn die Gruppe einen weicheren Rhythmus braucht."
       },
       {
-        "q": "Welchen Yogastil werden wir praktizieren?",
-        "a": "Eine Mischung: energetisierendes Vinyasa am Morgen, langsameres Hatha und tief regeneratives Yin am Abend, dazu Meditation und Atemarbeit. Jeder Tag richtet sich nach der Gruppe, sodass sich die Balance danach verschiebt, wie sich alle fühlen."
+        "q": "Können wir den Lehrer wählen?",
+        "a": "Bei privaten Retreats ja. Sag uns, welchen Praxisstil du möchtest, und wir schlagen die beste Lehrer-Kombination vor, inklusive Co-Teaching oder Gastpraktikern, wenn es sinnvoll ist. Bei festen Terminen steht das Lead Team vor der Buchung fest."
       },
       {
-        "q": "Wie sieht es mit Essen und Ernährungswünschen aus?",
-        "a": "Alle Mahlzeiten sind inklusive — pflanzenbetont, regional und im Familienstil serviert. Wir gehen gern auf vegetarische, vegane, glutenfreie und die meisten Allergien ein; sag uns einfach bei der Buchung Bescheid."
+        "q": "Kann Safari zu jedem Retreat ergänzt werden?",
+        "a": "Ja. Safari ist in der 14-tägigen Flagship-Reise enthalten und kann bei den meisten privaten oder Coastal-Retreat-Formaten davor oder danach ergänzt werden."
       },
       {
-        "q": "Ist die Safari im Retreat enthalten?",
-        "a": "Ja. Das Retreat ist jetzt als 14-tägige Reise mit einer fünftägigen Tansania-Safari inklusive aufgebaut, du musst sie also nicht separat hinzufügen. Sag uns einfach, wenn du vor oder nachher zusätzliche Strandnächte möchtest, und wir gestalten die ganze Route."
+        "q": "Müssen wir eigene Fotos oder einen eigenen Lehrer mitbringen?",
+        "a": "Nein. Wir können lokale Lehrer und Retreat-Visuals stellen oder mit einem Lehrer arbeiten, der seine eigene Gruppe und sein eigenes Markenmaterial mitbringt."
       }
     ]
   },
   "cta": {
-    "title": "Finde zu dir selbst zurück.",
-    "text": "Sag uns, wann du Zeit hast, und wir halten dir einen Platz für Ninas 14-tägige Yoga- und Safari-Reise frei. Kleine Gruppen sind schnell ausgebucht — je früher wir von dir hören, desto besser das Zimmer.",
-    "reserve": "Platz reservieren →",
+    "title": "Sag uns, welchen Rhythmus du willst.",
+    "text": "Wähle eine Retreat-Art, teile deine Daten mit uns und wir gestalten Lehrer-Team, Zimmer, Mahlzeiten, Ausflüge und optionale Safari rund um deine Gruppe.",
+    "reserve": "Retreat-Anfrage starten →",
     "ai_planner": "Oder chatte mit unserem KI-Planer"
   }
 }

--- a/src/locales/en/booking.json
+++ b/src/locales/en/booking.json
@@ -82,7 +82,7 @@
     {
       "value": "retreat",
       "label": "Retreat",
-      "text": "14-day yoga & safari retreat on Zanzibar — sunrise vinyasa, yin evenings, meditation, and a mainland safari."
+      "text": "Yoga, bodywork, coastal reset weeks, private teacher-led retreats, and safari journeys."
     }
   ],
   "payment_options": [
@@ -631,8 +631,16 @@
     },
     "retreat": {
       "yoga-safari-retreat": {
-        "label": "Yoga & Safari Retreat",
+        "label": "Yoga & Safari Journey",
         "category": "14 days · Zanzibar + safari"
+      },
+      "coastal-reset-week": {
+        "label": "Coastal Reset Week",
+        "category": "7 days · Zanzibar coast"
+      },
+      "private-teacher-led-retreat": {
+        "label": "Private Teacher-Led Retreat",
+        "category": "3 - 10 days · custom dates"
       }
     }
   }

--- a/src/locales/en/retreats.json
+++ b/src/locales/en/retreats.json
@@ -1,79 +1,134 @@
 {
-  "page_title": "14-Day Yoga & Safari Retreat · Zanzibar · Destination Paradise",
+  "page_title": "Yoga & Wellness Retreats · Zanzibar · Destination Paradise",
+  "meta_description": "Teacher-led yoga, bodywork, coastal reset weeks, and yoga safari retreats in Zanzibar with Destination Paradise.",
   "hero": {
-    "eyebrow": "14 days · yoga retreat · 5-day safari included",
-    "title_prefix": "More than just",
-    "title_em": "movement.",
-    "subtitle": "Fourteen days of yoga, breath, stillness, and safari.",
-    "lead": "A single, intimate journey with Nina — sunrise vinyasa, slow yin evenings, meditation, long unhurried days on the spice coast, and a five-day Tanzania safari woven into the experience.",
-    "see_day": "See a day",
-    "reserve": "Reserve a place →",
-    "stat_nights_value": "14",
-    "stat_nights": "Days",
-    "stat_guests_value": "5",
-    "stat_guests": "Safari days",
-    "stat_practices_value": "2",
-    "stat_practices": "Daily practices",
-    "stat_levels_value": "12",
-    "stat_levels": "Guests max"
+    "eyebrow": "Zanzibar wellness retreats",
+    "title_prefix": "Retreats for every",
+    "title_em": "body and journey.",
+    "subtitle": "Teacher-led yoga, Thaivedic bodywork, coastal reset weeks, and safari journeys.",
+    "lead": "Choose a fixed group retreat or ask us to shape a private teacher-led program around your dates, pace, and practice.",
+    "see_day": "Explore retreats",
+    "reserve": "Plan my retreat →",
+    "stat_nights_value": "3",
+    "stat_nights": "Retreat styles",
+    "stat_guests_value": "Team",
+    "stat_guests": "Teacher mix",
+    "stat_practices_value": "Daily",
+    "stat_practices": "Practice rhythm",
+    "stat_levels_value": "All",
+    "stat_levels": "Levels welcome"
   },
   "intention": {
     "eyebrow": "The intention",
-    "text": "Yoga is much more than a physical practice. It's a way of cultivating mindfulness, finding inner calm, and reconnecting with gratitude — learning to <em>slow down, listen, and create balance</em> in both body and mind."
+    "text": "A retreat can be a reset, a deep practice week, a softer landing after safari, or the heart of a longer Zanzibar journey. We build each one around <em>real teachers, generous time, and the kind of island days that let people breathe again</em>."
   },
-  "teacher": {
-    "kicker": "Nina · teacher & host",
-    "eyebrow": "Meet Nina",
-    "title": "A practice born from healing.",
-    "p1": "My journey with yoga began during one of the most challenging periods of my life. After a severe knee injury, five surgeries, and what seemed like little hope for recovery, yoga became a path back to stability, strength, and peace — healing me not only physically, but mentally and emotionally, and transforming the way I approached life's challenges.",
-    "p2": "I completed my teacher training in Portugal, where I deepened my understanding of both the practice and the philosophy of yoga. Along the way I had the privilege of meeting inspiring teachers who profoundly shaped my perspective, and I've since taught in studios in Morocco and Germany, sharing this practice with people from all walks of life.",
-    "p3": "Every encounter, lesson, and experience has become part of my teaching style — authentic, mindful, and rooted in a genuine passion for what yoga truly represents.",
-    "signoff": "— with love, Nina"
+  "retreat_types": {
+    "eyebrow": "Retreat styles",
+    "title": "Choose the rhythm that fits.",
+    "lead": "Start with one of our ready-made retreat formats, then let us tune the dates, teacher mix, excursions, rooms, and safari extensions around your group.",
+    "price_from": "From",
+    "items": [
+      {
+        "slug": "yoga-safari-retreat",
+        "title": "Yoga & Safari Journey",
+        "duration": "14 days · fixed departures",
+        "text": "The full Zanzibar-to-mainland journey: sunrise practice, slow coastal days, and a five-day Tanzania safari woven into the middle.",
+        "highlights": ["Vinyasa, yin, meditation", "5-day safari included", "Small group departures"],
+        "cta": "Reserve this journey",
+        "image_alt": "Yoga practice above the Zanzibar coastline"
+      },
+      {
+        "slug": "coastal-reset-week",
+        "title": "Coastal Reset Week",
+        "duration": "7 days · Zanzibar coast",
+        "text": "A lighter wellness week for travelers who want daily practice, ocean time, bodywork, nourishing meals, and optional island excursions.",
+        "highlights": ["Daily practice by the sea", "Optional bodywork sessions", "Beach, reef, and Stone Town add-ons"],
+        "cta": "Ask for reset dates",
+        "image_alt": "Side-bend yoga pose on a warm coastal terrace"
+      },
+      {
+        "slug": "private-teacher-led-retreat",
+        "title": "Private Teacher-Led Retreat",
+        "duration": "3 - 10 days · custom dates",
+        "text": "A tailor-made retreat for couples, friends, companies, or teachers bringing their own group to Zanzibar.",
+        "highlights": ["Practice lead matched to the group", "Private villa or boutique hotel base", "Flexible practice and excursion plan"],
+        "cta": "Build a private retreat",
+        "image_alt": "Hands-on bodywork session near the ocean"
+      }
+    ]
+  },
+  "teachers": {
+    "eyebrow": "Faculty & retreat team",
+    "title": "A teacher mix matched to the retreat.",
+    "lead": "The program comes first. We match each retreat to the right practice lead, bodywork support, guest practitioners, and local hosts instead of making the whole experience depend on one person.",
+    "items": [
+      {
+        "name": "Mindful flow & stillness",
+        "role": "Nina · vinyasa, yin, breathwork",
+        "text": "Nina leads warm, mindful practices shaped by teacher training in Portugal and teaching experience in Morocco and Germany. Her sessions bring movement, breath, music, philosophy, and quiet integration into the retreat rhythm.",
+        "specialties": ["Vinyasa flow", "Hatha and yin", "Meditation and breathwork"],
+        "image_alt": "Group yoga practice with a teacher leading the room"
+      },
+      {
+        "name": "All-level vinyasa & bodywork",
+        "role": "Awham Mohamed Al-Obaidy · @shela_yogi",
+        "text": "Lamu born and raised, Awham is an international yoga and Thaivedic expert, content creator, and wellness-hospitality storyteller. He brings vinyasa, hatha, and hands-on bodywork into retreat programs with an ocean-life sensibility.",
+        "specialties": ["Vinyasa for all levels", "Hatha yoga", "Thaivedic bodywork", "Lamu wellness lifestyle"],
+        "image_alt": "Hands-on bodywork session representing Awham Yoga's Thaivedic practice"
+      },
+      {
+        "name": "Guest practitioners & island hosts",
+        "role": "Sound, meditation, massage, culture",
+        "text": "Depending on the retreat, the team can include local wellness practitioners, guides, chefs, massage therapists, safari planners, and island hosts who keep the journey grounded, practical, and connected to place.",
+        "specialties": ["Sound and meditation", "Massage and recovery", "Island and safari support"],
+        "image_alt": "Small group practicing yoga by the beach"
+      }
+    ]
   },
   "quote": {
-    "text": "My greatest wish is for everyone to leave feeling lighter, stronger, more grounded, and deeply <em>connected to themselves</em> — carrying that balance into everyday life."
+    "text": "The best retreat does not ask everyone to move the same way. It creates enough structure to feel held, and enough space to <em>return to yourself</em>."
   },
   "practice": {
-    "eyebrow": "The practice",
-    "title": "Harmony between movement and stillness.",
-    "lead": "Every class is shaped around the people in the room — an energizing flow one morning, a gentle restorative practice the next. Music is part of it too: carefully chosen sounds that deepen awareness and create the atmosphere.",
+    "eyebrow": "Practice menu",
+    "title": "Movement, stillness, and bodywork.",
+    "lead": "The retreat program can lean energetic, restorative, therapeutic, or expedition-led depending on the teacher and the group.",
     "items": [
-      { "step": "01", "title": "Vinyasa Flow", "text": "Dynamic, energizing sequences that build strength, mobility, and focus — breath linked to movement as the sun comes up." },
-      { "step": "02", "title": "Hatha Yoga", "text": "Mindful alignment, conscious breathing, and the cultivation of inner stability and awareness. A slower, deliberate practice." },
-      { "step": "03", "title": "Yin Yoga", "text": "Long-held postures and deep release, with space for meditation, philosophy, and self-reflection. Profound relaxation." },
-      { "step": "04", "title": "Meditation & Breath", "text": "Conscious stretching, pranayama, and guided meditation to release tension, calm the mind, and restore balance." }
+      { "step": "01", "title": "Vinyasa for all levels", "text": "Dynamic, breath-led sequences with options for beginners, returning students, and experienced practitioners." },
+      { "step": "02", "title": "Hatha Yoga", "text": "Mindful alignment, conscious breathing, and steady practice that builds awareness without rushing the body." },
+      { "step": "03", "title": "Yin & restorative evenings", "text": "Long-held postures, soft props, meditation, and deep release after ocean days or safari travel." },
+      { "step": "04", "title": "Thaivedic bodywork", "text": "Hands-on therapeutic sessions that support recovery, nervous-system rest, and a more grounded retreat experience." }
     ]
   },
   "journey": {
-    "eyebrow": "The journey",
-    "title": "Fourteen days, unhurried.",
-    "lead": "Days of practice on the Zanzibar coast, a five-day safari inland, then back to the ocean to close — the wild heart of it right in the middle.",
+    "eyebrow": "How it can flow",
+    "title": "From one week to a full journey.",
+    "lead": "Use these as starting points. We can keep the retreat simple and coastal, build it around safari, or create a private program for your dates.",
     "items": [
-      { "days": "Days 1–2", "title": "Arrive on the coast", "text": "Land on the Zanzibar coast, breathe out, and ease in with an opening evening practice." },
-      { "days": "Days 3–6", "title": "Practice & the spice coast", "text": "Sunrise vinyasa, yin evenings, long breakfasts, and open afternoons by the ocean." },
-      { "days": "Days 7–11", "title": "Fly inland to safari", "text": "Fly to Arusha — flights included — for five days of Tanzania wildlife: game drives, wide skies, and nights under the stars." },
-      { "days": "Days 12–14", "title": "Back to the coast", "text": "Fly back to Zanzibar for closing days of practice and rest, and an unhurried goodbye." }
+      { "days": "3-4 days", "title": "Private coastal reset", "text": "A compact program with morning practice, bodywork, nourishing meals, and slow afternoons by the sea." },
+      { "days": "7 days", "title": "Reset week", "text": "Daily practice, one or two workshops, optional excursions, and enough empty space to actually rest." },
+      { "days": "10 days", "title": "Practice + island immersion", "text": "A deeper week with Stone Town, spice farms, reef days, or village experiences folded gently into the rhythm." },
+      { "days": "14 days", "title": "Yoga & safari journey", "text": "The flagship route: Zanzibar practice days, five days of Tanzania safari, then back to the ocean to close." }
     ],
-    "note": "Our first retreat departs <strong>early December 2026</strong> — warm, quiet, and just before peak season."
+    "note": "Our first flagship Yoga & Safari Journey departs <strong>early December 2026</strong>, while private and coastal reset formats can be shaped around your dates."
   },
   "day": {
     "eyebrow": "A day in the life",
-    "title": "No alarms but the birds.",
-    "lead": "A typical yoga day on the coast, before the journey opens into five safari days. Everything past breakfast is gently optional — the surest sign you're actually resting.",
+    "title": "Held structure, open space.",
+    "lead": "A typical coastal retreat day. Safari days and private programs shift the rhythm, but the balance stays the same: practice, nourishment, and unhurried time.",
     "items": [
-      { "time": "6:15", "title": "Dawn meditation", "text": "An optional sit on the deck as the sky turns. Tea, no talking." },
-      { "time": "7:00", "title": "Sunrise vinyasa", "text": "90 minutes of flow while it's still cool, breath linked to movement." },
-      { "time": "9:00", "title": "Long breakfast", "text": "Spice-coast fruit, fresh juice, good coffee. No rush anywhere." },
-      { "time": "10:30", "title": "Open afternoon", "text": "Beach, reef, a workshop, or a hammock. Entirely yours." },
-      { "time": "13:00", "title": "Shared lunch", "text": "Plant-forward, family style, under the palms." },
-      { "time": "17:30", "title": "Yin & restore", "text": "Slow, candlelit, breath-led. The day's gentle landing." },
-      { "time": "19:30", "title": "Dinner & stars", "text": "A long table, fresh fish, and a sky with no city in it." }
+      { "time": "6:15", "title": "Dawn quiet", "text": "Optional meditation, tea, or a silent walk before the island wakes." },
+      { "time": "7:00", "title": "Morning practice", "text": "Vinyasa, hatha, or breath-led movement while the air is still cool." },
+      { "time": "9:00", "title": "Long breakfast", "text": "Fruit, fresh juice, good coffee, and time to settle into the day." },
+      { "time": "10:30", "title": "Bodywork or workshop", "text": "Thaivedic bodywork, alignment, journaling, philosophy, or a guided excursion." },
+      { "time": "13:00", "title": "Shared lunch", "text": "Plant-forward, local, and easy to adapt for dietary needs." },
+      { "time": "15:00", "title": "Ocean hours", "text": "Beach, reef, hammock, massage, or simply doing less." },
+      { "time": "17:30", "title": "Evening landing", "text": "Yin, meditation, sound, or a softer practice to close the day." }
     ]
   },
   "gallery": {
     "eyebrow": "From the practice",
     "title": "Moments from the mat.",
-    "lead": "A glimpse of the practice — taken along the Indian Ocean coast. The same breath, wherever you unroll the mat.",
+    "lead": "A glimpse of the practice — coast, terraces, warm stone, hands-on support, and the quiet after movement.",
     "items": [
       { "caption": "Backbend · open sky" },
       { "caption": "Rooting down · warm stone" },
@@ -87,20 +142,20 @@
   },
   "included": {
     "eyebrow": "What's included",
-    "title": "One price. Everything that matters.",
-    "lead": "Flights aside, the rate covers the 14-day yoga and safari journey — practice, meals, stays, safari planning, and the small touches that make it feel cared for end to end.",
+    "title": "Build the retreat around the people coming.",
+    "lead": "Every retreat quote is shaped around the teacher team, group size, room standard, meals, excursions, and whether safari is part of the route.",
     "price_from": "From",
     "price_unit": "per person",
     "items": [
-      "14-day yoga and safari program",
-      "5-day Tanzania safari included",
-      "Two daily practices with Nina on retreat days",
-      "All meals & cold-pressed juices",
-      "Mat, props & all equipment",
-      "One signature spa treatment",
-      "Sound bath & meditation evenings",
-      "Safari transport, park planning & local guides",
-      "Airport pickups & 24/7 concierge"
+      "Teacher-led yoga or bodywork program",
+      "Vinyasa, hatha, yin, meditation, or Thaivedic bodywork",
+      "Boutique hotel, villa, or beach base sourcing",
+      "Meal planning with dietary support",
+      "Mat, props, and setup coordination",
+      "Optional Stone Town, reef, spice, or village excursions",
+      "Optional Tanzania safari extension",
+      "Airport pickups and local transfers",
+      "Destination Paradise planning and on-island support"
     ]
   },
   "faqs": {
@@ -108,31 +163,31 @@
     "title": "The questions everyone asks.",
     "items": [
       {
-        "q": "I'm a total beginner — is that okay?",
-        "a": "More than okay. Every class is designed with sensitivity to the people present, and with twelve guests max Nina can meet you exactly where you are — whether the day calls for an energizing flow or a gentler, restorative practice."
+        "q": "Is this still one retreat, or several?",
+        "a": "Several. The flagship is the 14-day Yoga & Safari Journey, but we now also shape coastal reset weeks and private teacher-led retreats for custom dates."
       },
       {
-        "q": "Can I come solo?",
-        "a": "Absolutely — most of our guests arrive on their own. A small group of twelve makes it easy to connect over shared meals and practice, while you keep as much quiet time as you like. Rooms are available as singles or to share."
+        "q": "Can beginners join?",
+        "a": "Yes. Awham explicitly teaches vinyasa for all levels, and Nina's programs can be adapted toward gentle hatha, yin, and breathwork when the group needs a softer rhythm."
       },
       {
-        "q": "What style of yoga will we practice?",
-        "a": "A blend: energizing vinyasa in the mornings, slower hatha and deeply restorative yin in the evenings, plus meditation and breathwork. Each day is shaped around the group, so the balance shifts to suit how everyone is feeling."
+        "q": "Can we choose the teacher?",
+        "a": "For private retreats, yes. Tell us the practice style you want and we will suggest the best teacher mix, including co-led programs or guest practitioners when helpful. Fixed departures list the lead team before booking."
       },
       {
-        "q": "What about food and dietary needs?",
-        "a": "All meals are included — plant-forward, locally sourced, and served family style. We happily cater for vegetarian, vegan, gluten-free, and most allergies; just let us know when you book."
+        "q": "Can safari be added to any retreat?",
+        "a": "Yes. Safari is built into the 14-day flagship journey, and it can be added before or after most private or coastal retreat formats."
       },
       {
-        "q": "Is the safari included in the retreat?",
-        "a": "Yes. The retreat is now built as a 14-day journey with a five-day Tanzania safari included, so you do not need to add it separately. Tell us if you want extra beach nights before or after and we'll shape the full route."
+        "q": "Do we need to bring our own photos or teacher?",
+        "a": "No. We can provide local teachers and retreat visuals, or coordinate with a teacher bringing their own group and brand material."
       }
     ]
   },
   "cta": {
-    "title": "Come back to yourself.",
-    "text": "Tell us when you're free and we'll hold you a place for Nina's 14-day yoga and safari journey. Small groups fill quickly — the sooner we hear from you, the better the room.",
-    "reserve": "Reserve your place →",
+    "title": "Tell us the rhythm you want.",
+    "text": "Choose a retreat style, share your dates, and we will shape the teacher team, rooms, meals, excursions, and optional safari around your group.",
+    "reserve": "Start a retreat request →",
     "ai_planner": "Or chat with our AI planner"
   }
 }

--- a/src/locales/pl/booking.json
+++ b/src/locales/pl/booking.json
@@ -82,7 +82,7 @@
     {
       "value": "retreat",
       "label": "Retreat",
-      "text": "14-dniowy retreat jogi i safari na Zanzibarze — poranna vinyasa, wieczorny yin, medytacja i safari na kontynencie."
+      "text": "Joga, bodywork, tygodnie coastal reset, prywatne retreaty z nauczycielem i podróże z safari."
     }
   ],
   "payment_options": [
@@ -631,8 +631,16 @@
     },
     "retreat": {
       "yoga-safari-retreat": {
-        "label": "Retreat jogi i safari",
+        "label": "Podróż joga i safari",
         "category": "14 dni · Zanzibar + safari"
+      },
+      "coastal-reset-week": {
+        "label": "Coastal Reset Week",
+        "category": "7 dni · wybrzeże Zanzibaru"
+      },
+      "private-teacher-led-retreat": {
+        "label": "Prywatny retreat z nauczycielem",
+        "category": "3 - 10 dni · własne daty"
       }
     }
   }

--- a/src/locales/pl/retreats.json
+++ b/src/locales/pl/retreats.json
@@ -1,79 +1,134 @@
 {
-  "page_title": "14-dniowy retreat jogi i safari · Zanzibar · Destination Paradise",
+  "page_title": "Retreaty jogi i wellness · Zanzibar · Destination Paradise",
+  "meta_description": "Retreaty jogi, bodyworku, coastal reset i jogi z safari na Zanzibarze z Destination Paradise.",
   "hero": {
-    "eyebrow": "14 dni · retreat jogi · 5-dniowe safari w cenie",
-    "title_prefix": "Coś więcej niż",
-    "title_em": "ruch.",
-    "subtitle": "Czternaście dni jogi, oddechu, ciszy i safari.",
-    "lead": "Jedna kameralna podróż z Niną — poranne vinyasy, spokojne wieczory yin, medytacja, długie niespieszne dni na korzennym wybrzeżu oraz pięciodniowe safari w Tanzanii wplecione w całe doświadczenie.",
-    "see_day": "Zobacz dzień",
-    "reserve": "Zarezerwuj miejsce →",
-    "stat_nights_value": "14",
-    "stat_nights": "Dni",
-    "stat_guests_value": "5",
-    "stat_guests": "Dni safari",
-    "stat_practices_value": "2",
-    "stat_practices": "Praktyki dziennie",
-    "stat_levels_value": "12",
-    "stat_levels": "Maks. gości"
+    "eyebrow": "Retreaty wellness na Zanzibarze",
+    "title_prefix": "Retreaty dla każdego",
+    "title_em": "ciała i każdej podróży.",
+    "subtitle": "Joga prowadzona przez nauczycieli, Thaivedic bodywork, tygodnie coastal reset i podróże z safari.",
+    "lead": "Wybierz gotowy retreat grupowy albo pozwól nam ułożyć prywatny program pod Twoje daty, tempo i praktykę.",
+    "see_day": "Zobacz retreaty",
+    "reserve": "Zaplanuj retreat →",
+    "stat_nights_value": "3",
+    "stat_nights": "Typy retreatów",
+    "stat_guests_value": "Zespół",
+    "stat_guests": "Mix nauczycieli",
+    "stat_practices_value": "Codziennie",
+    "stat_practices": "Rytm praktyki",
+    "stat_levels_value": "Wszystkie",
+    "stat_levels": "Poziomy mile widziane"
   },
   "intention": {
     "eyebrow": "Intencja",
-    "text": "Joga to znacznie więcej niż praktyka fizyczna. To sposób na pielęgnowanie uważności, odnajdywanie wewnętrznego spokoju i ponowne łączenie się z wdzięcznością — nauka, by <em>zwolnić, słuchać i tworzyć równowagę</em> zarówno w ciele, jak i w umyśle."
+    "text": "Retreat może być resetem, głębokim tygodniem praktyki, miękkim lądowaniem po safari albo sercem dłuższej podróży po Zanzibarze. Każdy program budujemy wokół <em>prawdziwych nauczycieli, dużej ilości czasu i dni na wyspie, które pozwalają znowu odetchnąć</em>."
   },
-  "teacher": {
-    "kicker": "Nina · nauczycielka i gospodyni",
-    "eyebrow": "Poznaj Ninę",
-    "title": "Praktyka zrodzona z uzdrawiania.",
-    "p1": "Moja przygoda z jogą zaczęła się w jednym z najtrudniejszych okresów mojego życia. Po poważnej kontuzji kolana, pięciu operacjach i pozornie znikomej nadziei na powrót do zdrowia joga stała się drogą powrotu do stabilności, siły i spokoju — uzdrawiając mnie nie tylko fizycznie, ale i psychicznie oraz emocjonalnie, i zmieniając sposób, w jaki podchodziłam do życiowych wyzwań.",
-    "p2": "Szkolenie nauczycielskie ukończyłam w Portugalii, gdzie pogłębiłam zrozumienie zarówno praktyki, jak i filozofii jogi. Po drodze miałam przywilej spotkać inspirujących nauczycieli, którzy głęboko ukształtowali moją perspektywę, a od tamtej pory uczyłam w studiach w Maroku i w Niemczech, dzieląc się tą praktyką z ludźmi z różnych środowisk.",
-    "p3": "Każde spotkanie, lekcja i doświadczenie stały się częścią mojego stylu nauczania — autentycznego, uważnego i zakorzenionego w prawdziwej pasji do tego, czym naprawdę jest joga.",
-    "signoff": "— z miłością, Nina"
+  "retreat_types": {
+    "eyebrow": "Typy retreatów",
+    "title": "Wybierz rytm, który pasuje.",
+    "lead": "Zacznij od jednego z gotowych formatów, a potem dopasujemy daty, nauczycieli, wycieczki, pokoje i przedłużenie safari do Twojej grupy.",
+    "price_from": "Od",
+    "items": [
+      {
+        "slug": "yoga-safari-retreat",
+        "title": "Podróż joga i safari",
+        "duration": "14 dni · stałe terminy",
+        "text": "Pełna podróż z Zanzibaru na ląd: praktyka o wschodzie słońca, spokojne dni na wybrzeżu i pięciodniowe safari w Tanzanii w środku programu.",
+        "highlights": ["Vinyasa, yin, medytacja", "5-dniowe safari w cenie", "Kameralne terminy grupowe"],
+        "cta": "Zarezerwuj tę podróż",
+        "image_alt": "Praktyka jogi nad wybrzeżem Zanzibaru"
+      },
+      {
+        "slug": "coastal-reset-week",
+        "title": "Coastal Reset Week",
+        "duration": "7 dni · wybrzeże Zanzibaru",
+        "text": "Lżejszy tydzień wellness dla osób, które chcą codziennej praktyki, czasu nad oceanem, bodyworku, odżywczych posiłków i opcjonalnych wycieczek po wyspie.",
+        "highlights": ["Codzienna praktyka nad morzem", "Opcjonalne sesje bodyworku", "Plaża, rafa i Stone Town jako dodatki"],
+        "cta": "Zapytaj o terminy resetu",
+        "image_alt": "Pozycja jogi w skłonie bocznym na ciepłym tarasie przy wybrzeżu"
+      },
+      {
+        "slug": "private-teacher-led-retreat",
+        "title": "Prywatny retreat z nauczycielem",
+        "duration": "3 - 10 dni · własne daty",
+        "text": "Retreat szyty na miarę dla par, przyjaciół, firm albo nauczycieli, którzy przywożą własną grupę na Zanzibar.",
+        "highlights": ["Prowadzenie praktyki dobrane do grupy", "Prywatna willa albo butikowy hotel", "Elastyczny plan praktyki i wycieczek"],
+        "cta": "Stwórz prywatny retreat",
+        "image_alt": "Sesja hands-on bodywork blisko oceanu"
+      }
+    ]
+  },
+  "teachers": {
+    "eyebrow": "Faculty i zespół retreatu",
+    "title": "Mix nauczycieli dopasowany do retreatu.",
+    "lead": "Najpierw jest program. Do każdego retreatu dobieramy prowadzącego praktykę, wsparcie bodywork, gościnnych praktyków i lokalnych hostów, zamiast opierać całe doświadczenie na jednej osobie.",
+    "items": [
+      {
+        "name": "Mindful flow i cisza",
+        "role": "Nina · vinyasa, yin, praca z oddechem",
+        "text": "Nina prowadzi ciepłe, uważne praktyki, ukształtowane przez szkolenie w Portugalii oraz doświadczenie w Maroku i Niemczech. Jej sesje wnoszą ruch, oddech, muzykę, filozofię i cichą integrację w rytm retreatu.",
+        "specialties": ["Vinyasa flow", "Hatha i yin", "Medytacja i praca z oddechem"],
+        "image_alt": "Grupowa praktyka jogi prowadzona przez nauczyciela"
+      },
+      {
+        "name": "Vinyasa dla wszystkich i bodywork",
+        "role": "Awham Mohamed Al-Obaidy · @shela_yogi",
+        "text": "Urodzony i wychowany w Lamu, Awham jest międzynarodowym ekspertem jogi i Thaivedic, twórcą treści oraz opowiada historię stylu życia wellness i hospitality. Do retreatów wnosi vinyasę, hathę i hands-on bodywork z oceaniczną wrażliwością.",
+        "specialties": ["Vinyasa dla wszystkich poziomów", "Hatha joga", "Thaivedic bodywork", "Styl życia wellness z Lamu"],
+        "image_alt": "Sesja hands-on bodywork reprezentująca praktykę Thaivedic Awham Yoga"
+      },
+      {
+        "name": "Gościnni praktycy i lokalni hostowie",
+        "role": "Dźwięk, medytacja, masaż, kultura",
+        "text": "W zależności od retreatu zespół może obejmować lokalnych praktyków wellness, przewodników, kucharzy, masażystów, planistów safari i hostów wyspy, którzy utrzymują podróż praktyczną, ugruntowaną i związaną z miejscem.",
+        "specialties": ["Dźwięk i medytacja", "Masaż i regeneracja", "Wsparcie na wyspie i safari"],
+        "image_alt": "Mała grupa praktykująca jogę przy plaży"
+      }
+    ]
   },
   "quote": {
-    "text": "Moim największym pragnieniem jest, by każdy wyjechał lżejszy, silniejszy, bardziej ugruntowany i głęboko <em>połączony z samym sobą</em> — niosąc tę równowagę w codzienność."
+    "text": "Najlepszy retreat nie wymaga, by wszyscy poruszali się tak samo. Daje wystarczająco struktury, by czuć się zaopiekowanym, i wystarczająco przestrzeni, by <em>wrócić do siebie</em>."
   },
   "practice": {
-    "eyebrow": "Praktyka",
-    "title": "Harmonia między ruchem a bezruchem.",
-    "lead": "Każde zajęcia kształtują się wokół osób na sali — jednego ranka energetyzujący flow, następnego łagodna praktyka regeneracyjna. Muzyka też jest częścią całości: starannie dobrane dźwięki, które pogłębiają świadomość i tworzą atmosferę.",
+    "eyebrow": "Menu praktyki",
+    "title": "Ruch, cisza i bodywork.",
+    "lead": "Program retreatu może być bardziej energetyczny, regeneracyjny, terapeutyczny albo podróżniczy — zależnie od nauczyciela i grupy.",
     "items": [
-      { "step": "01", "title": "Vinyasa Flow", "text": "Dynamiczne, energetyzujące sekwencje budujące siłę, mobilność i skupienie — oddech połączony z ruchem, gdy wschodzi słońce." },
-      { "step": "02", "title": "Hatha Joga", "text": "Uważne ustawienie, świadomy oddech oraz budowanie wewnętrznej stabilności i świadomości. Wolniejsza, rozważna praktyka." },
-      { "step": "03", "title": "Yin Joga", "text": "Długo utrzymywane pozycje i głębokie rozluźnienie, z przestrzenią na medytację, filozofię i autorefleksję. Głęboki relaks." },
-      { "step": "04", "title": "Medytacja i oddech", "text": "Świadome rozciąganie, pranajama i medytacja prowadzona, by uwolnić napięcie, wyciszyć umysł i przywrócić równowagę." }
+      { "step": "01", "title": "Vinyasa dla wszystkich poziomów", "text": "Dynamiczne sekwencje prowadzone oddechem, z opcjami dla początkujących, wracających do praktyki i zaawansowanych." },
+      { "step": "02", "title": "Hatha joga", "text": "Uważne ustawienie, świadomy oddech i stabilna praktyka, która buduje świadomość bez pośpiechu." },
+      { "step": "03", "title": "Yin i regeneracyjne wieczory", "text": "Długo utrzymywane pozycje, miękkie akcesoria, medytacja i głębokie rozluźnienie po dniach nad oceanem lub safari." },
+      { "step": "04", "title": "Thaivedic bodywork", "text": "Terapeutyczne sesje hands-on wspierające regenerację, odpoczynek układu nerwowego i bardziej ugruntowane doświadczenie retreatu." }
     ]
   },
   "journey": {
-    "eyebrow": "Podróż",
-    "title": "Czternaście dni bez pośpiechu.",
-    "lead": "Dni praktyki na wybrzeżu Zanzibaru, pięciodniowe safari w głębi lądu, a potem powrót nad ocean na zakończenie — to, co dzikie, leży dokładnie pośrodku.",
+    "eyebrow": "Możliwy rytm",
+    "title": "Od tygodnia po pełną podróż.",
+    "lead": "Potraktuj te formaty jako punkt wyjścia. Możemy utrzymać retreat prosto i nad wybrzeżem, zbudować go wokół safari albo stworzyć prywatny program na Twoje daty.",
     "items": [
-      { "days": "Dni 1–2", "title": "Przyjazd na wybrzeże", "text": "Ląduj na wybrzeżu Zanzibaru, odetchnij i wejdź w rytm wieczorną praktyką." },
-      { "days": "Dni 3–6", "title": "Praktyka i korzenne wybrzeże", "text": "Poranna vinyasa, wieczorny yin, długie śniadania i wolne popołudnia nad oceanem." },
-      { "days": "Dni 7–11", "title": "Lot na safari", "text": "Lot do Arushy — przeloty wliczone — na pięć dni tanzańskiej przyrody: przejażdżki, szerokie niebo i noce pod gwiazdami." },
-      { "days": "Dni 12–14", "title": "Powrót na wybrzeże", "text": "Powrót samolotem na Zanzibar na ostatnie dni praktyki i odpoczynku oraz niespieszne pożegnanie." }
+      { "days": "3-4 dni", "title": "Prywatny coastal reset", "text": "Krótki program z poranną praktyką, bodyworkiem, odżywczymi posiłkami i powolnymi popołudniami nad morzem." },
+      { "days": "7 dni", "title": "Tydzień resetu", "text": "Codzienna praktyka, jeden lub dwa warsztaty, opcjonalne wycieczki i wystarczająco wolnej przestrzeni, by naprawdę odpocząć." },
+      { "days": "10 dni", "title": "Praktyka i zanurzenie w wyspie", "text": "Głębszy tydzień ze Stone Town, farmami przypraw, dniami na rafie albo doświadczeniami w wioskach, delikatnie wplecionymi w rytm." },
+      { "days": "14 dni", "title": "Podróż joga i safari", "text": "Flagowa trasa: dni praktyki na Zanzibarze, pięć dni safari w Tanzanii, potem powrót nad ocean na zamknięcie." }
     ],
-    "note": "Nasz pierwszy retreat startuje <strong>na początku grudnia 2026</strong> — ciepło, spokojnie i tuż przed szczytem sezonu."
+    "note": "Nasza pierwsza flagowa Podróż Joga i Safari rusza <strong>na początku grudnia 2026</strong>, a prywatne i coastal reset formaty możemy ułożyć wokół Twoich dat."
   },
   "day": {
     "eyebrow": "Dzień na retreacie",
-    "title": "Żadnych budzików prócz ptaków.",
-    "lead": "Typowy dzień jogi na wybrzeżu, zanim podróż przejdzie w pięć dni safari. Wszystko po śniadaniu jest całkowicie opcjonalne — najpewniejszy znak, że naprawdę odpoczywasz.",
+    "title": "Struktura, która trzyma, i przestrzeń, która oddycha.",
+    "lead": "Typowy dzień retreatu na wybrzeżu. Dni safari i prywatne programy zmieniają rytm, ale równowaga pozostaje: praktyka, odżywienie i niespieszny czas.",
     "items": [
-      { "time": "6:15", "title": "Medytacja o świcie", "text": "Opcjonalne siedzenie na tarasie, gdy niebo zmienia barwy. Herbata, bez rozmów." },
-      { "time": "7:00", "title": "Vinyasa o wschodzie słońca", "text": "90 minut flow, póki jeszcze chłodno, oddech połączony z ruchem." },
-      { "time": "9:00", "title": "Długie śniadanie", "text": "Owoce korzennego wybrzeża, świeży sok, dobra kawa. Nigdzie się nie spieszymy." },
-      { "time": "10:30", "title": "Otwarte popołudnie", "text": "Plaża, rafa, warsztat albo hamak. W całości Twoje." },
-      { "time": "13:00", "title": "Wspólny obiad", "text": "Roślinnie, w stylu rodzinnym, pod palmami." },
-      { "time": "17:30", "title": "Yin i regeneracja", "text": "Powoli, przy świecach, prowadzone oddechem. Łagodne lądowanie dnia." },
-      { "time": "19:30", "title": "Kolacja i gwiazdy", "text": "Długi stół, świeża ryba i niebo bez miasta w tle." }
+      { "time": "6:15", "title": "Poranna cisza", "text": "Opcjonalna medytacja, herbata albo spokojny spacer, zanim wyspa się obudzi." },
+      { "time": "7:00", "title": "Poranna praktyka", "text": "Vinyasa, hatha albo ruch prowadzony oddechem, póki powietrze jest jeszcze chłodne." },
+      { "time": "9:00", "title": "Długie śniadanie", "text": "Owoce, świeży sok, dobra kawa i czas, by wejść w dzień." },
+      { "time": "10:30", "title": "Bodywork albo warsztat", "text": "Thaivedic bodywork, alignment, journaling, filozofia albo prowadzona wycieczka." },
+      { "time": "13:00", "title": "Wspólny obiad", "text": "Roślinnie, lokalnie i łatwo do dopasowania do diet." },
+      { "time": "15:00", "title": "Godziny oceanu", "text": "Plaża, rafa, hamak, masaż albo po prostu robienie mniej." },
+      { "time": "17:30", "title": "Wieczorne lądowanie", "text": "Yin, medytacja, dźwięk albo łagodniejsza praktyka na zamknięcie dnia." }
     ]
   },
   "gallery": {
     "eyebrow": "Z praktyki",
     "title": "Chwile z maty.",
-    "lead": "Spojrzenie na praktykę — uchwycone wzdłuż wybrzeża Oceanu Indyjskiego. Ten sam oddech, gdziekolwiek rozłożysz matę.",
+    "lead": "Spojrzenie na praktykę — wybrzeże, tarasy, ciepły kamień, wsparcie hands-on i cisza po ruchu.",
     "items": [
       { "caption": "Wygięcie · otwarte niebo" },
       { "caption": "Zapuszczanie korzeni · ciepły kamień" },
@@ -87,20 +142,20 @@
   },
   "included": {
     "eyebrow": "W cenie",
-    "title": "Jedna cena. Wszystko, co istotne.",
-    "lead": "Poza lotami stawka obejmuje 14-dniową podróż jogi i safari — praktykę, posiłki, pobyty, planowanie safari i drobne akcenty, dzięki którym całość jest dopracowana od początku do końca.",
+    "title": "Zbuduj retreat wokół ludzi, którzy przyjeżdżają.",
+    "lead": "Każda wycena retreatu zależy od zespołu nauczycieli, wielkości grupy, standardu pokoi, posiłków, wycieczek i tego, czy safari jest częścią trasy.",
     "price_from": "Od",
     "price_unit": "od osoby",
     "items": [
-      "14-dniowy program jogi i safari",
-      "5-dniowe safari w Tanzanii w cenie",
-      "Dwie praktyki dziennie z Niną w dni retreatowe",
-      "Wszystkie posiłki i soki tłoczone na zimno",
-      "Mata, akcesoria i cały sprzęt",
-      "Jeden charakterystyczny zabieg spa",
-      "Kąpiele dźwiękiem i wieczory medytacyjne",
-      "Transport safari, planowanie parków i lokalni przewodnicy",
-      "Transfery z lotniska i concierge 24/7"
+      "Program jogi lub bodyworku prowadzony przez nauczyciela",
+      "Vinyasa, hatha, yin, medytacja albo Thaivedic bodywork",
+      "Dobór butikowego hotelu, willi albo bazy przy plaży",
+      "Plan posiłków z obsługą diet",
+      "Maty, akcesoria i koordynacja setupu",
+      "Opcjonalne wycieczki do Stone Town, na rafę, przyprawy albo do wiosek",
+      "Opcjonalne przedłużenie o safari w Tanzanii",
+      "Transfery z lotniska i lokalne przejazdy",
+      "Planowanie Destination Paradise i wsparcie na wyspie"
     ]
   },
   "faqs": {
@@ -108,31 +163,31 @@
     "title": "Pytania, które zadają wszyscy.",
     "items": [
       {
-        "q": "Jestem zupełnie początkująca — czy to w porządku?",
-        "a": "Jak najbardziej. Każde zajęcia projektujemy z wyczuciem na obecne osoby, a przy maksymalnie dwunastu gościach Nina może spotkać Cię dokładnie tam, gdzie jesteś — czy dzień woła o energetyzujący flow, czy o łagodniejszą praktykę regeneracyjną."
+        "q": "Czy to nadal jeden retreat, czy kilka?",
+        "a": "Kilka. Flagowym programem jest 14-dniowa Podróż Joga i Safari, ale teraz tworzymy też tygodnie coastal reset i prywatne retreaty z nauczycielem na własne daty."
       },
       {
-        "q": "Czy mogę przyjechać sama?",
-        "a": "Oczywiście — większość naszych gości przyjeżdża w pojedynkę. Mała grupa dwunastu osób ułatwia nawiązanie kontaktu przy wspólnych posiłkach i praktyce, a jednocześnie zachowujesz tyle ciszy, ile chcesz. Pokoje dostępne są jako jednoosobowe lub do współdzielenia."
+        "q": "Czy początkujący mogą dołączyć?",
+        "a": "Tak. Awham wyraźnie uczy vinyasy dla wszystkich poziomów, a programy Niny można dopasować w stronę łagodnej hathy, yin i pracy z oddechem, jeśli grupa potrzebuje spokojniejszego rytmu."
       },
       {
-        "q": "W jakim stylu jogi będziemy praktykować?",
-        "a": "Mieszanka: energetyzująca vinyasa rano, wolniejsza hatha i głęboko regeneracyjny yin wieczorem, a do tego medytacja i praca z oddechem. Każdy dzień kształtuje się wokół grupy, więc równowaga zmienia się zależnie od samopoczucia wszystkich."
+        "q": "Czy możemy wybrać nauczyciela?",
+        "a": "W prywatnych retreatach tak. Powiedz nam, jakiego stylu praktyki szukasz, a zaproponujemy najlepszy miks nauczycieli, także co-teaching albo gościnnych praktyków, jeśli to ma sens. Stałe terminy pokazują zespół prowadzący przed rezerwacją."
       },
       {
-        "q": "A co z jedzeniem i potrzebami dietetycznymi?",
-        "a": "Wszystkie posiłki są w cenie — roślinne, z lokalnych składników, serwowane w stylu rodzinnym. Chętnie uwzględnimy diety wegetariańskie, wegańskie, bezglutenowe i większość alergii; wystarczy dać nam znać przy rezerwacji."
+        "q": "Czy safari można dodać do każdego retreatu?",
+        "a": "Tak. Safari jest częścią 14-dniowej flagowej podróży, a przy większości prywatnych lub coastal retreatów można je dodać przed albo po programie."
       },
       {
-        "q": "Czy safari jest wliczone w retreat?",
-        "a": "Tak. Retreat jest teraz zaplanowany jako 14-dniowa podróż z pięciodniowym safari w Tanzanii w cenie, więc nie musisz dodawać go osobno. Powiedz nam, jeśli chcesz dodatkowe noce na plaży przed lub po, a ułożymy całą trasę."
+        "q": "Czy musimy mieć własne zdjęcia albo nauczyciela?",
+        "a": "Nie. Możemy zapewnić lokalnych nauczycieli i materiały wizualne retreatu albo koordynować program z nauczycielem, który przywozi własną grupę i materiały marki."
       }
     ]
   },
   "cta": {
-    "title": "Wróć do siebie.",
-    "text": "Daj nam znać, kiedy masz wolne, a zarezerwujemy Ci miejsce na 14-dniową podróż jogi i safari z Niną. Małe grupy szybko się zapełniają — im wcześniej się odezwiesz, tym lepszy pokój.",
-    "reserve": "Zarezerwuj miejsce →",
+    "title": "Powiedz nam, jakiego rytmu chcesz.",
+    "text": "Wybierz typ retreatu, podaj daty, a my ułożymy zespół nauczycieli, pokoje, posiłki, wycieczki i opcjonalne safari wokół Twojej grupy.",
+    "reserve": "Rozpocznij zapytanie o retreat →",
     "ai_planner": "Albo porozmawiaj z naszym planerem AI"
   }
 }

--- a/src/pages/Booking.jsx
+++ b/src/pages/Booking.jsx
@@ -157,8 +157,9 @@ export default function Booking() {
   const isTransferRequest = form.serviceType === 'transfer';
   const isRetreatRequest = form.serviceType === 'retreat';
   const selectedTransferTier = transferTiers.find((item) => item.value === form.transferTier);
+  const selectedRetreatProduct = selectedProduct?.type === 'retreat' ? selectedProduct : null;
   const retreatDepartures = useMemo(() => {
-    const departures = products.retreats?.[0]?.raw.departures || [];
+    const departures = selectedRetreatProduct?.raw.departures || [];
     const formatter = new Intl.DateTimeFormat(i18n.resolvedLanguage || 'en', {
       day: 'numeric',
       month: 'short',
@@ -169,7 +170,7 @@ export default function Booking() {
       // Noon avoids the UTC-midnight off-by-one day shift in negative offsets.
       label: formatter.formatRange(new Date(`${dep.start}T12:00:00`), new Date(`${dep.end}T12:00:00`)),
     }));
-  }, [products.retreats, i18n.resolvedLanguage]);
+  }, [selectedRetreatProduct, i18n.resolvedLanguage]);
   const onDepartureChange = (event) => {
     const start = event.target.value;
     const departure = retreatDepartures.find((dep) => dep.start === start);
@@ -234,6 +235,12 @@ export default function Booking() {
           transferTier: value === 'transfer' ? current.transferTier || 'standard-private' : current.transferTier,
         }
         : {}),
+      ...(key === 'product' && current.serviceType === 'retreat'
+        ? {
+          startDate: '',
+          endDate: '',
+        }
+        : {}),
     }));
   };
 
@@ -245,7 +252,7 @@ export default function Booking() {
 
     const payload = {
       ...form,
-      endDate: showDateRange ? form.endDate : '',
+      endDate: showDateRange || isRetreatRequest ? form.endDate : '',
       budget: showTravelPreferences ? form.budget : '',
       budgetLabel: showTravelPreferences ? budgetLabel : '',
       accommodationLevel: showTravelPreferences ? accommodationLabel : '',

--- a/src/pages/Retreats.jsx
+++ b/src/pages/Retreats.jsx
@@ -8,15 +8,33 @@ import { RETREAT_PRODUCTS } from '../data/retreatProducts.js';
 import '../styles/excursions/hero.css';
 import '../styles/retreats.css';
 
-// Single source of truth for the retreat's "from" price (shared with booking).
-const RETREAT_PRICE = RETREAT_PRODUCTS[0].price;
+// Single source of truth for the retreat collection's "from" price.
+const RETREAT_PRICE = Math.min(...RETREAT_PRODUCTS.map((product) => product.price));
 
 const IMG = {
-  hero: '/assets/images/retreats/zanzibar-tree-pose-view.webp',
-  teacher: '/assets/images/retreats/teacher-garden-sun-portrait.webp',
   quote: '/assets/images/retreats/coastal-handstand-sunset.webp',
   cta: '/assets/images/retreats/mountain-star-pose.webp',
 };
+
+const HERO_IMAGES = [
+  '/assets/images/retreats/zanzibar-tree-pose-view.webp',
+  '/assets/images/retreats/studio-warrior-circle.webp',
+  '/assets/images/retreats/assisted-beach-stretch.webp',
+  '/assets/images/retreats/yoga-side-bend-beach.webp',
+  '/assets/images/retreats/yoga-plank-sunset-coast.webp',
+];
+
+const RETREAT_TYPE_IMAGES = [
+  '/assets/images/retreats/yoga-clifftop-ocean-view.webp',
+  '/assets/images/retreats/yoga-side-bend-beach.webp',
+  '/assets/images/retreats/assisted-beach-stretch.webp',
+];
+
+const TEACHER_IMAGES = [
+  '/assets/images/retreats/studio-warrior-circle.webp',
+  '/assets/images/retreats/assisted-beach-stretch.webp',
+  '/assets/images/retreats/beach-class-plank.webp',
+];
 
 // Bento gallery — paired with the localized captions (gallery.items), in order.
 const GALLERY_IMAGES = [
@@ -37,8 +55,11 @@ export default function Retreats() {
   const { format } = useCurrency();
   const pageRef = useRef(/** @type {HTMLElement | null} */ (null));
   const [openFaq, setOpenFaq] = useState(0);
+  const [heroSlide, setHeroSlide] = useState(0);
 
   const practices = arrayFromTranslation(t('practice.items', { returnObjects: true }));
+  const retreatTypes = arrayFromTranslation(t('retreat_types.items', { returnObjects: true }));
+  const teachers = arrayFromTranslation(t('teachers.items', { returnObjects: true }));
   const journey = arrayFromTranslation(t('journey.items', { returnObjects: true }));
   const daySchedule = arrayFromTranslation(t('day.items', { returnObjects: true }));
   const galleryItems = arrayFromTranslation(t('gallery.items', { returnObjects: true }));
@@ -56,6 +77,15 @@ export default function Retreats() {
   useEffect(() => {
     document.body.classList.add('has-retreat-page');
     return () => document.body.classList.remove('has-retreat-page');
+  }, []);
+
+  useEffect(() => {
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion || HERO_IMAGES.length < 2) return undefined;
+    const timer = window.setInterval(() => {
+      setHeroSlide((index) => (index + 1) % HERO_IMAGES.length);
+    }, 5200);
+    return () => window.clearInterval(timer);
   }, []);
 
   useEffect(() => {
@@ -84,16 +114,31 @@ export default function Retreats() {
     <main className="retreat-page" ref={pageRef}>
       {/* Hero — shared site hero pattern (mirrors excursions/safaris/packages) */}
       <section className="exc-hero">
-        <div className="exc-hero__bg">
-          <ResponsiveImage src={IMG.hero} alt="" fetchpriority="high" loading="eager" decoding="sync" sizes="100vw" />
+        <div className="exc-hero__bg ret-hero-slideshow">
+          {HERO_IMAGES.map((image, index) => (
+            <div
+              className={`ret-hero-slide${index === heroSlide ? ' is-active' : ''}`}
+              key={image}
+              aria-hidden="true"
+            >
+              <ResponsiveImage
+                src={image}
+                alt=""
+                fetchpriority={index === 0 ? 'high' : 'auto'}
+                loading={index === 0 ? 'eager' : 'lazy'}
+                decoding={index === 0 ? 'sync' : 'async'}
+                sizes="100vw"
+              />
+            </div>
+          ))}
         </div>
         <div className="exc-hero__inner">
           <span className="exc-hero__eyebrow">{t('hero.eyebrow')}</span>
           <h1 className="exc-hero__title">{t('hero.title_prefix')} <em>{t('hero.title_em')}</em></h1>
           <p className="exc-hero__lead">{t('hero.subtitle')}</p>
           <div className="exc-hero__row">
-            <a className="btn btn--lg" href="#day">{t('hero.see_day')}</a>
-            <Link className="btn btn--ghost btn--lg" to="/booking?type=retreat&item=yoga-safari-retreat">{t('hero.reserve')}</Link>
+            <a className="btn btn--lg" href="#retreat-types">{t('hero.see_day')}</a>
+            <Link className="btn btn--ghost btn--lg" to="/booking?type=retreat">{t('hero.reserve')}</Link>
           </div>
           <div className="exc-hero__meta">
             <div><strong>{t('hero.stat_nights_value')}</strong><span>{t('hero.stat_nights')}</span></div>
@@ -112,18 +157,68 @@ export default function Retreats() {
         </p>
       </section>
 
-      {/* Teacher */}
-      <section className="ret-teacher reveal">
-        <div className="ret-teacher__media">
-          <ResponsiveImage src={IMG.teacher} alt="Nina, your yoga teacher and retreat host" sizes="(max-width: 900px) 100vw, 42vw" />
+      {/* Retreat styles */}
+      <section className="ret-dark ret-types" id="retreat-types">
+        <header className="ret-dark__head reveal">
+          <span className="ret-eyebrow ret-eyebrow--light">{t('retreat_types.eyebrow')}</span>
+          <h2 className="ret-title ret-title--script">{t('retreat_types.title')}</h2>
+          <p className="ret-dark__lead">{t('retreat_types.lead')}</p>
+        </header>
+        <div className="ret-types__grid">
+          {retreatTypes.map((item, i) => {
+            const product = RETREAT_PRODUCTS.find((entry) => entry.slug === item.slug);
+            return (
+              <article className="ret-type-card reveal" key={item.slug} style={{ '--ret-reveal-index': i }}>
+                <div className="ret-type-card__media">
+                  <ResponsiveImage src={RETREAT_TYPE_IMAGES[i % RETREAT_TYPE_IMAGES.length]} alt={item.image_alt} sizes="(max-width: 900px) 100vw, 33vw" />
+                </div>
+                <div className="ret-type-card__copy">
+                  <span>{item.duration}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.text}</p>
+                  <ul>
+                    {arrayFromTranslation(item.highlights).map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                  <div className="ret-type-card__footer">
+                    {product && (
+                      <p>{t('retreat_types.price_from')} <strong>{format(product.price)}</strong></p>
+                    )}
+                    <Link to={`/booking?type=retreat&item=${item.slug}`}>{item.cta}</Link>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
         </div>
-        <div className="ret-teacher__copy">
-          <span className="ret-eyebrow">{t('teacher.eyebrow')}</span>
-          <h2 className="ret-title">{t('teacher.title')}</h2>
-          <p className="ret-teacher__lead"><span className="ret-dropcap">{t('teacher.p1').charAt(0)}</span>{t('teacher.p1').slice(1)}</p>
-          <p>{t('teacher.p2')}</p>
-          <p>{t('teacher.p3')}</p>
-          <p className="ret-teacher__signoff">{t('teacher.signoff')}</p>
+      </section>
+
+      {/* Teachers */}
+      <section className="ret-teachers reveal" id="teachers">
+        <header className="ret-teachers__head">
+          <span className="ret-eyebrow">{t('teachers.eyebrow')}</span>
+          <h2 className="ret-title">{t('teachers.title')}</h2>
+          <p>{t('teachers.lead')}</p>
+        </header>
+        <div className="ret-teachers__grid">
+          {teachers.map((teacher, i) => (
+            <article className="ret-teacher-card reveal" key={teacher.name} style={{ '--ret-reveal-index': i }}>
+              <div className="ret-teacher-card__media">
+                <ResponsiveImage src={TEACHER_IMAGES[i % TEACHER_IMAGES.length]} alt={teacher.image_alt} sizes="(max-width: 900px) 100vw, 45vw" />
+              </div>
+              <div className="ret-teacher-card__copy">
+                <span>{teacher.role}</span>
+                <h3>{teacher.name}</h3>
+                <p>{teacher.text}</p>
+                <ul>
+                  {arrayFromTranslation(teacher.specialties).map((specialty) => (
+                    <li key={specialty}>{specialty}</li>
+                  ))}
+                </ul>
+              </div>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -269,7 +364,7 @@ export default function Retreats() {
           <h2 className="ret-title ret-title--light">{t('cta.title')}</h2>
           <p>{t('cta.text')}</p>
           <div className="ret-cta__btns">
-            <Link className="btn btn--lg btn--accent" to="/booking?type=retreat&item=yoga-safari-retreat">{t('cta.reserve')}</Link>
+            <Link className="btn btn--lg btn--accent" to="/booking?type=retreat">{t('cta.reserve')}</Link>
             <Link className="btn btn--ghost-light btn--lg" to="/trip-planner">{t('cta.ai_planner')}</Link>
           </div>
         </div>

--- a/src/styles/retreats.css
+++ b/src/styles/retreats.css
@@ -1,4 +1,4 @@
-/* Retreats — single Yoga Retreat detail page.
+/* Retreats — yoga and wellness retreat hub.
    Self-contained styles built on the Destination Paradise tokens
    (tokens.css). Shared .btn and .btn--* come from site-shell.css. */
 
@@ -119,8 +119,28 @@ html[data-theme="dark"] .retreat-page {
   to { opacity: 1; transform: none; }
 }
 
-.retreat-page .exc-hero__bg img {
+.retreat-page .ret-hero-slideshow {
+  background: #0c2739;
+}
+.retreat-page .ret-hero-slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 1.35s ease;
+  will-change: opacity;
+}
+.retreat-page .ret-hero-slide.is-active {
+  opacity: 1;
+}
+.retreat-page .ret-hero-slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   animation: heroImageReveal 1.4s var(--dp-ease-out) both, retHeroDrift 18s ease-in-out 1.4s infinite alternate;
+}
+.retreat-page .exc-hero {
+  min-height: 100svh;
 }
 .retreat-page .exc-hero__meta div {
   transition: transform 0.3s var(--dp-ease-out), background 0.3s ease, border-color 0.3s ease;
@@ -145,6 +165,238 @@ html[data-theme="dark"] .retreat-page {
   color: var(--text);
 }
 .ret-intention__text em { font-style: italic; color: var(--dp-accent); }
+
+/* ---------- Retreat styles ---------- */
+.ret-types {
+  padding-top: clamp(4rem, 8vw, 6.5rem);
+}
+.ret-types__grid {
+  width: min(var(--site-max-width), 92%);
+  margin: clamp(2.5rem, 5vw, 3.5rem) auto 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+.ret-type-card {
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  border: 1px solid var(--ret-panel-border);
+  border-radius: 8px;
+  background: var(--ret-panel);
+  box-shadow: 0 16px 38px rgba(14, 36, 56, 0.1);
+  transition:
+    opacity 0.7s var(--dp-ease-out),
+    transform 0.7s var(--dp-ease-out),
+    filter 0.7s var(--dp-ease-out),
+    background 0.3s ease,
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
+}
+.ret-type-card.is-visible:hover {
+  transform: translateY(-6px);
+  background: var(--ret-panel-hover);
+  box-shadow: 0 22px 54px rgba(14, 36, 56, 0.16);
+}
+.ret-type-card__media {
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+.ret-type-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.9s var(--dp-ease-out), filter 0.9s var(--dp-ease-out);
+}
+.ret-type-card.is-visible:hover .ret-type-card__media img {
+  transform: scale(1.06);
+  filter: saturate(1.06);
+}
+.ret-type-card__copy {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.25rem, 2vw, 1.7rem);
+}
+.ret-type-card__copy > span {
+  font-size: var(--dp-fs-caption);
+  line-height: 1.3;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dp-hover);
+  font-weight: 700;
+}
+.ret-type-card__copy h3 {
+  margin: 0.55rem 0 0;
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.35rem, 1.2vw + 1rem, 1.9rem);
+  line-height: 1.1;
+  color: var(--ret-section-text);
+}
+.ret-type-card__copy p {
+  margin: 0.85rem 0 0;
+  font-size: var(--dp-fs-body-sm);
+  line-height: 1.58;
+  color: var(--ret-section-muted);
+}
+.ret-type-card__copy ul {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+.ret-type-card__copy li {
+  position: relative;
+  padding-left: 1rem;
+  font-size: var(--dp-fs-caption);
+  line-height: 1.45;
+  color: var(--ret-section-text);
+}
+.ret-type-card__copy li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 50%;
+  background: var(--dp-accent);
+}
+.ret-type-card__footer {
+  margin-top: auto;
+  padding-top: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.ret-type-card__footer p {
+  margin: 0;
+  color: var(--ret-section-muted);
+}
+.ret-type-card__footer strong {
+  font-family: var(--dp-font-display);
+  font-size: 1.3rem;
+  color: var(--ret-section-text);
+}
+.ret-type-card__footer a {
+  color: var(--dp-hover);
+  font-weight: 800;
+  font-size: var(--dp-fs-caption);
+  text-decoration: none;
+}
+.ret-type-card__footer a:hover {
+  color: var(--dp-accent);
+}
+
+/* ---------- Teachers ---------- */
+.ret-teachers {
+  width: min(var(--site-max-width), 92%);
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 7rem) 0;
+}
+.ret-teachers__head {
+  max-width: 840px;
+}
+.ret-teachers__head p {
+  max-width: 62ch;
+  margin: 1rem 0 0;
+  color: var(--text-muted);
+  font-size: var(--dp-fs-body);
+  line-height: 1.65;
+}
+.ret-teachers__grid {
+  margin-top: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.85rem, 1.6vw, 1.25rem);
+}
+.ret-teacher-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  overflow: hidden;
+  border: 1px solid var(--ret-panel-border);
+  border-radius: 8px;
+  background: var(--ret-panel);
+  box-shadow: 0 18px 42px rgba(14, 36, 56, 0.11);
+  transition:
+    opacity 0.7s var(--dp-ease-out),
+    transform 0.7s var(--dp-ease-out),
+    filter 0.7s var(--dp-ease-out),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+}
+.ret-teacher-card.is-visible:hover {
+  transform: translateY(-5px);
+  background: var(--ret-panel-hover);
+  box-shadow: 0 24px 58px rgba(14, 36, 56, 0.16);
+}
+.ret-teacher-card__media {
+  aspect-ratio: 4 / 3;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--surface-2);
+}
+.ret-teacher-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.9s var(--dp-ease-out), filter 0.9s var(--dp-ease-out);
+}
+.ret-teacher-card.is-visible:hover .ret-teacher-card__media img {
+  transform: scale(1.05);
+  filter: saturate(1.06);
+}
+.ret-teacher-card__copy {
+  padding: clamp(1.35rem, 2.2vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.ret-teacher-card__copy > span {
+  color: var(--dp-hover);
+  font-size: var(--dp-fs-caption);
+  line-height: 1.35;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+.ret-teacher-card__copy h3 {
+  margin: 0.55rem 0 0;
+  color: var(--text);
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.35rem, 1vw + 1rem, 1.85rem);
+  line-height: 1.08;
+}
+.ret-teacher-card__copy p {
+  margin: 0.95rem 0 0;
+  color: var(--text-muted);
+  font-size: var(--dp-fs-body-sm);
+  line-height: 1.62;
+}
+.ret-teacher-card__copy ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: auto 0 0;
+  padding: 1.25rem 0 0;
+}
+.ret-teacher-card__copy li {
+  border: 1px solid var(--ret-panel-border);
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--text);
+  font-size: var(--dp-fs-caption);
+  line-height: 1.2;
+  background: rgba(255, 255, 255, 0.46);
+}
+html[data-theme="dark"] .ret-teacher-card__copy li {
+  background: rgba(255, 255, 255, 0.05);
+}
 
 /* ---------- Teacher ---------- */
 .ret-teacher {
@@ -607,10 +859,15 @@ body.has-retreat-page .footer {
 @media (prefers-reduced-motion: reduce) {
   .retreat-page .reveal,
   .retreat-page .reveal.is-visible,
+  .ret-type-card,
   .ret-practice__card,
   .ret-faq__item,
   .ret-gallery__cell figcaption,
   .ret-gallery__cell img,
+  .ret-type-card__media img,
+  .ret-teacher-card,
+  .ret-teacher-card__media img,
+  .ret-hero-slide,
   .ret-teacher__media img,
   .retreat-page .exc-hero__meta div {
     transition: none;
@@ -630,11 +887,14 @@ body.has-retreat-page .footer {
 @media (max-width: 900px) {
   .ret-teacher { grid-template-columns: 1fr; }
   .ret-teacher__media { max-width: 460px; }
+  .ret-types__grid { grid-template-columns: 1fr; }
+  .ret-teachers__grid { grid-template-columns: 1fr; }
   .ret-included { grid-template-columns: 1fr; }
 }
 @media (max-width: 720px) {
   .ret-hero { min-height: 92vh; }
   .ret-hero__stats { gap: 1.6rem 2.4rem; }
+  .ret-teacher-card__media { aspect-ratio: 4 / 3; }
   .ret-practice__grid { grid-template-columns: 1fr; }
   .ret-journey__grid { grid-template-columns: 1fr; }
   .ret-gallery__grid { grid-template-columns: repeat(2, 1fr); grid-auto-rows: 150px; }


### PR DESCRIPTION
## What

Grows `/retreats` from a single yoga-safari retreat into a three-product collection and wires the new products through booking.

**Products** (`retreatProducts.js`): adds **Coastal Reset Week** (7-day, scheduled departures) and **Private Teacher-Led Retreat** (flexible, no fixed dates) alongside the existing Yoga & Safari Retreat.

**Retreats page**:
- Hero slideshow (5 slides, reduced-motion aware, first slide eager/high-priority)
- New **retreat-types** section — one card per product, matched to `RETREAT_PRODUCTS` by `slug` for the "from" price
- New multi-**teachers** section replacing the single-host block
- Locales (en/de/pl) gain `retreat_types` + `teachers` content at full parity (3 items each)

**Booking flow** (`Booking.jsx`, `BookingForm.jsx`): departures come from the *selected* retreat product; the departure `<select>` only renders when the product has fixed dates; dates reset on product switch; `endDate` included in the retreat payload.

**Two React 18 attribute bug fixes surfaced by this work**:
- `ResponsiveImage` passed camelCase `fetchPriority` (not a valid DOM attribute) → now spreads lowercase `fetchpriority` only when set.
- `SiteNav` set the mobile dialog's `inert` via a JSX prop React 18 ignores → now toggled through a DOM effect.

## Verification
Lint clean · typecheck clean · **52/52 tests** (locale-parity included) · full build green, **120/120 routes prerendered**. Confirmed all referenced retreat images exist, product slugs ↔ locale slugs align, and the prerendered `/retreats` HTML contains the new sections with no unresolved i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)