### PR TITLE
Add safe Threads auto-commenter

### DIFF
--- a/.github/workflows/threads-auto-commenter.yml
+++ b/.github/workflows/threads-auto-commenter.yml
@@ -1,0 +1,93 @@
+name: Threads Auto Commenter
+
+on:
+  schedule:
+    - cron: '23 8,12,16 * * *'
+      timezone: Africa/Dar_es_Salaam
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish replies; otherwise perform a dry run
+        required: true
+        type: boolean
+        default: false
+      initialize_state:
+        description: Create empty state only when no prior remote state exists
+        required: true
+        type: boolean
+        default: false
+
+concurrency:
+  group: destination-paradise-threads-auto-commenter
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  comment:
+    name: Find and help travelers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      THREADS_EXPECTED_USERNAME: yournexttriptoparadise
+      THREADS_STATE_PATH: .threads-auto-commenter-data/state.json
+      THREADS_TIME_ZONE: Africa/Dar_es_Salaam
+      THREADS_USER_ACCESS_TOKEN: ${{ secrets.THREADS_USER_ACCESS_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Restore duplicate-prevention state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INITIALIZE_STATE: ${{ inputs.initialize_state || 'false' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .threads-auto-commenter-data
+          artifact_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=threads-auto-commenter-state&per_page=100" --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | reverse | .[0].id // empty')"
+          if [[ -n "${artifact_id}" ]]; then
+            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/threads-auto-commenter-state.zip
+            unzip -jo /tmp/threads-auto-commenter-state.zip -d .threads-auto-commenter-data
+          elif [[ "${INITIALIZE_STATE}" == "true" ]]; then
+            printf '%s\n' '{"version":1,"records":[]}' > .threads-auto-commenter-data/state.json
+          else
+            echo '::error::No remote Threads state exists. Run this workflow manually once with initialize_state enabled and publish disabled.'
+            exit 1
+          fi
+
+      - name: Validate authorization is configured
+        run: |
+          set -euo pipefail
+          if [[ -z "${THREADS_USER_ACCESS_TOKEN}" ]]; then
+            echo '::error::Missing THREADS_USER_ACCESS_TOKEN. Complete the Threads OAuth grant before enabling publishing.'
+            exit 1
+          fi
+
+      - name: Publish or validate replies
+        env:
+          MANUAL_PUBLISH: ${{ inputs.publish || 'false' }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${MANUAL_PUBLISH}" == "true" ]]; then
+            npm run threads:comment:publish
+          else
+            npm run threads:comment:dry-run
+          fi
+
+      - name: Persist duplicate-prevention state
+        if: ${{ always() && hashFiles('.threads-auto-commenter-data/state.json') != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: threads-auto-commenter-state
+          path: .threads-auto-commenter-data/state.json
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dev-dist
 *.log
 .instagram-story-state.json
 .instagram-story-log.jsonl
+.threads-auto-commenter-state.json
 
 # Docs-side asset/archive snapshots
 docs/

--- a/THREADS_AUTO_COMMENTER.md
+++ b/THREADS_AUTO_COMMENTER.md
@@ -1,0 +1,58 @@
+# Destination Paradise Threads auto-commenter
+
+This automation is separate from the Instagram Story publisher. It uses only Meta's official Threads API to search recent public posts and publish replies. It does not scan Facebook Groups, scrape Meta pages, use browser clicks, or keep a lead database.
+
+## Safety model
+
+- Dry-run is the default. Publishing requires `--publish` or the explicit workflow input.
+- Candidates must be fresh, original posts with both a Zanzibar/Tanzania destination signal and clear question/request intent.
+- News, politics, complaints, businesses, promotions, spam, ambiguous posts, and medical/visa/entry questions are rejected.
+- The account is verified as `@yournexttriptoparadise` before candidates are processed.
+- The script checks the account's recent replies through `/me/replies` and also keeps minimal duplicate-prevention state.
+- The Zanzibar-day cap is five attempts. A run handles at most two posts, and one post is attempted only once.
+- State retains only the source post ID, reply ID when known, timestamps, and a small status value. It is pruned after 90 days.
+- A post ID is journaled before publishing. The publish endpoint is called exactly once. A timeout, 5xx response, rate-limit response, or other uncertain failure is recorded and is never retried automatically.
+
+## Required Threads authorization
+
+The existing Instagram credentials are not valid for Threads. Create or use a Meta app with the **Threads API** use case, authorize the Destination Paradise Threads profile, and grant:
+
+- `threads_basic`
+- `threads_content_publish`
+- `threads_manage_replies`
+- `threads_read_replies`
+- `threads_keyword_search`
+
+Complete Meta's authorization-code flow, exchange the resulting user token for a long-lived Threads user access token, and confirm the scopes and expiry in Meta's Access Token Debugger. Keep the app secret and authorization code out of this repository and out of Actions logs.
+
+Store only the resulting long-lived token in the GitHub Actions secret `THREADS_USER_ACCESS_TOKEN`. For example, from an authenticated shell, this prompts without printing the value:
+
+```sh
+gh secret set THREADS_USER_ACCESS_TOKEN --repo louisclarencepeter/destinationparadise
+```
+
+Meta's official references:
+
+- [Threads API getting started](https://developers.facebook.com/docs/threads/get-started/)
+- [Threads authorization](https://developers.facebook.com/docs/threads/get-started/get-access-tokens-and-permissions/)
+- [Threads keyword search](https://developers.facebook.com/docs/threads/keyword-search/)
+- [Meta's official Threads API workspace](https://www.postman.com/meta/threads/overview)
+
+## Safe activation order
+
+Scheduled workflows only run from this repository's default branch (`main`). Do not move this workflow to `main` until the OAuth grant has been completed and a manual dry-run has been reviewed.
+
+1. Add `THREADS_USER_ACCESS_TOKEN` as a GitHub Actions secret.
+2. After the workflow reaches `main`, manually run **Threads Auto Commenter** with `initialize_state=true` and `publish=false`.
+3. Review the dry-run summary. It intentionally logs no source usernames, post text, permalinks, categories, or generated reply text.
+4. Manually run once with `publish=true` and inspect the resulting public reply.
+5. Leave the schedule enabled only after that reply passes review.
+
+Local commands use the same secret from the environment:
+
+```sh
+npm run threads:comment:dry-run
+npm run threads:comment:publish
+```
+
+Never put the token in a tracked `.env` file. The local state file `.threads-auto-commenter-state.json` is ignored by Git.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "instagram:story:dry-run": "node scripts/instagram-story.mjs --dry-run",
-    "instagram:story:publish": "node scripts/instagram-story.mjs --publish"
+    "instagram:story:publish": "node scripts/instagram-story.mjs --publish",
+    "threads:comment:dry-run": "node scripts/threads-auto-commenter.mjs --dry-run",
+    "threads:comment:publish": "node scripts/threads-auto-commenter.mjs --publish"
   },
   "dependencies": {
     "@sentry/node": "^10.63.0",

--- a/scripts/threads-auto-commenter.mjs
+++ b/scripts/threads-auto-commenter.mjs
@@ -1,0 +1,421 @@
+import { createHash } from 'node:crypto';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const API_ORIGIN = 'https://graph.threads.net';
+const SITE_ORIGIN = 'https://yournexttriptoparadise.com';
+const TIME_ZONE = process.env.THREADS_TIME_ZONE || 'Africa/Dar_es_Salaam';
+const STATE_PATH = path.resolve(
+  ROOT,
+  process.env.THREADS_STATE_PATH || '.threads-auto-commenter-state.json',
+);
+const EXPECTED_USERNAME = process.env.THREADS_EXPECTED_USERNAME || 'yournexttriptoparadise';
+const DAILY_CAP = 5;
+const PER_RUN_CAP = Math.min(2, Math.max(1, Number(process.env.THREADS_PER_RUN_CAP) || 2));
+const SEARCH_LOOKBACK_HOURS = 36;
+const STATE_RETENTION_DAYS = 90;
+
+const SEARCH_QUERIES = [
+  'Zanzibar',
+  'Zanzibar hotel',
+  'Zanzibar safari',
+  'Tanzania travel',
+  'Tanzania safari',
+  'Tanzania itinerary',
+];
+
+const DESTINATION_PATTERN = /\b(zanzibar|tanzania|serengeti|kilimanjaro|nungwi|kendwa|paje|jambiani|stone town|safari)\b/i;
+const REQUEST_PATTERN = /\?|\b(any (?:advice|recommendations?|suggestions?|tips)|looking for (?:advice|recommendations?|suggestions?|tips)|need (?:advice|recommendations?|suggestions?|tips|help)|can anyone (?:recommend|suggest|help)|could anyone (?:recommend|suggest|help)|where should (?:i|we)|what should (?:i|we)|what is the best|what's the best|which (?:area|beach|place|route|safari)|would you recommend|how many days|how long should|best time to|tips for|help (?:me|us) (?:choose|plan)|planning .{0,80}(?:where|what|which|how|advice|recommend))\b/i;
+const EXCLUSION_PATTERNS = [
+  /\b(election|president|government|minister|parliament|politics|protest|war|breaking news|earthquake|flood|outbreak)\b/i,
+  /\b(scamm?ed|scammer|refund|cancelled|canceled|complaint|terrible|worst|awful|hate|overrated|disappointed|stolen|robbed|harass(?:ed|ment)?|rip.?off|avoid this|never again)\b/i,
+  /\b(book now|limited offer|discount code|promo code|special deal|dm me|contact us|whatsapp|our (?:tour|hotel|package|agency)|travel agent|tour operator|marketing|business inquiry)\b/i,
+  /\b(visa|passport|immigration|entry requirements?|yellow fever|vaccin(?:e|ation)|malaria|medical|hospital|insurance claim)\b/i,
+  /\b(buy followers?|crypto|forex|giveaway|betting|casino|onlyfans)\b/i,
+];
+
+const CATEGORY_PATTERNS = [
+  ['safari', /\b(safari|serengeti|ngorongoro|tarangire|nyerere|selous|mikumi|game drive)\b/i],
+  ['stay', /\b(where to stay|which area|which beach|hotel|resort|nungwi|kendwa|paje|jambiani|stone town|beach)\b/i],
+  ['transport', /\b(transfer|transport|taxi|airport|ferry|flight|getting around|drive|road)\b/i],
+  ['season', /\b(best time|weather|rain|rainy|season|month|january|february|march|april|may|june|july|august|september|october|november|december)\b/i],
+  ['itinerary', /\b(itinerary|how many days|how long|days? in|nights?|route|split (?:my|our|the) trip)\b/i],
+  ['excursions', /\b(excursion|things to do|activity|activities|snorkel|diving|dive|spice|jozani|stone town|mnemba|prison island|nakupenda)\b/i],
+  ['budget', /\b(budget|cost|price|expensive|cheap|afford)\b/i],
+];
+
+function modeFromArguments(argv) {
+  const publish = argv.includes('--publish');
+  const dryRun = argv.includes('--dry-run');
+  if (publish && dryRun) throw new Error('Choose either --publish or --dry-run, not both.');
+  return publish ? 'publish' : 'dry-run';
+}
+
+function choiceFor(postId, label, values) {
+  const digest = createHash('sha256').update(`${postId}:${label}`).digest();
+  return values[digest.readUInt32BE(0) % values.length];
+}
+
+export function zanzibarDateKey(value, timeZone = TIME_ZONE) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const parts = new Intl.DateTimeFormat('en', {
+    day: '2-digit',
+    month: '2-digit',
+    timeZone,
+    year: 'numeric',
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function classifyCandidate(post, now = new Date()) {
+  const text = String(post?.text || '').replace(/\s+/g, ' ').trim();
+  const timestamp = new Date(post?.timestamp || '');
+  const ageMs = now.getTime() - timestamp.getTime();
+
+  if (!post?.id || text.length < 18 || text.length > 500) return null;
+  if (Number.isNaN(timestamp.getTime()) || ageMs < 0 || ageMs > SEARCH_LOOKBACK_HOURS * 3_600_000) return null;
+  if (post.is_quote_post || post.is_reply || !DESTINATION_PATTERN.test(text)) return null;
+  if (!REQUEST_PATTERN.test(text) || EXCLUSION_PATTERNS.some((pattern) => pattern.test(text))) return null;
+
+  const category = CATEGORY_PATTERNS.find(([, pattern]) => pattern.test(text))?.[0] || 'general';
+  const daysMatch = text.match(/\b(\d{1,2})\s*(?:days?|nights?)\b/i);
+  const days = daysMatch ? Number(daysMatch[1]) : null;
+  const specificity = CATEGORY_PATTERNS.filter(([, pattern]) => pattern.test(text)).length;
+
+  return {
+    id: String(post.id),
+    permalink: post.permalink || null,
+    text,
+    timestamp: timestamp.toISOString(),
+    category,
+    days: days && days <= 30 ? days : null,
+    score: 10 + Math.min(specificity, 3) + (text.includes('?') ? 2 : 0),
+  };
+}
+
+const ADVICE = {
+  safari: [
+    'From Zanzibar, Nyerere is the easiest short safari add-on; for Serengeti and Ngorongoro, allow more time and plan the mainland routing rather than squeezing it into one rushed day.',
+    'If the safari is an add-on to Zanzibar, a fly-in option saves a lot of transfer time. Nyerere suits a short trip; the northern circuit is stronger when you can give it several days.',
+  ],
+  stay: [
+    'For sunsets and easier swimming through more of the day, look at Nungwi or Kendwa. Paje and Jambiani are better for kitesurfing, a quieter village feel, and travelers who enjoy the tidal landscape.',
+    'Choose the coast by experience: Nungwi or Kendwa for sunsets and more tide-independent swimming; Paje or Jambiani for kitesurfing, local atmosphere, and wide tidal beaches.',
+  ],
+  transport: [
+    'Pre-arrange the first airport or ferry transfer, confirm the total price and pickup point in writing, and leave a generous buffer around ferries or domestic flights.',
+    'For the smoothest arrival, book a named driver in advance and share the flight or ferry number. Build in buffer time because island transfers and port queues can vary.',
+  ],
+  season: [
+    'June to October is generally drier and comfortable; January and February are also popular. March to May is the wetter stretch, while short rains can appear around November, so exact dates matter.',
+    'For drier weather, June through October is the usual first choice, with January and February another good window. Shoulder months can be quieter but are less predictable.',
+  ],
+  itinerary: [
+    'A balanced first visit usually combines Stone Town with one coast rather than changing hotels repeatedly. Add a second coast only if the trip is long enough to enjoy the contrast without losing days to transfers.',
+    'Keep the route simple: one or two nights around Stone Town, then settle on the coast that fits your priorities. Too many hotel moves make a short Zanzibar trip feel rushed.',
+  ],
+  excursions: [
+    'A good mix is one culture day around Stone Town and a spice farm, one nature day such as Jozani, and one sea day chosen for the season and tides. Avoid packing a boat trip into every day.',
+    'Mix the trip rather than stacking similar tours: Stone Town for history, Jozani or a spice farm on land, then one well-chosen snorkeling or sandbank day with a licensed operator.',
+  ],
+  budget: [
+    'The biggest budget drivers are coast, hotel level, private transfers, and boat trips. Price the full stay with transfers and activities included; a cheap room can be a false saving if every outing starts far away.',
+    'Build the budget in four lines: accommodation, airport or ferry transfers, meals, and excursions. Location matters because repeated cross-island taxis can quickly outweigh a lower nightly rate.',
+  ],
+  general: [
+    'Start with the month, number of nights, and whether the priority is beach, culture, or safari. Those three choices determine the right coast and whether splitting the stay is worthwhile.',
+    'The best plan depends on three things: travel month, trip length, and whether you value swimming, local atmosphere, or safari most. Pick the coast after those are clear.',
+  ],
+};
+
+const FOLLOW_UPS = {
+  safari: 'How many mainland safari nights can you give it?',
+  stay: 'Are swimming, nightlife, or a quieter local atmosphere most important?',
+  transport: 'Which arrival point and hotel area are you using?',
+  season: 'Which exact month are you considering?',
+  itinerary: 'What month and how many nights do you have?',
+  excursions: 'Which coast will you stay on, and what month?',
+  budget: 'What nightly hotel range and trip length are you planning?',
+  general: 'What month and trip length are you considering?',
+};
+
+const LINKS = {
+  safari: `${SITE_ORIGIN}/safaris`,
+  transport: `${SITE_ORIGIN}/transfers`,
+  excursions: `${SITE_ORIGIN}/excursions`,
+};
+
+export function buildReply(candidate) {
+  const intro = choiceFor(candidate.id, 'intro', [
+    'Destination Paradise tip:',
+    'A practical Zanzibar planning tip:',
+    'From our Zanzibar team:',
+  ]);
+  let advice = choiceFor(candidate.id, `advice:${candidate.category}`, ADVICE[candidate.category]);
+
+  if (candidate.category === 'itinerary' && candidate.days) {
+    if (candidate.days <= 4) {
+      advice = `With ${candidate.days} days, use one coast as your base and add Stone Town as a focused day or overnight; changing hotels more than once will eat into the trip.`;
+    } else if (candidate.days <= 8) {
+      advice = `With ${candidate.days} days, one or two nights around Stone Town plus the rest on one coast is a comfortable split. Add a second coast only if the contrast matters more than slow beach time.`;
+    } else {
+      advice = `With ${candidate.days} days, you have room for Stone Town, two contrasting coasts, or a short mainland safari without rushing every stop.`;
+    }
+  }
+
+  const followUp = FOLLOW_UPS[candidate.category];
+  const link = LINKS[candidate.category];
+  const parts = [`${intro} ${advice}`, followUp];
+  if (link) parts.push(`Relevant details: ${link}`);
+  const reply = parts.join(' ');
+  if (reply.length > 500) throw new Error(`Generated reply exceeds the Threads limit (${reply.length}).`);
+  return reply;
+}
+
+function normalizeState(value) {
+  const records = Array.isArray(value?.records) ? value.records : [];
+  return {
+    version: 1,
+    records: records
+      .filter((record) => record?.postId && record?.attemptedAt)
+      .map((record) => ({
+        postId: String(record.postId),
+        attemptedAt: String(record.attemptedAt),
+        ...(record.status ? { status: String(record.status) } : {}),
+        ...(record.replyId ? { replyId: String(record.replyId) } : {}),
+        ...(record.publishedAt ? { publishedAt: String(record.publishedAt) } : {}),
+      })),
+  };
+}
+
+async function readState() {
+  try {
+    return normalizeState(JSON.parse(await readFile(STATE_PATH, 'utf8')));
+  } catch (error) {
+    if (error.code === 'ENOENT') return normalizeState({});
+    throw error;
+  }
+}
+
+function pruneState(state, now = new Date()) {
+  const cutoff = now.getTime() - STATE_RETENTION_DAYS * 86_400_000;
+  return {
+    version: 1,
+    records: state.records.filter((record) => new Date(record.attemptedAt).getTime() >= cutoff),
+  };
+}
+
+async function writeState(state) {
+  const temporaryPath = `${STATE_PATH}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(normalizeState(state), null, 2)}\n`, 'utf8');
+  await rename(temporaryPath, STATE_PATH);
+}
+
+function attemptsToday(state, now = new Date()) {
+  const today = zanzibarDateKey(now);
+  return state.records.filter((record) => zanzibarDateKey(record.attemptedAt) === today).length;
+}
+
+function createApiError(message, response, json, method) {
+  const error = new Error(json?.error?.message || message);
+  error.httpStatus = response.status;
+  error.code = json?.error?.code;
+  error.subcode = json?.error?.error_subcode;
+  error.uncertain = method === 'POST' && (response.status === 408 || response.status === 429 || response.status >= 500);
+  return error;
+}
+
+async function apiRequest(token, endpoint, { body, method = 'GET', params } = {}) {
+  const url = new URL(`${API_ORIGIN}/${endpoint.replace(/^\/+/, '')}`);
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value !== null && value !== undefined && value !== '') url.searchParams.set(key, String(value));
+  }
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
+      },
+      body: body ? new URLSearchParams(body) : undefined,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (cause) {
+    const error = new Error(`Threads API ${method} request did not return a response.`);
+    error.cause = cause;
+    error.uncertain = method === 'POST';
+    throw error;
+  }
+
+  const text = await response.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw createApiError(`Threads API returned an invalid response (${response.status}).`, response, null, method);
+  }
+  if (!response.ok || json.error) {
+    throw createApiError(`Threads API request failed (${response.status}).`, response, json, method);
+  }
+  return json;
+}
+
+async function searchCandidates(token, now) {
+  const since = Math.floor((now.getTime() - SEARCH_LOOKBACK_HOURS * 3_600_000) / 1_000);
+  const results = await Promise.all(
+    SEARCH_QUERIES.map((query) => apiRequest(token, 'keyword_search', {
+      params: {
+        q: query,
+        search_type: 'RECENT',
+        search_mode: 'KEYWORD',
+        fields: 'id,username,text,timestamp,permalink,is_quote_post',
+        limit: 50,
+        since,
+      },
+    })),
+  );
+  const unique = new Map();
+  for (const result of results) {
+    for (const post of result.data || []) unique.set(String(post.id), post);
+  }
+  return [...unique.values()].map((post) => classifyCandidate(post, now)).filter(Boolean);
+}
+
+async function ownReplyTargets(token, now) {
+  const since = Math.floor((now.getTime() - 7 * 86_400_000) / 1_000);
+  const result = await apiRequest(token, 'me/replies', {
+    params: {
+      fields: 'id,timestamp,replied_to,root_post',
+      limit: 100,
+      since,
+    },
+  });
+  const targets = new Set();
+  for (const reply of result.data || []) {
+    if (reply.replied_to?.id) targets.add(String(reply.replied_to.id));
+  }
+  return targets;
+}
+
+function safeError(error) {
+  return {
+    message: error.message,
+    ...(error.httpStatus ? { httpStatus: error.httpStatus } : {}),
+    ...(error.code ? { code: error.code } : {}),
+    ...(error.subcode ? { subcode: error.subcode } : {}),
+    ...(error.uncertain ? { uncertain: true } : {}),
+  };
+}
+
+async function main() {
+  const mode = modeFromArguments(process.argv.slice(2));
+  const token = process.env.THREADS_USER_ACCESS_TOKEN;
+  if (!token) throw new Error('Missing Threads authorization: THREADS_USER_ACCESS_TOKEN.');
+
+  const now = new Date();
+  let state = pruneState(await readState(), now);
+  const usedPostIds = new Set(state.records.map((record) => record.postId));
+  const remainingToday = Math.max(0, DAILY_CAP - attemptsToday(state, now));
+
+  const profile = await apiRequest(token, 'me', { params: { fields: 'id,username' } });
+  if (!profile.id || profile.username !== EXPECTED_USERNAME) {
+    throw new Error(`Safety check failed: expected @${EXPECTED_USERNAME}, received @${profile.username || 'unknown'}.`);
+  }
+
+  const [candidates, repliedTargets] = await Promise.all([
+    searchCandidates(token, now),
+    ownReplyTargets(token, now),
+  ]);
+  const eligible = candidates
+    .filter((candidate) => !usedPostIds.has(candidate.id) && !repliedTargets.has(candidate.id))
+    .sort((left, right) => right.score - left.score || right.timestamp.localeCompare(left.timestamp));
+  const selected = eligible.slice(0, Math.min(PER_RUN_CAP, remainingToday));
+
+  if (mode === 'dry-run') {
+    console.log(JSON.stringify({
+      ok: true,
+      mode,
+      account: `@${profile.username}`,
+      discoveredCount: candidates.length,
+      eligibleCount: eligible.length,
+      remainingToday,
+      selections: selected.map((candidate) => ({
+        postId: candidate.id,
+        sourceTimestamp: candidate.timestamp,
+      })),
+    }));
+    return;
+  }
+
+  const published = [];
+  for (const candidate of selected) {
+    const record = {
+      postId: candidate.id,
+      attemptedAt: new Date().toISOString(),
+      status: 'selected',
+    };
+    state.records.push(record);
+    await writeState(state);
+
+    let container;
+    try {
+      container = await apiRequest(token, 'me/threads', {
+        method: 'POST',
+        body: {
+          media_type: 'TEXT',
+          text: buildReply(candidate),
+          reply_to_id: candidate.id,
+        },
+      });
+    } catch (error) {
+      record.status = error.uncertain ? 'create-uncertain' : 'create-failed';
+      await writeState(state);
+      throw error;
+    }
+    if (!container.id) {
+      record.status = 'create-uncertain';
+      await writeState(state);
+      throw new Error('Threads created no identifiable reply container; the post will not be retried.');
+    }
+
+    record.status = 'publish-pending';
+    await writeState(state);
+    try {
+      const result = await apiRequest(token, 'me/threads_publish', {
+        method: 'POST',
+        body: { creation_id: container.id },
+      });
+      record.status = 'published';
+      record.replyId = String(result.id);
+      record.publishedAt = new Date().toISOString();
+      await writeState(state);
+      published.push({ postId: candidate.id, replyId: record.replyId, publishedAt: record.publishedAt });
+    } catch (error) {
+      record.status = error.uncertain ? 'publish-uncertain' : 'publish-failed';
+      await writeState(state);
+      throw error;
+    }
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    mode,
+    account: `@${profile.username}`,
+    published,
+    skipped: selected.length === 0,
+    reason: selected.length === 0 ? (remainingToday === 0 ? 'daily-cap-reached' : 'no-eligible-posts') : undefined,
+  }));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === import.meta.filename) {
+  main().catch((error) => {
+    console.error(JSON.stringify({ ok: false, ...safeError(error) }));
+    process.exitCode = 1;
+  });
+}

--- a/test/scripts/threads-auto-commenter.test.mjs
+++ b/test/scripts/threads-auto-commenter.test.mjs
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildReply,
+  classifyCandidate,
+  zanzibarDateKey,
+} from '../../scripts/threads-auto-commenter.mjs';
+
+const NOW = new Date('2026-07-13T10:00:00.000Z');
+
+function post(text, overrides = {}) {
+  return {
+    id: 'post-123',
+    text,
+    timestamp: '2026-07-13T09:00:00.000Z',
+    permalink: 'https://www.threads.net/@traveler/post/example',
+    ...overrides,
+  };
+}
+
+describe('Threads candidate safety filter', () => {
+  it('accepts a fresh, specific Zanzibar travel question', () => {
+    const candidate = classifyCandidate(
+      post('Where should we stay in Zanzibar: Nungwi or Paje? We care most about swimming.'),
+      NOW,
+    );
+    expect(candidate).toMatchObject({ category: 'stay', id: 'post-123' });
+  });
+
+  it.each([
+    'Our Zanzibar tour package is 20% off. Book now and DM me!',
+    'Terrible Zanzibar hotel, how can I get a refund?',
+    'What are the Tanzania visa and yellow fever vaccine requirements?',
+    'Breaking news: Tanzania election results and government reaction',
+    'Zanzibar is beautiful today',
+  ])('rejects unsafe or ambiguous content: %s', (text) => {
+    expect(classifyCandidate(post(text), NOW)).toBeNull();
+  });
+
+  it('rejects quotes, replies, stale posts, and missing destinations', () => {
+    expect(classifyCandidate(post('Any advice for Zanzibar?', { is_quote_post: true }), NOW)).toBeNull();
+    expect(classifyCandidate(post('Any advice for Zanzibar?', { is_reply: true }), NOW)).toBeNull();
+    expect(classifyCandidate(post('Any advice for Zanzibar?', { timestamp: '2026-07-10T09:00:00Z' }), NOW)).toBeNull();
+    expect(classifyCandidate(post('Any advice for our beach holiday?'), NOW)).toBeNull();
+  });
+});
+
+describe('Threads contextual reply builder', () => {
+  it('gives specific coast advice without a promotional link', () => {
+    const candidate = classifyCandidate(
+      post('Where should we stay in Zanzibar: Nungwi or Paje? We care most about swimming.'),
+      NOW,
+    );
+    const reply = buildReply(candidate);
+    expect(reply).toMatch(/Nungwi|Kendwa/);
+    expect(reply).toMatch(/Paje|Jambiani/);
+    expect(reply).not.toContain('https://');
+    expect(reply.length).toBeLessThanOrEqual(500);
+  });
+
+  it('uses the stated trip length and a useful deep link', () => {
+    const itinerary = classifyCandidate(post('How should we plan a 7 day Zanzibar itinerary?'), NOW);
+    const safari = classifyCandidate(post('Can anyone recommend a short Tanzania safari from Zanzibar?'), NOW);
+    expect(buildReply(itinerary)).toContain('With 7 days');
+    expect(buildReply(safari)).toContain('https://yournexttriptoparadise.com/safaris');
+  });
+
+  it('varies replies deterministically across post IDs', () => {
+    const first = classifyCandidate(post('Where should we stay in Zanzibar, Nungwi or Paje?'), NOW);
+    const second = classifyCandidate(post('Where should we stay in Zanzibar, Nungwi or Paje?', { id: 'post-456' }), NOW);
+    expect(buildReply(first)).not.toBe(buildReply(second));
+    expect(buildReply(first)).toBe(buildReply(first));
+  });
+});
+
+describe('Threads daily cap date', () => {
+  it('uses the Zanzibar calendar day', () => {
+    expect(zanzibarDateKey('2026-07-12T21:30:00.000Z')).toBe('2026-07-13');
+  });
+});


### PR DESCRIPTION
## Summary
- add a separate official Threads API keyword-search and reply publisher
- enforce strict intent filtering, Zanzibar-day caps, duplicate prevention, and no automatic publish retries
- add a dry-run-first GitHub Actions workflow with minimal retained state
- document the separate Threads OAuth grant required before activation

## Validation
- npm test (63 passed)
- npm run lint
- npm run typecheck
- npm run build
- development CI passed

## Activation note
`THREADS_USER_ACCESS_TOKEN` and initial remote state are intentionally absent, so promotion cannot publish until the separate Threads OAuth setup and manual dry run are completed.