### PR TITLE
fix: resolve two Sentry errors (service-worker registration + CSS preload)

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -10,7 +10,9 @@ function isChunkLoadError(error) {
   const name = error.name || '';
   const message = error.message || '';
   if (name === 'ChunkLoadError') return true;
-  return /Loading chunk [\w-]+ failed|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module/i.test(
+  // "Unable to preload CSS for ..." is Vite's vite:preloadError message for a
+  // lazily-loaded chunk whose CSS 404s after a new deploy (Sentry DESTINATIONPARADISE-3).
+  return /Loading chunk [\w-]+ failed|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Unable to preload CSS for/i.test(
     message,
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import App from './App.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
 import { CurrencyProvider } from './context/CurrencyContext.jsx';
 import { applyTheme, readStoredTheme } from './utils/theme.js';
+import { registerServiceWorker } from './utils/registerServiceWorker.js';
 import './i18n/index.js';
 import './styles/tokens.css';
 import './styles/site-shell.css';
@@ -26,3 +27,5 @@ createRoot(document.getElementById('root')).render(
     </BrowserRouter>
   </StrictMode>
 );
+
+registerServiceWorker();

--- a/src/types/vite-plugin-pwa.d.ts
+++ b/src/types/vite-plugin-pwa.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite-plugin-pwa/client" />
+
+// Provides the `virtual:pwa-register` module declaration used by
+// src/utils/registerServiceWorker.js.

--- a/src/utils/registerServiceWorker.js
+++ b/src/utils/registerServiceWorker.js
@@ -1,0 +1,35 @@
+import { captureSentryException } from './sentry.js';
+
+// Manually register the vite-plugin-pwa service worker.
+//
+// Previously the plugin auto-injected a `registerSW.js` that called
+// `navigator.serviceWorker.register()` with no error handling, so any
+// registration failure (e.g. crawler / insecure-context environments such as
+// Google-Read-Aloud) bubbled up as an unhandled promise rejection —
+// Sentry DESTINATIONPARADISE-2. Registering here lets us catch that failure,
+// report it as a *handled* exception, and keep it out of the noise.
+//
+// The `virtual:pwa-register` module is imported dynamically and guarded with a
+// `.catch()` so a failure to even load the register helper can never produce an
+// unhandled rejection either (and so it stays out of the test module graph).
+export function registerServiceWorker() {
+  if (typeof window === 'undefined') return;
+  if (!('serviceWorker' in navigator)) return;
+
+  import('virtual:pwa-register')
+    .then(({ registerSW }) => {
+      registerSW({
+        immediate: true,
+        onRegisterError(error) {
+          captureSentryException(error, {
+            tags: { serviceWorker: 'register' },
+          });
+        },
+      });
+    })
+    .catch((error) => {
+      captureSentryException(error, {
+        tags: { serviceWorker: 'register-import' },
+      });
+    });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,11 @@ export default defineConfig(({ mode }) => {
       react(),
       VitePWA({
         registerType: 'autoUpdate',
-        injectRegister: 'script-defer',
+        // Register the service worker manually (see src/utils/registerServiceWorker.js)
+        // so registration failures are caught instead of surfacing as unhandled
+        // promise rejections (Sentry DESTINATIONPARADISE-2). The auto-injected
+        // registerSW.js called navigator.serviceWorker.register() with no .catch().
+        injectRegister: false,
         workbox: {
           clientsClaim: true,
           skipWaiting: true,


### PR DESCRIPTION
## Summary

Fixes the two real unresolved issues surfaced in Sentry (the other two open issues — `DESTINATIONPARADISE-1` and `JAVASCRIPT-1` — are the setup smoke test and Sentry's built-in demo event, so no code change is needed for those).

## Issue 1 — `DESTINATIONPARADISE-2`: unhandled promise rejection "Rejected" on `/explore/`

**Cause:** `vite-plugin-pwa` was configured with `injectRegister: 'script-defer'`, which auto-generates a `registerSW.js` that calls `navigator.serviceWorker.register()` with **no `.catch()`**. When registration fails (observed under a crawler user-agent, `Google-Read-Aloud`, i.e. an insecure-context / scope edge case) the rejection surfaces as an unhandled promise rejection. Stack trace pointed straight at `registerSW.js`.

**Fix:** register the service worker manually.
- `vite.config.js`: `injectRegister: false` — stop auto-injecting the un-caught `registerSW.js`.
- New `src/utils/registerServiceWorker.js`: dynamically imports `virtual:pwa-register` and calls `registerSW({ immediate: true, onRegisterError })`, reporting failures to Sentry as **handled** exceptions. The dynamic import is itself `.catch()`-guarded so a load failure can't produce an unhandled rejection either.
- `src/main.jsx`: call `registerServiceWorker()` after render.

`registerType: 'autoUpdate'` and the workbox `skipWaiting` / `clientsClaim` behaviour are unchanged — only the registration path moves.

## Issue 2 — `DESTINATIONPARADISE-3`: "Unable to preload CSS for /assets/Retreats-*.css" on `/retreats`

**Cause:** Vite's `vite:preloadError` message for a lazily-loaded route chunk whose hashed CSS 404s after a new deploy (stale `index.html` referencing a since-removed chunk). The root `ErrorBoundary` already has one-shot auto-reload recovery for chunk-load failures, but its `isChunkLoadError()` matcher didn't recognise the CSS-preload message, so it rendered the full error page instead of recovering.

**Fix:** extend the `isChunkLoadError()` regex in `src/components/ErrorBoundary.jsx` to also match `Unable to preload CSS for`, routing it through the existing (sessionStorage-guarded, no-loop) reload recovery.

## Verification

- `eslint` — clean
- `tsc` typecheck — clean (added `src/types/vite-plugin-pwa.d.ts` for the `virtual:pwa-register` module types)
- `vitest run` — 33/33 passing
- `vite build` — succeeds; `dist/index.html` no longer references `registerSW.js`, and `dist/sw.js` is still emitted (PWA/auto-update intact)

## Notes / follow-up (infra, not code)

Issue 2's underlying trigger is deploy-cache hygiene — old `/assets/*` chunks being purged the moment a new build ships while a client still holds a stale `index.html`. The auto-reload above makes it self-heal for users, but keeping the previous build's hashed assets available for a short grace period (and correct `Cache-Control` on `index.html`) would prevent the error from firing at all. Left out of this PR since it's a hosting/CDN config change, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfz2BbSrBn5u8XZV5HcfqH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hfz2BbSrBn5u8XZV5HcfqH)_