### PR TITLE
Retreats hero: widen slideshow, clip slides

### DIFF
--- a/src/pages/Retreats.jsx
+++ b/src/pages/Retreats.jsx
@@ -22,6 +22,18 @@ const HERO_IMAGES = [
   '/assets/images/retreats/assisted-beach-stretch.webp',
   '/assets/images/retreats/yoga-side-bend-beach.webp',
   '/assets/images/retreats/yoga-plank-sunset-coast.webp',
+  '/assets/images/retreats/terrace-wheel-pose.webp',
+  '/assets/images/retreats/red-rock-tree-pose.webp',
+  '/assets/images/retreats/terrace-balance-pose.webp',
+  '/assets/images/retreats/red-rock-wild-thing.webp',
+  '/assets/images/retreats/beach-class-plank.webp',
+  '/assets/images/retreats/alpine-tree-pose.webp',
+  '/assets/images/retreats/yoga-clifftop-ocean-view.webp',
+  '/assets/images/retreats/yoga-tree-pose-beach.webp',
+  '/assets/images/retreats/coastal-handstand-sunset.webp',
+  '/assets/images/retreats/mountain-star-pose.webp',
+  '/assets/images/retreats/teacher-garden-sun-portrait.webp',
+  '/assets/images/retreats/teacher-portrait-garden.webp',
 ];
 
 const RETREAT_TYPE_IMAGES = [

--- a/src/styles/retreats.css
+++ b/src/styles/retreats.css
@@ -121,10 +121,13 @@ html[data-theme="dark"] .retreat-page {
 
 .retreat-page .ret-hero-slideshow {
   background: #0c2739;
+  contain: paint;
+  overflow: hidden;
 }
 .retreat-page .ret-hero-slide {
   position: absolute;
   inset: 0;
+  overflow: hidden;
   opacity: 0;
   pointer-events: none;
   transition: opacity 1.35s ease;
@@ -854,6 +857,10 @@ body.has-retreat-page .footer {
   z-index: 1;
   margin-top: -2px;
   border-top: 0;
+}
+
+body.has-retreat-page {
+  overflow-x: clip;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Follow-on to the retreats expansion: grows the hero slideshow pool from 5 to 17 images and adds `contain: paint` + `overflow: hidden` so slides stay clipped to the hero frame during the crossfade.

All 17 referenced images verified present. Lint/typecheck clean, build green (120/120 routes prerendered, `/retreats` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)