### PR TITLE
Add "Our Zanzibar Guide" food & events section to the Explore page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ docs/
 
 # Local editor workspace settings
 .vscode/
+
+# Local scratch output (browser session logs, generated assets, temp files)
+.playwright-cli/
+output/
+tmp/

--- a/data/instagramStoryCards.mjs
+++ b/data/instagramStoryCards.mjs
@@ -1,0 +1,17 @@
+// Editorially approved Story queue. Keep each image, title, and caption together.
+export const INSTAGRAM_STORY_CARDS = [
+  { id: 'safari-blue-dhow', source: '/assets/images/excursions/trips/safari-blue-dhow.webp', title: 'Safari Blue', caption: 'A day on clear water, a traditional boat, and time to slow down.' },
+  { id: 'stone-town-old-fort', source: '/assets/images/excursions/stone-town-old-fort.webp', title: 'Stone Town Stories', caption: 'Walk the old streets with a local guide and discover the island beyond the beach.' },
+  { id: 'jozani-red-colobus', source: '/assets/images/excursions/jozani-red-colobus.webp', title: 'Jozani Forest', caption: 'Meet Zanzibar’s rare red colobus monkeys in the island’s last indigenous forest.' },
+  { id: 'prison-island-tortoise', source: '/assets/images/excursions/prison-island-tortoise.webp', title: 'Prison Island', caption: 'Giant Aldabra tortoises, a short boat ride, and time for a swim in clear water.' },
+  { id: 'dream-dhow-sunset', source: '/assets/images/excursions/dream-dhow-sunset.webp', title: 'Sunset by Dhow', caption: 'End the day on the Indian Ocean as Zanzibar’s sky turns gold.' },
+  { id: 'dolphin-snorkeling', source: '/assets/images/excursions/dolphin-snorkeling.webp', title: 'Ocean Morning', caption: 'Set out early for the south coast, then snorkel in Zanzibar’s warm blue water.' },
+  { id: 'spice-tour', source: '/assets/images/excursions/trips/spice-tour.webp', title: 'The Spice Island', caption: 'Cloves, cinnamon, nutmeg, and a Swahili lunch straight from the plantation.' },
+  { id: 'mnemba-snorkeling', source: '/assets/images/excursions/trips/mnemba-snorkeling.webp', title: 'Mnemba Day Out', caption: 'Good company, a day on the boat, and Zanzibar’s bright blue water all around.' },
+  { id: 'private-sunset-dhow', source: '/assets/images/excursions/trips/private-sunset-dhow.webp', title: 'Sunset on the Sand', caption: 'Take the evening slowly and watch the Indian Ocean turn gold.' },
+  { id: 'organic-spice-farm', source: '/assets/images/excursions/trips/organic-spice-farm.webp', title: 'A Spice Farm Welcome', caption: 'Fresh coconut, generous local hospitality, and a taste of Zanzibar’s spice country.' },
+  { id: 'nakupenda-sandbank', source: '/assets/images/excursions/trips/nakupenda-sandbank.webp', title: 'Sandbank Escape', caption: 'White sand, an open horizon, and nowhere else you need to be.' },
+  { id: 'wellness-yoga-beach', source: '/assets/images/excursions/trips/wellness-yoga-beach.webp', title: 'Golden Hour', caption: 'A simple evening by the sea, shared with the people you came to Zanzibar with.' },
+];
+
+export const INSTAGRAM_STORY_CARD_BY_ID = new Map(INSTAGRAM_STORY_CARDS.map((card) => [card.id, card]));

--- a/netlify/functions/instagram-story-image.mjs
+++ b/netlify/functions/instagram-story-image.mjs
@@ -3,6 +3,8 @@ import { readFile } from 'node:fs/promises';
 import opentype from 'opentype.js';
 import sharp from 'sharp';
 
+import { INSTAGRAM_STORY_CARD_BY_ID } from '../../data/instagramStoryCards.mjs';
+
 const SITE_ORIGIN = 'https://yournexttriptoparadise.com';
 const ALLOWED_SOURCE = /^\/assets\/images\/(home|excursions|safaris)\/[a-z0-9/-]+\.webp$/;
 const WIDTH = 1080;
@@ -49,54 +51,6 @@ function titleFromSource(source) {
 
 function sourceNumber(source) {
   return [...source].reduce((total, character) => (total * 31 + character.charCodeAt(0)) >>> 0, 7);
-}
-
-function copyForSource(source, variation) {
-  let options;
-  if (/sunset|dhow|harbor|waterfront/.test(source)) {
-    options = [
-      'Golden light, warm ocean air, and Zanzibar moving at its own rhythm.',
-      'Chase the last light across the Indian Ocean, one unforgettable sail at a time.',
-      'When the sky turns gold, Zanzibar saves its most beautiful moment for you.',
-    ];
-  } else if (/snorkel|reef|lagoon|sandbank|dolphin|diving|mnemba|kayak|marine|ocean/.test(source)) {
-    options = [
-      'Clear water, coral worlds, and another unforgettable day in paradise.',
-      'Trade the shoreline for turquoise water and a little island magic.',
-      'Above the water is paradise. Below it is an entirely new world.',
-    ];
-  } else if (/spice|cooking|coffee|herbal|forodhani/.test(source)) {
-    options = [
-      'Taste the stories, traditions, and unmistakable spirit of Zanzibar.',
-      'Fragrant spices, local recipes, and the flavors that make this island home.',
-      'The soul of Zanzibar is best discovered one flavor at a time.',
-    ];
-  } else if (/stone-town|hidden-alleys|ruins|baths|dhow-heritage|village/.test(source)) {
-    options = [
-      'Go beyond the postcard and discover the stories that shaped the island.',
-      'Follow the winding streets into centuries of culture, craft, and character.',
-      'Every doorway, alley, and ocean breeze carries another Zanzibar story.',
-    ];
-  } else if (/safaris\//.test(source)) {
-    options = [
-      'Wild landscapes, unforgettable encounters, and Tanzania at its most extraordinary.',
-      'The kind of wild beauty that stays with you long after the journey ends.',
-      'Open skies, untamed horizons, and a front-row seat to the wild.',
-    ];
-  } else if (/home\//.test(source)) {
-    options = [
-      'Your next journey to Zanzibar and Tanzania starts right here.',
-      'Come for the beauty. Stay for the feeling you will never quite forget.',
-      'A thoughtfully planned escape, made personal from the very first hello.',
-    ];
-  } else {
-    options = [
-      'Experience Zanzibar beyond the postcard, thoughtfully planned from start to finish.',
-      'Find the places, people, and moments that make paradise feel personal.',
-      'More than a destination: a journey designed around the way you love to travel.',
-    ];
-  }
-  return options[variation % options.length];
 }
 
 function wrapText(text, maxCharacters) {
@@ -165,8 +119,8 @@ function svgTextLines(lines, { x, startY, lineHeight, fontSize, fontWeight = 400
     .join('');
 }
 
-function createOverlay(source) {
-  const sourceSeed = sourceNumber(source);
+function createOverlay(card) {
+  const sourceSeed = sourceNumber(card.id);
   const style = [
     {
       accent: '#f1c56d',
@@ -205,9 +159,9 @@ function createOverlay(source) {
       decoration: '<rect x="64" y="1260" width="952" height="590" rx="28" fill="#07111b" fill-opacity="0.18" stroke="#f4d678" stroke-opacity="0.75" stroke-width="3" />',
     },
   ][sourceSeed % 4];
-  const title = titleFromSource(source);
+  const title = card.title || titleFromSource(card.source);
   const titleLines = wrapText(title, style.anchor === 'middle' ? 25 : 23).slice(0, 2);
-  const copyLines = wrapText(copyForSource(source, sourceSeed), style.anchor === 'middle' ? 46 : 42).slice(0, 3);
+  const copyLines = wrapText(card.caption, style.anchor === 'middle' ? 46 : 42).slice(0, 3);
   const titleStart = style.titleY - (titleLines.length - 1) * 34;
   const copyStart = titleStart + titleLines.length * 78 + 34;
   const headerX = style.anchor === 'end' ? 992 : style.anchor === 'middle' ? 540 : 88;
@@ -241,8 +195,10 @@ export default async (request) => {
     return new Response('Method not allowed', { status: 405, headers: { Allow: 'GET, HEAD' } });
   }
 
-  const source = new URL(request.url).searchParams.get('src') || '';
-  if (!ALLOWED_SOURCE.test(source)) {
+  const url = new URL(request.url);
+  const source = url.searchParams.get('src') || '';
+  const card = INSTAGRAM_STORY_CARD_BY_ID.get(url.searchParams.get('card'));
+  if (!ALLOWED_SOURCE.test(source) || !card || card.source !== source) {
     return new Response('Invalid image source', { status: 400 });
   }
 
@@ -254,7 +210,7 @@ export default async (request) => {
   const sourceImage = Buffer.from(await sourceResponse.arrayBuffer());
   const storyImage = await sharp(sourceImage)
     .resize(WIDTH, HEIGHT, { fit: 'cover', position: 'centre' })
-    .composite([{ input: createOverlay(source), top: 0, left: 0 }])
+    .composite([{ input: createOverlay(card), top: 0, left: 0 }])
     .jpeg({ quality: 86, chromaSubsampling: '4:4:4' })
     .toBuffer();
 

--- a/scripts/instagram-story.mjs
+++ b/scripts/instagram-story.mjs
@@ -1,7 +1,9 @@
-import { createHash, randomInt } from 'node:crypto';
-import { appendFile, readFile, readdir, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { access, appendFile, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+
+import { INSTAGRAM_STORY_CARDS } from '../data/instagramStoryCards.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
 const ENV_PATH = path.resolve(ROOT, process.env.INSTAGRAM_STORY_ENV_PATH || '.env.instagram-story');
@@ -9,7 +11,6 @@ const STATE_PATH = path.resolve(ROOT, process.env.INSTAGRAM_STORY_STATE_PATH || 
 const LOG_PATH = path.resolve(ROOT, process.env.INSTAGRAM_STORY_LOG_PATH || '.instagram-story-log.jsonl');
 const SITE_ORIGIN = 'https://yournexttriptoparadise.com';
 const EXPECTED_USERNAME = 'yournexttriptoparadise';
-const ALLOWED_IMAGE_ROOTS = ['home', 'excursions', 'safaris'];
 const STORY_TIME_ZONE = process.env.INSTAGRAM_STORY_TIME_ZONE || 'Africa/Dar_es_Salaam';
 const mode = process.argv.includes('--publish') ? 'publish' : 'dry-run';
 
@@ -51,28 +52,11 @@ async function loadConfig() {
   return values;
 }
 
-async function listFiles(directory) {
-  const entries = await readdir(directory, { withFileTypes: true });
-  const files = await Promise.all(
-    entries.map((entry) => {
-      const fullPath = path.join(directory, entry.name);
-      return entry.isDirectory() ? listFiles(fullPath) : [fullPath];
-    }),
+async function listApprovedCards() {
+  await Promise.all(
+    INSTAGRAM_STORY_CARDS.map((card) => access(path.join(ROOT, 'public', card.source))),
   );
-  return files.flat();
-}
-
-async function listCandidates() {
-  const root = path.join(ROOT, 'public', 'assets', 'images');
-  const files = (
-    await Promise.all(ALLOWED_IMAGE_ROOTS.map((folder) => listFiles(path.join(root, folder))))
-  ).flat();
-
-  return files
-    .filter((file) => file.endsWith('.webp'))
-    .filter((file) => !file.endsWith('-600w.webp'))
-    .map((file) => `/${path.relative(path.join(ROOT, 'public'), file).split(path.sep).join('/')}`)
-    .sort();
+  return INSTAGRAM_STORY_CARDS;
 }
 
 async function readState() {
@@ -103,25 +87,28 @@ export function alreadyPublishedToday(state, now = new Date(), timeZone = STORY_
   return publishedDate !== null && publishedDate === storyDateKey(now, timeZone);
 }
 
-function chooseCandidate(candidates, state) {
-  const existing = new Set(candidates);
-  const used = (state.used || []).filter((candidate) => existing.has(candidate));
-  let remaining = candidates.filter((candidate) => !used.includes(candidate));
+export function chooseStoryCard(cards, state) {
+  const existing = new Set(cards.map((card) => card.id));
+  const usedCards = (state.usedCards || []).filter((id) => existing.has(id));
+  const legacyUsedSources = new Set(state.used || []);
+  let remaining = cards.filter(
+    (card) => !usedCards.includes(card.id) && !legacyUsedSources.has(card.source),
+  );
   let cycle = Number(state.cycle) || 1;
 
   if (!remaining.length) {
-    remaining = candidates;
-    used.length = 0;
+    remaining = cards;
+    usedCards.length = 0;
     cycle += 1;
   }
 
-  if (!remaining.length) throw new Error('No eligible Destination Paradise images found.');
-  const selected = remaining[randomInt(remaining.length)];
-  return { selected, nextState: { cycle, used: [...used, selected] } };
+  if (!remaining.length) throw new Error('No approved Destination Paradise Story cards found.');
+  const selected = remaining[0];
+  return { selected, nextState: { cycle, usedCards: [...usedCards, selected.id] } };
 }
 
-function createImageUrl(sourcePath) {
-  const params = new URLSearchParams({ src: sourcePath, v: '2' });
+function createImageUrl(card) {
+  const params = new URLSearchParams({ src: card.source, card: card.id, v: '3' });
   return `${SITE_ORIGIN}/api/instagram-story-image?${params}`;
 }
 
@@ -208,11 +195,11 @@ async function main() {
     );
   }
 
-  const candidates = await listCandidates();
-  const { selected, nextState } = chooseCandidate(candidates, state);
+  const cards = await listApprovedCards();
+  const { selected, nextState } = chooseStoryCard(cards, state);
   const imageUrl = createImageUrl(selected);
   const image = await verifyImage(imageUrl);
-  const selectionHash = createHash('sha256').update(selected).digest('hex').slice(0, 12);
+  const selectionHash = createHash('sha256').update(selected.id).digest('hex').slice(0, 12);
 
   if (mode === 'dry-run') {
     console.log(
@@ -220,8 +207,10 @@ async function main() {
         {
           mode,
           account: `@${profile.username}`,
-          candidateCount: candidates.length,
-          selected,
+          cardCount: cards.length,
+          selected: selected.source,
+          title: selected.title,
+          caption: selected.caption,
           selectionHash,
           imageUrl,
           image,
@@ -260,7 +249,10 @@ async function main() {
   await recordLog({
     publishedAt,
     mediaId: published.id,
-    selected,
+    selected: selected.source,
+    cardId: selected.id,
+    title: selected.title,
+    caption: selected.caption,
     selectionHash,
     account: `@${profile.username}`,
   });
@@ -269,7 +261,10 @@ async function main() {
       ok: true,
       publishedAt,
       mediaId: published.id,
-      selected,
+      selected: selected.source,
+      cardId: selected.id,
+      title: selected.title,
+      caption: selected.caption,
       account: `@${profile.username}`,
     }),
   );

--- a/scripts/instagram-story.mjs
+++ b/scripts/instagram-story.mjs
@@ -13,6 +13,7 @@ const SITE_ORIGIN = 'https://yournexttriptoparadise.com';
 const EXPECTED_USERNAME = 'yournexttriptoparadise';
 const STORY_TIME_ZONE = process.env.INSTAGRAM_STORY_TIME_ZONE || 'Africa/Dar_es_Salaam';
 const mode = process.argv.includes('--publish') ? 'publish' : 'dry-run';
+const SAFE_REQUEST_RETRIES = 2;
 
 function parseEnv(source) {
   return Object.fromEntries(
@@ -112,8 +113,34 @@ function createImageUrl(card) {
   return `${SITE_ORIGIN}/api/instagram-story-image?${params}`;
 }
 
+const TRANSIENT_HTTP_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+async function fetchWithSafeRetries(url, options = {}) {
+  const method = (options.method || 'GET').toUpperCase();
+  if (!['GET', 'HEAD'].includes(method)) return fetch(url, options);
+
+  let lastError;
+  for (let attempt = 0; attempt <= SAFE_REQUEST_RETRIES; attempt += 1) {
+    if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+    try {
+      const response = await fetch(url, options);
+      // Return the final transient response so callers can surface the API's
+      // own error payload instead of a generic retry message.
+      if (!TRANSIENT_HTTP_STATUSES.has(response.status) || attempt === SAFE_REQUEST_RETRIES) {
+        return response;
+      }
+      lastError = new Error(`received transient HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `${method} request failed after ${SAFE_REQUEST_RETRIES + 1} attempts: ${lastError?.message || 'unknown network error'}.`,
+  );
+}
+
 async function graphRequest(config, endpoint, options = {}) {
-  const response = await fetch(
+  const response = await fetchWithSafeRetries(
     `https://graph.facebook.com/${config.META_GRAPH_VERSION}/${endpoint}`,
     {
       ...options,
@@ -135,7 +162,7 @@ async function graphRequest(config, endpoint, options = {}) {
 }
 
 async function verifyImage(imageUrl) {
-  const response = await fetch(imageUrl, { method: 'HEAD' });
+  const response = await fetchWithSafeRetries(imageUrl, { method: 'HEAD' });
   if (!response.ok) throw new Error(`Story image is not publicly available (${response.status}).`);
   const contentType = response.headers.get('content-type') || '';
   const contentLength = Number(response.headers.get('content-length') || 0);

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -21,6 +21,7 @@ const FOOTER_ICONS = {
   route: ['M5 18a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z', 'M19 10a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z', 'M7 16h4a4 4 0 0 0 0-8h6'],
   map: ['M9 18 3 21V6l6-3 6 3 6-3v15l-6 3-6-3Z', 'M9 3v15', 'M15 6v15'],
   book: ['M4 5a3 3 0 0 1 3-3h13v17H7a3 3 0 0 0-3 3V5Z', 'M4 5v17'],
+  utensils: ['M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2', 'M7 2v20', 'M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7'],
   users: ['M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2', 'M9.5 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z', 'M22 21v-2a4 4 0 0 0-3-3.87', 'M16 3.13a4 4 0 0 1 0 7.75'],
   leaf: ['M20 4c-7.5.5-12.5 4.5-13 11 4.5.5 9.5-1.5 13-11Z', 'M5 19c3-5 7-8 12-10'],
   newspaper: ['M4 5h13a3 3 0 0 1 3 3v11H7a3 3 0 0 1-3-3V5Z', 'M8 9h5', 'M8 13h8', 'M8 17h6'],
@@ -237,6 +238,7 @@ export default function SiteFooter() {
             <li><Link to="/packages"><FooterIcon name="suitcase" />{t('columns.pages.packages')}</Link></li>
             <li><Link to="/trip-planner"><FooterIcon name="route" />{t('columns.pages.trip_planner')}</Link></li>
             <li><Link to="/explore"><FooterIcon name="map" />{t('columns.pages.explore')}</Link></li>
+            <li><Link to="/explore#our-zanzibar-guide"><FooterIcon name="utensils" />{t('columns.pages.local_guide')}</Link></li>
             <li><Link to="/aboutus"><FooterIcon name="book" />{t('columns.pages.about')}</Link></li>
           </ul>
         </div>

--- a/src/components/explore/ExploreLocalGuide.jsx
+++ b/src/components/explore/ExploreLocalGuide.jsx
@@ -38,7 +38,7 @@ export default function ExploreLocalGuide() {
   const location = useLocation();
   const tabsRef = useRef(/** @type {(HTMLButtonElement | null)[]} */ ([]));
   const [activeArea, setActiveArea] = useState(() => {
-    const requested = new URLSearchParams(location.search).get(GUIDE_PARAM);
+    const requested = new URLSearchParams(location.search).get(GUIDE_PARAM) || '';
     return AREA_KEYS.includes(requested) ? requested : DEFAULT_AREA;
   });
 

--- a/src/components/explore/ExploreLocalGuide.jsx
+++ b/src/components/explore/ExploreLocalGuide.jsx
@@ -1,0 +1,225 @@
+import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
+import { CONTACT_INFO } from '../../constants/contactInfo.js';
+import { arrayFromTranslation } from '../../utils/translationValues.js';
+
+const AREA_KEYS = ['stone_town', 'north', 'north_east', 'pongwe', 'michamvi', 'jambiani', 'paje', 'south'];
+const DEFAULT_AREA = 'stone_town';
+const GUIDE_PARAM = 'guide';
+
+const TRIP_IMAGES = '/assets/images/excursions/trips';
+const EVENT_LINKS = {
+  'sauti-busara': '/excursions/sauti-busara',
+  ziff: '/excursions/ziff',
+  'water-sports': '/excursions/water-sports-festival',
+};
+const AREA_IMAGES = {
+  stone_town: 'forodhani-street-food',
+  north: 'nungwi-coast',
+  north_east: 'mnemba-snorkeling',
+  pongwe: 'blue-lagoon-snorkeling',
+  michamvi: 'the-rock-restaurant',
+  jambiani: 'seaweed-cooperative',
+  paje: 'kitesurfing-beach',
+  south: 'kizimkazi-fishing-boat',
+};
+
+const MapArrow = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M5 12h14" />
+    <path d="m13 6 6 6-6 6" />
+  </svg>
+);
+
+export default function ExploreLocalGuide() {
+  const { t } = useTranslation('explore');
+  const { t: tBrand } = useTranslation('footer');
+  const location = useLocation();
+  const tabsRef = useRef(/** @type {(HTMLButtonElement | null)[]} */ ([]));
+  const [activeArea, setActiveArea] = useState(() => {
+    const requested = new URLSearchParams(location.search).get(GUIDE_PARAM);
+    return AREA_KEYS.includes(requested) ? requested : DEFAULT_AREA;
+  });
+
+  const places = arrayFromTranslation(t(`local_guide.areas.${activeArea}.places`, { returnObjects: true }));
+  const events = arrayFromTranslation(t('local_guide.events.items', { returnObjects: true }));
+  const mapArea = t(`local_guide.areas.${activeArea}.map_label`);
+  const areaImage = AREA_IMAGES[activeArea];
+  const totalPlaces = useMemo(
+    () => AREA_KEYS.reduce(
+      (sum, area) => sum + arrayFromTranslation(t(`local_guide.areas.${area}.places`, { returnObjects: true })).length,
+      0,
+    ),
+    [t],
+  );
+
+  const selectArea = (area) => {
+    setActiveArea(area);
+    // Mirror the selection into the URL without a router navigation: navigating
+    // would re-run the layout's hash-scroll effect and jump the viewport.
+    const params = new URLSearchParams(window.location.search);
+    params.set(GUIDE_PARAM, area);
+    window.history.replaceState(window.history.state, '', `${window.location.pathname}?${params}${window.location.hash}`);
+  };
+
+  const handleTabKeyDown = (event, index) => {
+    let nextIndex;
+
+    if (event.key === 'ArrowRight') nextIndex = (index + 1) % AREA_KEYS.length;
+    if (event.key === 'ArrowLeft') nextIndex = (index - 1 + AREA_KEYS.length) % AREA_KEYS.length;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = AREA_KEYS.length - 1;
+    if (nextIndex === undefined) return;
+
+    event.preventDefault();
+    selectArea(AREA_KEYS[nextIndex]);
+    tabsRef.current[nextIndex]?.focus();
+  };
+
+  return (
+    <section className="local-guide" id="our-zanzibar-guide" aria-labelledby="local-guide-title">
+      <div className="local-guide__inner">
+        <header className="local-guide__head">
+          <div className="local-guide__heading">
+            <span className="section-eyebrow reveal" style={{ '--reveal-index': 0 }}>{t('local_guide.eyebrow')}</span>
+            <h2 className="local-guide__title reveal" id="local-guide-title" style={{ '--reveal-index': 1 }}>{t('local_guide.title')}</h2>
+            <p className="local-guide__lead reveal" style={{ '--reveal-index': 2 }}>{t('local_guide.lead')}</p>
+            <p className="local-guide__coverage reveal" style={{ '--reveal-index': 3 }}>
+              {t('local_guide.coverage', { areas: AREA_KEYS.length, places: totalPlaces, events: events.length })}
+            </p>
+          </div>
+
+          <aside className="local-guide__note reveal" style={{ '--reveal-index': 2 }}>
+            <img src="/assets/brand/destination-paradise-logo-96.webp" alt="" width="52" height="52" loading="lazy" decoding="async" />
+            <div>
+              <p>{t('local_guide.note')}</p>
+              <span>{t('local_guide.reviewed')}</span>
+              <em>{tBrand('brand.typed_tagline')}</em>
+            </div>
+          </aside>
+        </header>
+
+        <label className="local-guide__mobile-select">
+          <span>{t('local_guide.area_label')}</span>
+          <select value={activeArea} onChange={(event) => selectArea(event.target.value)}>
+            {AREA_KEYS.map((area) => (
+              <option value={area} key={area}>{t(`local_guide.areas.${area}.label`)}</option>
+            ))}
+          </select>
+        </label>
+
+        <div className="local-guide__tabs" role="tablist" aria-label={t('local_guide.area_label')}>
+          {AREA_KEYS.map((area, index) => {
+            const selected = activeArea === area;
+            return (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`local-guide-panel-${area}`}
+                id={`local-guide-tab-${area}`}
+                className={selected ? 'is-active' : ''}
+                tabIndex={selected ? 0 : -1}
+                onClick={() => selectArea(area)}
+                onKeyDown={(event) => handleTabKeyDown(event, index)}
+                ref={(element) => { tabsRef.current[index] = element; }}
+                key={area}
+              >
+                <strong>{t(`local_guide.areas.${area}.label`)}</strong>
+                <span>{t(`local_guide.areas.${area}.hint`)}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          className="local-guide__body"
+          role="tabpanel"
+          id={`local-guide-panel-${activeArea}`}
+          aria-labelledby={`local-guide-tab-${activeArea}`}
+        >
+          <figure className="local-guide__media" key={`media-${activeArea}`}>
+            <img
+              src={`${TRIP_IMAGES}/${areaImage}-600w.webp`}
+              srcSet={`${TRIP_IMAGES}/${areaImage}-600w.webp 600w, ${TRIP_IMAGES}/${areaImage}.webp 1200w`}
+              sizes="(max-width: 820px) 100vw, 420px"
+              alt=""
+              width="600"
+              height="750"
+              loading="lazy"
+              decoding="async"
+            />
+            <span className="local-guide__media-badge">{t(`local_guide.areas.${activeArea}.label`)}</span>
+            <figcaption>{mapArea} · Zanzibar</figcaption>
+          </figure>
+
+          <div className="local-guide__places" key={`places-${activeArea}`}>
+            {places.map((place, index) => (
+              <article className="local-guide__place" key={place.name}>
+                <span className="local-guide__number">{String(index + 1).padStart(2, '0')}</span>
+                <div className="local-guide__place-copy">
+                  <span className="local-guide__occasion">{place.occasion}</span>
+                  <h3>{place.name}</h3>
+                  <p>{place.description}</p>
+                  <a
+                    href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${place.name} ${mapArea} Zanzibar`)}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {t('local_guide.open_map')} <MapArrow />
+                  </a>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        {events.length > 0 && (
+          <div className="local-guide__events">
+            <header className="local-guide__events-head">
+              <span className="local-guide__events-label">{t('local_guide.events.label')}</span>
+              <h3 className="local-guide__events-title">{t('local_guide.events.title')}</h3>
+              <p className="local-guide__events-lead">{t('local_guide.events.lead')}</p>
+            </header>
+            <ol className="local-guide__events-list">
+              {events.map((event) => (
+                <li className="local-guide__event" key={event.id}>
+                  <span className="local-guide__event-when">{event.when}</span>
+                  <div className="local-guide__event-copy">
+                    <h4>{event.name}</h4>
+                    <span className="local-guide__event-where">{event.where}</span>
+                    <p>{event.description}</p>
+                    {EVENT_LINKS[event.id] ? (
+                      <Link to={EVENT_LINKS[event.id]}>
+                        {t('local_guide.events.details')} <MapArrow />
+                      </Link>
+                    ) : (
+                      <a
+                        href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${event.where} Zanzibar`)}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {t('local_guide.open_map')} <MapArrow />
+                      </a>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        <footer className="local-guide__footer">
+          <div>
+            <strong>{t('local_guide.footer_title')}</strong>
+            <p>{t('local_guide.footer_text')}</p>
+          </div>
+          <a className="btn btn--accent" href={CONTACT_INFO.whatsappUrl} target="_blank" rel="noreferrer">
+            {t('local_guide.ask_us')}
+          </a>
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/src/data/siteSearchIndex.js
+++ b/src/data/siteSearchIndex.js
@@ -62,6 +62,13 @@ const pageItems = [
     keywords: ['book now', 'request', 'payment', 'reserve', 'availability'],
   },
   {
+    title: 'Our Zanzibar Guide',
+    category: 'Local guide',
+    description: 'Our current restaurant recommendations across eight Zanzibar areas, plus the island events worth planning around.',
+    to: '/explore#our-zanzibar-guide',
+    keywords: ['restaurants', 'food', 'where to eat', 'stone town', 'nungwi', 'kendwa', 'matemwe', 'kiwengwa', 'pongwe', 'michamvi', 'paje', 'bwejuu', 'jambiani', 'kizimkazi', 'local guide', 'family dinner', 'events', 'festivals', 'whats on', 'sauti za busara', 'ziff', 'full moon party', 'mwaka kogwa', 'forodhani night market'],
+  },
+  {
     title: 'About Us',
     category: 'Page',
     description: 'Learn about Destination Paradise, our mission, story, community, and local travel approach.',

--- a/src/locales/de/explore.json
+++ b/src/locales/de/explore.json
@@ -25,6 +25,287 @@
     },
     "no_fit": "Hier nicht der wichtigste Fokus."
   },
+  "local_guide": {
+    "eyebrow": "Unser Insel-Guide für Essen & Events",
+    "title": "Wohin wir Freunde zum Essen schicken.",
+    "lead": "Von Stone Town bis zur Nord- und Südküste: Das ist unsere aktuelle Auswahl für den Moment, in dem ein Gast fragt: Wo sollen wir wirklich essen gehen — und was sollten wir nicht verpassen?",
+    "coverage": "{{areas}} Regionen · {{places}} handverlesene Orte · {{events}} Termine zum Vormerken",
+    "note": "Ausgewählt, wie unsere Destination Guides einem Freund einen Ort empfehlen: passend zur Stimmung, zum Anlass und zu den Mitreisenden.",
+    "reviewed": "Guide geprüft · Juli 2026",
+    "area_label": "Ort auswählen",
+    "open_map": "In Maps öffnen",
+    "footer_title": "Sollen wir die Auswahl eingrenzen?",
+    "footer_text": "Sag uns, wo du wohnst, mit wem du reist und worauf du Appetit hast. Wir empfehlen dir den besten passenden Ort.",
+    "ask_us": "Auf WhatsApp fragen",
+    "events": {
+      "label": "Feste & Termine",
+      "title": "Wenn die Insel feiert.",
+      "lead": "Ein paar Termine, um die man eine Reise wunderbar planen kann — vom Abendmarkt bis zu den großen Festivals.",
+      "details": "Festival-Details",
+      "items": [
+        {
+          "id": "forodhani",
+          "when": "Jeden Abend",
+          "name": "Forodhani Night Market",
+          "where": "Forodhani-Gärten, Stone Town",
+          "description": "Nach Sonnenuntergang verwandeln sich die Gärten an der Uferpromenade in einen Open-Air-Foodmarkt. Kommt hungrig, schaut an den Grills vorbei und esst im Stehen mit den Einheimischen."
+        },
+        {
+          "id": "sauti-busara",
+          "when": "Anfang Februar",
+          "name": "Sauti za Busara",
+          "where": "Old Fort, Stone Town",
+          "description": "Ostafrikas herzlichstes Musikfestival — panafrikanische Line-ups im Old Fort und Karnevalsstimmung in den Gassen. Unterkünfte in Stone Town früh buchen."
+        },
+        {
+          "id": "ziff",
+          "when": "Juli",
+          "name": "Zanzibar International Film Festival",
+          "where": "Old Fort, Stone Town",
+          "description": "Open-Air-Kino, Ausstellungen und Musik übernehmen für eine Woche die Altstadt. Ein schöner Anlass, ein bis zwei Nächte länger in Stone Town zu bleiben."
+        },
+        {
+          "id": "mwaka-kogwa",
+          "when": "Ende Juli",
+          "name": "Mwaka Kogwa",
+          "where": "Makunduchi",
+          "description": "Das Shirazi-Neujahr: vier Tage voller Rituale, Schaukämpfe und Gesang im Süden der Insel. Am besten mit lokalem Guide — und vor dem Fotografieren fragen."
+        },
+        {
+          "id": "water-sports",
+          "when": "August",
+          "name": "Beach & Water Sports Festival",
+          "where": "Strände der Ost- & Nordküste",
+          "description": "Dhau-Rennen, Kite-Wettbewerbe und Strandspiele ziehen eine Woche lang die Küste entlang. Lässt sich gut mit einem Strandaufenthalt in Paje oder Nungwi verbinden."
+        },
+        {
+          "id": "full-moon",
+          "when": "Bei jedem Vollmond",
+          "name": "Kendwa Full Moon Party",
+          "where": "Kendwa Rocks, Kendwa",
+          "description": "Die bekannteste Strandparty der Insel, am Samstag um den Vollmond. Wer in Kendwa oder Nungwi wohnt, hat nachts nur einen kurzen Heimweg."
+        }
+      ]
+    },
+    "areas": {
+      "stone_town": {
+        "label": "Stone Town",
+        "hint": "Lokale Klassiker & Dachterrassen",
+        "map_label": "Stone Town",
+        "places": [
+          {
+            "name": "Lukmaan Restaurant",
+            "occasion": "Lokales Mittagessen",
+            "description": "Ein lebhafter, unkomplizierter Stopp für sansibarische Klassiker. Zeig auf das, was gut aussieht, probiere mehrere Gerichte und komm hungrig."
+          },
+          {
+            "name": "Taarab Restaurant",
+            "occasion": "Abend auf dem Dach",
+            "description": "Für ein Dinner über der Altstadt, das sich ein wenig besonderer anfühlen darf. Passt gut für Paare oder einen langen Familienabend."
+          },
+          {
+            "name": "Breadfruit Restaurant & Café",
+            "occasion": "Stilvoll & zentral",
+            "description": "Eine angenehme zentrale Wahl für eine ruhige Mahlzeit nach den Gassen der Altstadt. Lokale Zutaten treffen hier auf ein gepflegteres Ambiente."
+          },
+          {
+            "name": "The Beach House Restaurant",
+            "occasion": "Sonnenuntergang am Wasser",
+            "description": "Für Meerblick, Drinks und ein entspanntes Dinner am Rand von Stone Town. Reserviere vorab, wenn dir der genaue Sonnenuntergang wichtig ist."
+          }
+        ]
+      },
+      "north": {
+        "label": "Nungwi & Kendwa",
+        "hint": "Strandtage & Sunset-Dinner",
+        "map_label": "Nungwi Kendwa",
+        "places": [
+          {
+            "name": "Fish Market Local Restaurant",
+            "occasion": "Frisch & lokal",
+            "description": "Eine unkomplizierte Wahl für Meeresfrüchte und lokale Aromen ohne Resort-Formalität. Ideal, wenn sich das Essen entspannt und nach Nungwi anfühlen soll."
+          },
+          {
+            "name": "Badolina Secret Garden",
+            "occasion": "Versteckter Garten",
+            "description": "Ein geselliger, lockerer Ort mit Auswahl für unterschiedliche Wünsche. Der grüne Garten ist eine schöne Abwechslung zum nächsten Tisch direkt am Strand."
+          },
+          {
+            "name": "Terrace Nungwi",
+            "occasion": "Dinner mit Aussicht",
+            "description": "Für einen längeren Abend nah am Wasser und ein etwas bewussteres Menü. Unsere Wahl, wenn die Kulisse Teil des Anlasses sein soll."
+          },
+          {
+            "name": "Mocco Beach Villa & Restaurant",
+            "occasion": "Barfuß in Kendwa",
+            "description": "Eine entspannte Adresse in Kendwa für Lunch oder Dinner nah am Sand. Perfekt, wenn du im Rhythmus des Strandtags bleiben möchtest."
+          }
+        ]
+      },
+      "north_east": {
+        "label": "Matemwe & Kiwengwa",
+        "hint": "Ruhige Küste & lange Lunches",
+        "map_label": "Matemwe Kiwengwa",
+        "places": [
+          {
+            "name": "Bin Jabir Restaurant",
+            "occasion": "Lokal in Matemwe",
+            "description": "Ein herzlicher, unkomplizierter Stopp für Swahili-Küche und Meeresfrüchte. Gut, wenn du außerhalb des Hotelrestaurants lokal essen möchtest."
+          },
+          {
+            "name": "Marlin Restaurant",
+            "occasion": "Meeresfrüchte ohne Schnickschnack",
+            "description": "Für eine entspannte Mahlzeit rund um Fisch und Meeresfrüchte. Passt zu Lunch oder Dinner, wenn der Plan einfach gut essen und langsamer werden lautet."
+          },
+          {
+            "name": "Zanzibar Sunrise at Bandas",
+            "occasion": "Langer Abend am Strand",
+            "description": "Für eine Lage am Strand und einen Abend, der etwas länger dauern darf. Hier geht es mehr ums Ankommen an der Küste als um Eile."
+          },
+          {
+            "name": "La Base JungleKite",
+            "occasion": "Locker in Kiwengwa",
+            "description": "Eine lässige Adresse mit aktiver, geselliger Stimmung. Gut für ein unkompliziertes Essen nach einem Tag auf dem Wasser."
+          }
+        ]
+      },
+      "pongwe": {
+        "label": "Pongwe",
+        "hint": "Abgeschiedene Tische an der Ostküste",
+        "map_label": "Pongwe",
+        "places": [
+          {
+            "name": "The Island – Pongwe Restaurant",
+            "occasion": "Lunch als Ausflug",
+            "description": "Die kleine vorgelagerte Lage macht schon den Lunch zum Erlebnis. Wähle es für die besondere Kulisse und prüfe Zugang und Zeiten vor der Abfahrt."
+          },
+          {
+            "name": "The Cliff Grill",
+            "occasion": "Ein ruhigeres Dinner",
+            "description": "Passend für einen stillen Abend mit Meeresluft und etwas mehr Eleganz. Gut für Paare oder Familien, die sich gerne Zeit lassen."
+          },
+          {
+            "name": "The Club by Pongwe Bay Resort",
+            "occasion": "Komfort im Resort",
+            "description": "Eine verlässliche Wahl für ein angenehmes, unkompliziertes Essen in Pongwe. Praktisch, wenn verschiedene Altersgruppen und Wünsche zusammenkommen."
+          },
+          {
+            "name": "Pongwe Beach Hotel Restaurant",
+            "occasion": "Lunch an der Bucht",
+            "description": "Für ein langes Essen an einer der ruhigeren Buchten der Ostküste. Lässt sich ganz natürlich mit einem langsamen Strandtag verbinden."
+          }
+        ]
+      },
+      "michamvi": {
+        "label": "Michamvi & Pingwe",
+        "hint": "Sonnenuntergänge & besondere Kulissen",
+        "map_label": "Michamvi Pingwe",
+        "places": [
+          {
+            "name": "Kae Funk Sunset Beach Bar",
+            "occasion": "Sonnenuntergang & barfuß",
+            "description": "Für Musik, Sand und den Sonnenuntergang an der Westseite der Halbinsel statt eines formellen Dinners. Komm rechtzeitig, bevor sich der Himmel färbt."
+          },
+          {
+            "name": "The Rock Restaurant Zanzibar",
+            "occasion": "Der ikonische Tisch",
+            "description": "Die Lage ist der Grund: ein Restaurant auf einem Felsen direkt vor Pingwe. Früh reservieren und als Sansibar-Erlebnis sehen, nicht nur als Mahlzeit."
+          },
+          {
+            "name": "Dreamland Restaurant & Bar",
+            "occasion": "Einfach & herzlich",
+            "description": "Eine entspannte Alternative für freundlichen Service und ein unkompliziertes Dinner, ohne den Abend gleich zum großen Ereignis zu machen."
+          },
+          {
+            "name": "Sagando Restaurant & Bar",
+            "occasion": "Lockeres Inseldinner",
+            "description": "Eine angenehme lokale Wahl für einen einfachen Abend in Michamvi. Gut, wenn die Gruppe Vertrautes neben Inselaromen sucht."
+          }
+        ]
+      },
+      "jambiani": {
+        "label": "Jambiani",
+        "hint": "Unsere ersten Tipps vor Ort",
+        "map_label": "Jambiani",
+        "places": [
+          {
+            "name": "Fadhil Restaurant",
+            "occasion": "Lokal & entspannt",
+            "description": "Für ehrliche Swahili-Küche, gegrillten Fisch und Currys. Eine gute Wahl, wenn es lokal, herzlich und unkompliziert sein soll."
+          },
+          {
+            "name": "Lost Soles",
+            "occasion": "Entspannt mit der Familie",
+            "description": "Eine lockere Adresse für gegrillten Thunfisch, Meeresfrüchte und vertraute Gerichte – praktisch, wenn am Tisch jeder etwas anderes möchte."
+          },
+          {
+            "name": "Ocean Boho House",
+            "occasion": "Ein besonderer Abend",
+            "description": "Für kreative Gerichte und ein etwas feineres Dinner, ohne die entspannte Inselstimmung zu verlieren. Hier würden wir vorher reservieren."
+          },
+          {
+            "name": "Sharazad The View",
+            "occasion": "Am Strand & ohne Eile",
+            "description": "Eine schöne Kulisse für ein langes Familienessen oder Dinner zum Sonnenuntergang. Die Aussicht gehört zum Erlebnis – am besten vorher reservieren."
+          }
+        ]
+      },
+      "paje": {
+        "label": "Paje & Bwejuu",
+        "hint": "Kaffee, Auswahl & Strandenergie",
+        "map_label": "Paje Bwejuu",
+        "places": [
+          {
+            "name": "Mr Kahawa",
+            "occasion": "Frühstück am Strand",
+            "description": "Unsere unkomplizierte Wahl für Kaffee, Frühstück oder ein entspanntes Mittagessen mit Blick aufs Meer. Früh kommen, wenn du es ruhiger magst."
+          },
+          {
+            "name": "Mapacha Food Court",
+            "occasion": "Locker & flexibel",
+            "description": "Gut für Familien und Gruppen, die sich nicht auf eine Küche einigen können. Die Atmosphäre ist ungezwungen und jeder findet etwas Passendes."
+          },
+          {
+            "name": "Shanga Restaurant Paje",
+            "occasion": "Swahili & Meeresfrüchte",
+            "description": "Eine gute Wahl für lokale Aromen und Meeresfrüchte im Zentrum von Paje, wenn sich das Dinner wirklich nach Insel anfühlen soll."
+          },
+          {
+            "name": "Sahari Zanzibar",
+            "occasion": "Am Strand in Bwejuu",
+            "description": "Eine ruhigere Alternative zu Paje für ein Essen am Strand mit mehr Raum. Schön für Paare oder einen langsamen Familienlunch."
+          }
+        ]
+      },
+      "south": {
+        "label": "Kizimkazi & der Süden",
+        "hint": "Abgelegen, entspannt & ohne Eile",
+        "map_label": "Kizimkazi",
+        "places": [
+          {
+            "name": "Restaurant Stone Village & The Dream Garden",
+            "occasion": "Dinner im Garten",
+            "description": "Eine herzliche Wahl für ein entspanntes Dinner in Kizimkazi. Gut, wenn der Abend persönlich und fern von den größeren Resorts sein soll."
+          },
+          {
+            "name": "Kameleon Blue Bar & Restaurant",
+            "occasion": "Locker an der Südküste",
+            "description": "Ein lässiger Ort für einen langen Lunch oder ein unkompliziertes Dinner. Passt, wenn du nach einem Tag im Süden entspannt bleiben möchtest."
+          },
+          {
+            "name": "Karamba Restaurant",
+            "occasion": "Lunch mit Meerblick",
+            "description": "Komm wegen der Lage an der Küste und bring Zeit mit. Das passt besser zu einem langen Lunch als zu einem schnellen Stopp zwischen Aktivitäten."
+          },
+          {
+            "name": "Fahari Off The Grid",
+            "occasion": "Etwas anderes",
+            "description": "Eine charaktervolle Wahl abseits des üblichen Strandhotel-Ablaufs. Prüfe vor der Fahrt die aktuellen Öffnungsdetails."
+          }
+        ]
+      }
+    }
+  },
   "doorways": {
     "eyebrow": "Einstiege",
     "title": "Wenn du noch nicht weißt, wo du anfangen sollst.",

--- a/src/locales/de/footer.json
+++ b/src/locales/de/footer.json
@@ -13,6 +13,7 @@
       "packages": "Pakete",
       "trip_planner": "Reiseplaner",
       "explore": "Entdecken",
+      "local_guide": "Unser Sansibar-Guide",
       "about": "Über uns"
     },
     "about": {

--- a/src/locales/en/explore.json
+++ b/src/locales/en/explore.json
@@ -25,6 +25,287 @@
     },
     "no_fit": "Not the main fit here."
   },
+  "local_guide": {
+    "eyebrow": "Our island food & events guide",
+    "title": "Where we send friends to eat.",
+    "lead": "From Stone Town to the north and south coasts, this is our current shortlist for the moments when a guest asks: where should we really eat — and what's worth planning around?",
+    "coverage": "{{areas}} areas · {{places}} hand-picked places · {{events}} dates to know",
+    "note": "Chosen the way our destination guides recommend a place to a friend: by mood, occasion and who you are travelling with.",
+    "reviewed": "Guide reviewed · July 2026",
+    "area_label": "Choose an area",
+    "open_map": "Open in Maps",
+    "footer_title": "Want us to narrow it down?",
+    "footer_text": "Tell us where you are staying, who you are with and what you feel like eating. We will suggest the best fit.",
+    "ask_us": "Ask us on WhatsApp",
+    "events": {
+      "label": "What's on",
+      "title": "When the island celebrates.",
+      "lead": "A few dates worth planning a trip around — from the nightly market to the island's big festivals.",
+      "details": "Festival details",
+      "items": [
+        {
+          "id": "forodhani",
+          "when": "Every evening",
+          "name": "Forodhani Night Market",
+          "where": "Forodhani Gardens, Stone Town",
+          "description": "Stone Town's seafront gardens turn into an open-air food market after sunset. Come hungry, browse the grills and eat standing up with the locals."
+        },
+        {
+          "id": "sauti-busara",
+          "when": "Early February",
+          "name": "Sauti za Busara",
+          "where": "Old Fort, Stone Town",
+          "description": "East Africa's warmest music festival — pan-African line-ups inside the Old Fort and a carnival mood in the streets. Book Stone Town beds early."
+        },
+        {
+          "id": "ziff",
+          "when": "July",
+          "name": "Zanzibar International Film Festival",
+          "where": "Old Fort, Stone Town",
+          "description": "Open-air screenings, exhibitions and music take over the old town for a week. A lovely excuse to slow down in Stone Town for a night or two."
+        },
+        {
+          "id": "mwaka-kogwa",
+          "when": "Late July",
+          "name": "Mwaka Kogwa",
+          "where": "Makunduchi",
+          "description": "The Shirazi new year: four days of rituals, mock fights and song in the island's south. Go with a local guide and ask before photographing."
+        },
+        {
+          "id": "water-sports",
+          "when": "August",
+          "name": "Beach & Water Sports Festival",
+          "where": "East & north coast beaches",
+          "description": "Dhow races, kite contests and beach games move along the coast for a week. Easy to combine with a beach stay in Paje or Nungwi."
+        },
+        {
+          "id": "full-moon",
+          "when": "Every full moon",
+          "name": "Kendwa Full Moon Party",
+          "where": "Kendwa Rocks, Kendwa",
+          "description": "The island's best-known beach party, on the Saturday closest to the full moon. Stay in Kendwa or Nungwi so the night ends with a short walk home."
+        }
+      ]
+    },
+    "areas": {
+      "stone_town": {
+        "label": "Stone Town",
+        "hint": "Local classics & rooftops",
+        "map_label": "Stone Town",
+        "places": [
+          {
+            "name": "Lukmaan Restaurant",
+            "occasion": "Local lunch",
+            "description": "A lively, no-fuss stop for Zanzibari favourites. Point to what looks good, try a few dishes and come hungry. Best when atmosphere matters more than ceremony."
+          },
+          {
+            "name": "Taarab Restaurant",
+            "occasion": "Rooftop evening",
+            "description": "Choose this when you want dinner above the old town, with a little more occasion around it. A good fit for couples or an unhurried family evening."
+          },
+          {
+            "name": "Breadfruit Restaurant & Café",
+            "occasion": "Polished & central",
+            "description": "A comfortable central choice for a calmer meal after exploring the alleys. Useful when you want local ingredients in a more polished setting."
+          },
+          {
+            "name": "The Beach House Restaurant",
+            "occasion": "Sunset by the water",
+            "description": "Go for sea views, drinks and an easy sunset dinner on the edge of Stone Town. Reserve ahead if the timing of the sunset matters to you."
+          }
+        ]
+      },
+      "north": {
+        "label": "Nungwi & Kendwa",
+        "hint": "Beach days & sunset dinners",
+        "map_label": "Nungwi Kendwa",
+        "places": [
+          {
+            "name": "Fish Market Local Restaurant",
+            "occasion": "Fresh & local",
+            "description": "A straightforward choice for seafood and local flavours without the resort formality. Come when you want the meal to feel relaxed and rooted in Nungwi."
+          },
+          {
+            "name": "Badolina Secret Garden",
+            "occasion": "Garden hideaway",
+            "description": "A sociable, easy-going spot that works well when your group wants variety. The leafy setting makes a welcome change from another table directly on the beach."
+          },
+          {
+            "name": "Terrace Nungwi",
+            "occasion": "Dinner with a view",
+            "description": "One for a longer evening with the water close by and a more considered menu. We would choose it when the setting is part of the celebration."
+          },
+          {
+            "name": "Mocco Beach Villa & Restaurant",
+            "occasion": "Barefoot Kendwa",
+            "description": "A relaxed Kendwa option for lunch or dinner close to the sand. Useful when you want to stay in the rhythm of a beach day instead of dressing up for dinner."
+          }
+        ]
+      },
+      "north_east": {
+        "label": "Matemwe & Kiwengwa",
+        "hint": "Quiet coast & long lunches",
+        "map_label": "Matemwe Kiwengwa",
+        "places": [
+          {
+            "name": "Bin Jabir Restaurant",
+            "occasion": "Matemwe local",
+            "description": "A warm, uncomplicated stop for Swahili food and seafood. A good choice when you want local cooking away from the hotel dining room."
+          },
+          {
+            "name": "Marlin Restaurant",
+            "occasion": "Seafood without fuss",
+            "description": "Come for a relaxed meal centred on fish and seafood. It suits an easy lunch or dinner when the plan is simply to eat well and slow down."
+          },
+          {
+            "name": "Zanzibar Sunrise at Bandas",
+            "occasion": "Slow beach evening",
+            "description": "Choose it for a beach setting and an evening that can stretch a little longer. It is more about settling into the coast than rushing through courses."
+          },
+          {
+            "name": "La Base JungleKite",
+            "occasion": "Casual Kiwengwa",
+            "description": "A laid-back option with an active, social feel. Good for a casual meal when you want something easy after time on the water."
+          }
+        ]
+      },
+      "pongwe": {
+        "label": "Pongwe",
+        "hint": "Secluded east-coast tables",
+        "map_label": "Pongwe",
+        "places": [
+          {
+            "name": "The Island – Pongwe Restaurant",
+            "occasion": "A destination lunch",
+            "description": "A tiny offshore setting that turns lunch into an outing of its own. Pick this for the experience and check access and timing before you set off."
+          },
+          {
+            "name": "The Cliff Grill",
+            "occasion": "A quieter dinner",
+            "description": "A good fit when you want a calm evening, sea air and a little more polish. Best for couples or families happy to take their time."
+          },
+          {
+            "name": "The Club by Pongwe Bay Resort",
+            "occasion": "Resort comfort",
+            "description": "A dependable choice for an easy, comfortable meal in Pongwe. Useful when different ages and appetites need to work around one table."
+          },
+          {
+            "name": "Pongwe Beach Hotel Restaurant",
+            "occasion": "Lunch by the bay",
+            "description": "Come for an unhurried meal beside one of the quieter bays on the east coast. It pairs naturally with a slow beach day."
+          }
+        ]
+      },
+      "michamvi": {
+        "label": "Michamvi & Pingwe",
+        "hint": "Sunsets & special settings",
+        "map_label": "Michamvi Pingwe",
+        "places": [
+          {
+            "name": "Kae Funk Sunset Beach Bar",
+            "occasion": "Sunset & bare feet",
+            "description": "Go for music, sand and the west-facing sunset rather than a formal dinner. Arrive with time to settle in before the sky changes."
+          },
+          {
+            "name": "The Rock Restaurant Zanzibar",
+            "occasion": "The iconic table",
+            "description": "The setting is the reason to go: a restaurant on a rock just offshore at Pingwe. Book ahead and treat it as a Zanzibar experience, not only a meal."
+          },
+          {
+            "name": "Dreamland Restaurant & Bar",
+            "occasion": "Easy & welcoming",
+            "description": "A relaxed alternative when you want friendly service and a straightforward dinner without turning the evening into a big event."
+          },
+          {
+            "name": "Sagando Restaurant & Bar",
+            "occasion": "Casual island dinner",
+            "description": "A comfortable local option for an easy evening in Michamvi. Good when the group wants familiar choices alongside island flavours."
+          }
+        ]
+      },
+      "jambiani": {
+        "label": "Jambiani",
+        "hint": "Our first choices nearby",
+        "map_label": "Jambiani",
+        "places": [
+          {
+            "name": "Fadhil Restaurant",
+            "occasion": "Local & relaxed",
+            "description": "Come for straightforward Swahili cooking, grilled fish and curries. A good choice when you want something local, warm and unpretentious."
+          },
+          {
+            "name": "Lost Soles",
+            "occasion": "Easy family dinner",
+            "description": "A relaxed option for grilled tuna, seafood and familiar comfort food — especially useful when everyone around the table wants something different."
+          },
+          {
+            "name": "Ocean Boho House",
+            "occasion": "A special evening",
+            "description": "Choose this for creative plates and a more polished dinner without losing the easy island mood. It is one we would reserve ahead."
+          },
+          {
+            "name": "Sharazad The View",
+            "occasion": "Beachfront & unhurried",
+            "description": "A beautiful setting for a slow family lunch or sunset dinner. Come for the view as much as the food, and book ahead for the best timing."
+          }
+        ]
+      },
+      "paje": {
+        "label": "Paje & Bwejuu",
+        "hint": "Coffee, choice & beach energy",
+        "map_label": "Paje Bwejuu",
+        "places": [
+          {
+            "name": "Mr Kahawa",
+            "occasion": "Breakfast by the beach",
+            "description": "Our easy choice for coffee, breakfast or a relaxed lunch with the ocean in front of you. Go earlier if you prefer a quieter table."
+          },
+          {
+            "name": "Mapacha Food Court",
+            "occasion": "Casual & flexible",
+            "description": "A good answer for families and groups who cannot agree on one cuisine. The atmosphere is informal and everyone can choose their own direction."
+          },
+          {
+            "name": "Shanga Restaurant Paje",
+            "occasion": "Swahili & seafood",
+            "description": "One to consider for local flavours and seafood in the centre of Paje, especially when you want dinner to feel rooted in the island."
+          },
+          {
+            "name": "Sahari Zanzibar",
+            "occasion": "Bwejuu by the beach",
+            "description": "A quieter alternative to Paje for a beachside meal with a little more breathing room. A nice fit for couples or a slow family lunch."
+          }
+        ]
+      },
+      "south": {
+        "label": "Kizimkazi & the south",
+        "hint": "Remote, relaxed & unhurried",
+        "map_label": "Kizimkazi",
+        "places": [
+          {
+            "name": "Restaurant Stone Village & The Dream Garden",
+            "occasion": "Garden dinner",
+            "description": "A welcoming choice for a relaxed dinner in Kizimkazi. Pick it when you want the evening to feel personal and away from the larger resorts."
+          },
+          {
+            "name": "Kameleon Blue Bar & Restaurant",
+            "occasion": "Easy-going south coast",
+            "description": "A casual place for a slow lunch or uncomplicated dinner. It works well when the plan is to stay relaxed after a day on the south coast."
+          },
+          {
+            "name": "Karamba Restaurant",
+            "occasion": "Ocean-view lunch",
+            "description": "Come for the coastal setting and give yourself time. This is a good match for a long lunch rather than a quick stop between activities."
+          },
+          {
+            "name": "Fahari Off The Grid",
+            "occasion": "Something different",
+            "description": "A characterful option when you want to step away from the usual beach-hotel routine. Check the day's opening details before making the journey."
+          }
+        ]
+      }
+    }
+  },
   "doorways": {
     "eyebrow": "Quick guide",
     "title": "Pick the right doorway.",

--- a/src/locales/en/footer.json
+++ b/src/locales/en/footer.json
@@ -13,6 +13,7 @@
       "packages": "Packages",
       "trip_planner": "Trip Planner",
       "explore": "Explore",
+      "local_guide": "Our Zanzibar Guide",
       "about": "About Us"
     },
     "about": {

--- a/src/locales/pl/explore.json
+++ b/src/locales/pl/explore.json
@@ -25,6 +25,287 @@
     },
     "no_fit": "To nie jest tutaj główny wybór."
   },
+  "local_guide": {
+    "eyebrow": "Nasz przewodnik po jedzeniu i wydarzeniach",
+    "title": "Miejsca, do których wysyłamy przyjaciół na posiłek.",
+    "lead": "Od Stone Town po północne i południowe wybrzeże — to nasza aktualna lista na moment, gdy gość pyta: gdzie naprawdę warto zjeść — i czego nie przegapić?",
+    "coverage": "{{areas}} okolic · {{places}} starannie wybranych miejsc · {{events}} dat wartych zapamiętania",
+    "note": "Wybrane tak, jak nasi przewodnicy po destynacji polecają miejsce znajomym: według nastroju, okazji i tego, z kim podróżujesz.",
+    "reviewed": "Przewodnik sprawdzony · lipiec 2026",
+    "area_label": "Wybierz okolicę",
+    "open_map": "Otwórz w Mapach",
+    "footer_title": "Mamy zawęzić wybór?",
+    "footer_text": "Powiedz nam, gdzie mieszkasz, z kim podróżujesz i na co masz ochotę. Podpowiemy miejsce najlepiej dopasowane do Ciebie.",
+    "ask_us": "Zapytaj nas na WhatsAppie",
+    "events": {
+      "label": "Wydarzenia",
+      "title": "Kiedy wyspa świętuje.",
+      "lead": "Kilka dat, wokół których dobrze planować podróż — od wieczornego targu po największe festiwale.",
+      "details": "Szczegóły festiwalu",
+      "items": [
+        {
+          "id": "forodhani",
+          "when": "Co wieczór",
+          "name": "Forodhani Night Market",
+          "where": "Ogrody Forodhani, Stone Town",
+          "description": "Po zachodzie słońca nadmorskie ogrody zamieniają się w targ z jedzeniem pod gołym niebem. Przyjdźcie głodni, obejrzyjcie grille i jedzcie na stojąco razem z mieszkańcami."
+        },
+        {
+          "id": "sauti-busara",
+          "when": "Początek lutego",
+          "name": "Sauti za Busara",
+          "where": "Stary Fort, Stone Town",
+          "description": "Najcieplejszy festiwal muzyczny Afryki Wschodniej — panafrykańskie koncerty w Starym Forcie i karnawałowy nastrój na ulicach. Noclegi w Stone Town warto rezerwować wcześnie."
+        },
+        {
+          "id": "ziff",
+          "when": "Lipiec",
+          "name": "Zanzibar International Film Festival",
+          "where": "Stary Fort, Stone Town",
+          "description": "Kino plenerowe, wystawy i muzyka na tydzień przejmują stare miasto. Dobry pretekst, by zostać w Stone Town o noc lub dwie dłużej."
+        },
+        {
+          "id": "mwaka-kogwa",
+          "when": "Koniec lipca",
+          "name": "Mwaka Kogwa",
+          "where": "Makunduchi",
+          "description": "Szyraski Nowy Rok: cztery dni rytuałów, pozorowanych walk i pieśni na południu wyspy. Najlepiej z lokalnym przewodnikiem — i pytajcie, zanim zrobicie zdjęcie."
+        },
+        {
+          "id": "water-sports",
+          "when": "Sierpień",
+          "name": "Beach & Water Sports Festival",
+          "where": "Plaże wschodniego i północnego wybrzeża",
+          "description": "Regaty dhow, zawody kitesurfingowe i plażowe gry przez tydzień wędrują wzdłuż wybrzeża. Łatwo połączyć je z pobytem w Paje lub Nungwi."
+        },
+        {
+          "id": "full-moon",
+          "when": "W każdą pełnię",
+          "name": "Kendwa Full Moon Party",
+          "where": "Kendwa Rocks, Kendwa",
+          "description": "Najsłynniejsza plażowa impreza na wyspie, w sobotę najbliższą pełni księżyca. Nocując w Kendwie lub Nungwi, wracacie do łóżka pieszo."
+        }
+      ]
+    },
+    "areas": {
+      "stone_town": {
+        "label": "Stone Town",
+        "hint": "Lokalna klasyka i dachy",
+        "map_label": "Stone Town",
+        "places": [
+          {
+            "name": "Lukmaan Restaurant",
+            "occasion": "Lokalny lunch",
+            "description": "Tętniące życiem, bezpretensjonalne miejsce na zanzibarskie klasyki. Wskaż to, co wygląda dobrze, spróbuj kilku dań i przyjdź głodny."
+          },
+          {
+            "name": "Taarab Restaurant",
+            "occasion": "Wieczór na dachu",
+            "description": "Wybierz je na kolację ponad starym miastem, gdy wieczór ma być nieco bardziej wyjątkowy. Dobre dla par i rodzin bez pośpiechu."
+          },
+          {
+            "name": "Breadfruit Restaurant & Café",
+            "occasion": "Stylowo i centralnie",
+            "description": "Wygodny wybór w centrum na spokojny posiłek po spacerze uliczkami. Lokalnym składnikom towarzyszy tu bardziej dopracowana oprawa."
+          },
+          {
+            "name": "The Beach House Restaurant",
+            "occasion": "Zachód słońca nad wodą",
+            "description": "Na widok morza, drinki i swobodną kolację na skraju Stone Town. Zarezerwuj wcześniej, jeśli zależy Ci na porze zachodu słońca."
+          }
+        ]
+      },
+      "north": {
+        "label": "Nungwi i Kendwa",
+        "hint": "Plaża i kolacje o zachodzie słońca",
+        "map_label": "Nungwi Kendwa",
+        "places": [
+          {
+            "name": "Fish Market Local Restaurant",
+            "occasion": "Świeżo i lokalnie",
+            "description": "Prosty wybór na owoce morza i lokalne smaki bez resortowej formalności. Dla tych, którzy chcą, by posiłek był swobodny i mocno związany z Nungwi."
+          },
+          {
+            "name": "Badolina Secret Garden",
+            "occasion": "Ukryty ogród",
+            "description": "Towarzyskie, swobodne miejsce z wyborem dla różnych apetytów. Zielony ogród jest miłą odmianą od kolejnego stolika bezpośrednio na plaży."
+          },
+          {
+            "name": "Terrace Nungwi",
+            "occasion": "Kolacja z widokiem",
+            "description": "Na dłuższy wieczór blisko wody i bardziej przemyślane menu. Wybralibyśmy je, gdy sceneria ma być częścią świętowania."
+          },
+          {
+            "name": "Mocco Beach Villa & Restaurant",
+            "occasion": "Boso w Kendwie",
+            "description": "Luźna opcja w Kendwie na lunch lub kolację blisko piasku. Dobra, gdy chcesz zostać w rytmie dnia na plaży."
+          }
+        ]
+      },
+      "north_east": {
+        "label": "Matemwe i Kiwengwa",
+        "hint": "Spokojne wybrzeże i długie lunche",
+        "map_label": "Matemwe Kiwengwa",
+        "places": [
+          {
+            "name": "Bin Jabir Restaurant",
+            "occasion": "Lokalnie w Matemwe",
+            "description": "Serdeczny, prosty przystanek na kuchnię suahili i owoce morza. Dobry, gdy chcesz zjeść lokalnie poza hotelową restauracją."
+          },
+          {
+            "name": "Marlin Restaurant",
+            "occasion": "Owoce morza bez zadęcia",
+            "description": "Na spokojny posiłek oparty na rybach i owocach morza. Pasuje na lunch lub kolację, kiedy plan brzmi: dobrze zjeść i zwolnić."
+          },
+          {
+            "name": "Zanzibar Sunrise at Bandas",
+            "occasion": "Długi wieczór na plaży",
+            "description": "Wybierz ze względu na plażową scenerię i wieczór, który może potrwać dłużej. Tu chodzi bardziej o rytm wybrzeża niż o pośpiech."
+          },
+          {
+            "name": "La Base JungleKite",
+            "occasion": "Swobodnie w Kiwengwie",
+            "description": "Luźne miejsce z aktywną, towarzyską atmosferą. Dobre na prosty posiłek po czasie spędzonym na wodzie."
+          }
+        ]
+      },
+      "pongwe": {
+        "label": "Pongwe",
+        "hint": "Kameralne stoły na wschodnim wybrzeżu",
+        "map_label": "Pongwe",
+        "places": [
+          {
+            "name": "The Island – Pongwe Restaurant",
+            "occasion": "Lunch jako wyprawa",
+            "description": "Maleńka lokalizacja tuż przy brzegu zmienia lunch w osobną przygodę. Jedź dla doświadczenia i sprawdź dojazd oraz godziny przed wyjazdem."
+          },
+          {
+            "name": "The Cliff Grill",
+            "occasion": "Spokojniejsza kolacja",
+            "description": "Dobry wybór na cichy wieczór, morskie powietrze i odrobinę elegancji. Dla par i rodzin, które lubią mieć czas."
+          },
+          {
+            "name": "The Club by Pongwe Bay Resort",
+            "occasion": "Resortowy komfort",
+            "description": "Pewny wybór na łatwy, wygodny posiłek w Pongwe. Przydatny, gdy przy jednym stole spotykają się różne pokolenia i apetyty."
+          },
+          {
+            "name": "Pongwe Beach Hotel Restaurant",
+            "occasion": "Lunch nad zatoką",
+            "description": "Na niespieszny posiłek przy jednej ze spokojniejszych zatok wschodniego wybrzeża. Naturalnie łączy się z powolnym dniem na plaży."
+          }
+        ]
+      },
+      "michamvi": {
+        "label": "Michamvi i Pingwe",
+        "hint": "Zachody słońca i wyjątkowe miejsca",
+        "map_label": "Michamvi Pingwe",
+        "places": [
+          {
+            "name": "Kae Funk Sunset Beach Bar",
+            "occasion": "Zachód słońca boso",
+            "description": "Idź dla muzyki, piasku i zachodu słońca po zachodniej stronie półwyspu, nie dla formalnej kolacji. Przyjedź, zanim niebo zacznie się zmieniać."
+          },
+          {
+            "name": "The Rock Restaurant Zanzibar",
+            "occasion": "Kultowy stolik",
+            "description": "Najważniejsza jest sceneria: restauracja na skale tuż przy brzegu Pingwe. Rezerwuj wcześniej i potraktuj ją jako doświadczenie Zanzibaru."
+          },
+          {
+            "name": "Dreamland Restaurant & Bar",
+            "occasion": "Prosto i gościnnie",
+            "description": "Swobodna alternatywa na przyjazną obsługę i prostą kolację bez zmieniania wieczoru w wielkie wydarzenie."
+          },
+          {
+            "name": "Sagando Restaurant & Bar",
+            "occasion": "Luźna wyspiarska kolacja",
+            "description": "Wygodny lokalny wybór na łatwy wieczór w Michamvi. Dobry, gdy grupa szuka znajomych dań obok wyspiarskich smaków."
+          }
+        ]
+      },
+      "jambiani": {
+        "label": "Jambiani",
+        "hint": "Nasze pierwsze wybory w okolicy",
+        "map_label": "Jambiani",
+        "places": [
+          {
+            "name": "Fadhil Restaurant",
+            "occasion": "Lokalnie i swobodnie",
+            "description": "Na prostą kuchnię suahili, grillowaną rybę i curry. Dobry wybór, kiedy ma być lokalnie, serdecznie i bez zadęcia."
+          },
+          {
+            "name": "Lost Soles",
+            "occasion": "Łatwa kolacja z rodziną",
+            "description": "Swobodne miejsce na grillowanego tuńczyka, owoce morza i bardziej znajome dania — szczególnie gdy każdy przy stole ma ochotę na coś innego."
+          },
+          {
+            "name": "Ocean Boho House",
+            "occasion": "Wyjątkowy wieczór",
+            "description": "Na kreatywne dania i nieco bardziej elegancką kolację bez utraty wyspiarskiego luzu. Tutaj zarezerwowalibyśmy stolik wcześniej."
+          },
+          {
+            "name": "Sharazad The View",
+            "occasion": "Nad oceanem i bez pośpiechu",
+            "description": "Piękna sceneria na długi rodzinny lunch lub kolację o zachodzie słońca. Widok jest częścią doświadczenia — warto wcześniej zarezerwować."
+          }
+        ]
+      },
+      "paje": {
+        "label": "Paje i Bwejuu",
+        "hint": "Kawa, wybór i energia plaży",
+        "map_label": "Paje Bwejuu",
+        "places": [
+          {
+            "name": "Mr Kahawa",
+            "occasion": "Śniadanie przy plaży",
+            "description": "Nasz prosty wybór na kawę, śniadanie lub spokojny lunch z widokiem na ocean. Przyjdź wcześniej, jeśli wolisz cichszy stolik."
+          },
+          {
+            "name": "Mapacha Food Court",
+            "occasion": "Swobodnie i elastycznie",
+            "description": "Dobra odpowiedź dla rodzin i grup, które nie mogą zdecydować się na jedną kuchnię. Atmosfera jest luźna, a każdy wybiera po swojemu."
+          },
+          {
+            "name": "Shanga Restaurant Paje",
+            "occasion": "Suahili i owoce morza",
+            "description": "Warto rozważyć ze względu na lokalne smaki i owoce morza w centrum Paje, zwłaszcza gdy kolacja ma mieć prawdziwie wyspiarski charakter."
+          },
+          {
+            "name": "Sahari Zanzibar",
+            "occasion": "Na plaży w Bwejuu",
+            "description": "Spokojniejsza alternatywa dla Paje na posiłek przy plaży z większą przestrzenią. Dobra dla par lub na długi rodzinny lunch."
+          }
+        ]
+      },
+      "south": {
+        "label": "Kizimkazi i południe",
+        "hint": "Daleko, spokojnie i bez pośpiechu",
+        "map_label": "Kizimkazi",
+        "places": [
+          {
+            "name": "Restaurant Stone Village & The Dream Garden",
+            "occasion": "Kolacja w ogrodzie",
+            "description": "Gościnny wybór na spokojną kolację w Kizimkazi. Dla tych, którzy chcą osobistego wieczoru z dala od większych resortów."
+          },
+          {
+            "name": "Kameleon Blue Bar & Restaurant",
+            "occasion": "Swobodne południe wyspy",
+            "description": "Luźne miejsce na długi lunch lub prostą kolację. Pasuje, gdy po dniu na południowym wybrzeżu chcesz zachować spokojne tempo."
+          },
+          {
+            "name": "Karamba Restaurant",
+            "occasion": "Lunch z widokiem na ocean",
+            "description": "Przyjdź dla nadmorskiej scenerii i daj sobie czas. Lepiej pasuje do długiego lunchu niż szybkiego przystanku między atrakcjami."
+          },
+          {
+            "name": "Fahari Off The Grid",
+            "occasion": "Coś innego",
+            "description": "Miejsce z charakterem, z dala od zwykłej rutyny hotelu przy plaży. Przed podróżą sprawdź aktualne godziny otwarcia."
+          }
+        ]
+      }
+    }
+  },
   "doorways": {
     "eyebrow": "Szybki przewodnik",
     "title": "Wybierz właściwe wejście.",

--- a/src/locales/pl/footer.json
+++ b/src/locales/pl/footer.json
@@ -13,6 +13,7 @@
       "packages": "Pakiety",
       "trip_planner": "Planer podróży",
       "explore": "Odkrywaj",
+      "local_guide": "Nasz przewodnik po Zanzibarze",
       "about": "O nas"
     },
     "about": {

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,13 +5,16 @@ import ExploreCta from '../components/explore/ExploreCta.jsx';
 import ExploreDoorways from '../components/explore/ExploreDoorways.jsx';
 import ExploreHero from '../components/explore/ExploreHero.jsx';
 import ExploreHub from '../components/explore/ExploreHub.jsx';
+import ExploreLocalGuide from '../components/explore/ExploreLocalGuide.jsx';
 import ExplorePaths from '../components/explore/ExplorePaths.jsx';
 import MapSection from '../components/homepage/MapSection.jsx';
 import { buildLocalizedExploreContent, plannerHrefForHub } from '../data/explorePageContent.js';
 import { usePageMeta } from '../hooks/usePageMeta.js';
 import { useRevealOnScroll } from '../hooks/useRevealOnScroll.js';
+import { preferredScrollBehavior } from '../utils/motion.js';
 import '../styles/homepage.css';
 import '../styles/excursions.css';
+import '../styles/explore-local-guide.css';
 import '../styles/safaris.css';
 
 export default function Explore() {
@@ -41,6 +44,9 @@ export default function Explore() {
     return () => window.removeEventListener('dp-theme-change', handleThemeChange);
   }, []);
 
+  // location.key re-runs this on every router navigation, so clicking a link
+  // to the hash we are already on still scrolls; scrollIntoView (unlike direct
+  // scrollTop writes) honours the section's scroll-margin-top nav offset.
   useEffect(() => {
     if (!ready || !location.hash) return undefined;
     const timeout = window.setTimeout(() => {
@@ -50,12 +56,10 @@ export default function Explore() {
       target.classList.add('is-visible');
       target.style.opacity = '1';
       target.style.transform = 'none';
-      const top = target.getBoundingClientRect().top + document.documentElement.scrollTop;
-      document.documentElement.scrollTop = top;
-      document.body.scrollTop = top;
+      target.scrollIntoView({ behavior: preferredScrollBehavior(), block: 'start' });
     }, 80);
     return () => window.clearTimeout(timeout);
-  }, [ready, location.hash]);
+  }, [ready, location.hash, location.key]);
 
   if (!ready) return null;
 
@@ -75,6 +79,7 @@ export default function Explore() {
       />
 
       <ExploreHub hub={activeHub} plannerHref={activeHubPlannerHref} />
+      <ExploreLocalGuide />
       <ExploreDoorways />
       <ExplorePaths paths={paths} />
       <ExploreCta />

--- a/src/styles/explore-local-guide.css
+++ b/src/styles/explore-local-guide.css
@@ -1,0 +1,487 @@
+.local-guide {
+  padding: clamp(4.5rem, 9vw, 8rem) clamp(1.25rem, 5vw, 6rem);
+  background:
+    radial-gradient(circle at 92% 10%, rgba(255, 111, 97, 0.08), transparent 24rem),
+    var(--surface, #fff);
+  scroll-margin-top: calc(var(--nav-height, 66px) + 1rem);
+}
+
+.local-guide__inner {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+/* ---- Header: coral eyebrow, script headline, serif lead ---- */
+
+.local-guide__head {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  align-items: end;
+  gap: clamp(2.5rem, 6vw, 6.5rem);
+  padding-bottom: clamp(2.5rem, 5vw, 4.5rem);
+  border-bottom: 1px solid var(--line, var(--dp-border));
+}
+
+.local-guide__heading .section-eyebrow::after { display: none; }
+
+.local-guide__title {
+  margin: 1rem 0 1.15rem;
+  color: var(--text-soft, var(--dp-primary));
+  font-family: var(--dp-font-script);
+  font-size: clamp(2.4rem, 4.6vw, 4.1rem);
+  font-weight: 400;
+  line-height: 1.08;
+  text-wrap: balance;
+}
+
+.local-guide__lead {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.05rem, 1.25vw, 1.2rem);
+  line-height: 1.8;
+}
+
+.local-guide__coverage {
+  display: inline-flex;
+  margin: 1.5rem 0 0;
+  padding: 0.5rem 0.85rem;
+  color: var(--dp-accent-text);
+  background: color-mix(in srgb, var(--dp-accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--dp-accent) 25%, transparent);
+  border-radius: 999px;
+  font-family: var(--dp-font-sans);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* ---- Note: paper card with serif quote and script tagline ---- */
+
+.local-guide__note {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.1rem;
+  align-items: start;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  background: color-mix(in srgb, var(--dp-primary) 4%, var(--surface, #fff));
+  border: 1px solid var(--line, var(--dp-border));
+  border-radius: var(--dp-radius-lg);
+}
+
+.local-guide__note img {
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--dp-primary) 18%, transparent);
+}
+
+.local-guide__note p {
+  margin: 0 0 0.85rem;
+  color: var(--text-soft, var(--dp-primary));
+  font-family: var(--dp-font-display);
+  font-size: clamp(1rem, 1.4vw, 1.18rem);
+  font-style: italic;
+  line-height: 1.6;
+}
+
+.local-guide__note span {
+  display: block;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-sans);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.local-guide__note em {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-script);
+  font-size: 1.05rem;
+  font-style: normal;
+}
+
+/* ---- Area tabs ---- */
+
+.local-guide__tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: clamp(2.5rem, 5vw, 4rem);
+}
+
+.local-guide__tabs button {
+  position: relative;
+  display: grid;
+  gap: 0.4rem;
+  min-height: 96px;
+  padding: 1.05rem 1.15rem 1.15rem;
+  color: var(--text-muted, var(--dp-fg-3));
+  text-align: left;
+  background: color-mix(in srgb, var(--surface, #fff) 96%, var(--dp-primary));
+  border: 1px solid var(--line, var(--dp-border));
+  border-radius: var(--dp-radius-md);
+  cursor: pointer;
+  font-family: var(--dp-font-sans);
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.local-guide__tabs button::after {
+  content: '';
+  position: absolute;
+  right: 0.75rem;
+  bottom: -1px;
+  left: 0.75rem;
+  height: 3px;
+  border-radius: 999px 999px 0 0;
+  background: var(--dp-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s var(--dp-ease-out);
+}
+
+.local-guide__tabs button:hover,
+.local-guide__tabs button.is-active {
+  color: var(--text-soft, var(--dp-primary));
+  border-color: color-mix(in srgb, var(--dp-accent) 45%, var(--line, var(--dp-border)));
+}
+.local-guide__tabs button:hover { transform: translateY(-2px); }
+.local-guide__tabs button:focus-visible { outline: 3px solid color-mix(in srgb, var(--dp-accent) 45%, transparent); outline-offset: 2px; }
+.local-guide__tabs button.is-active::after { transform: scaleX(1); }
+
+.local-guide__tabs strong {
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.25rem, 1.9vw, 1.6rem);
+  font-weight: 500;
+}
+
+.local-guide__tabs span {
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.local-guide__mobile-select { display: none; }
+
+/* ---- Body: area photo beside an editorial place list ---- */
+
+.local-guide__body {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.8fr) minmax(0, 1.2fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+.local-guide__media {
+  position: sticky;
+  top: calc(var(--nav-height, 66px) + 1.5rem);
+  margin: 0;
+  animation: local-guide-fade 0.4s var(--dp-ease-out, ease) both;
+}
+
+.local-guide__media img {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+  border-radius: var(--dp-radius-lg);
+  box-shadow: var(--dp-shadow-2);
+}
+
+.local-guide__media-badge {
+  position: absolute;
+  top: 1.1rem;
+  left: 1.1rem;
+  padding: 0.4rem 0.85rem;
+  color: #fff;
+  background: color-mix(in srgb, var(--dp-primary) 78%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-radius: 999px;
+  font-family: var(--dp-font-sans);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.local-guide__media figcaption {
+  margin-top: 0.8rem;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-sans);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.local-guide__places {
+  animation: local-guide-fade 0.4s var(--dp-ease-out, ease) both;
+}
+
+.local-guide__place {
+  display: grid;
+  grid-template-columns: 3.2rem minmax(0, 1fr);
+  gap: 1.15rem;
+  padding: clamp(1.75rem, 3vw, 2.5rem) 0;
+  border-bottom: 1px solid var(--line, var(--dp-border));
+}
+
+.local-guide__place:first-child { padding-top: 0.5rem; }
+
+.local-guide__number {
+  padding-top: 0.3rem;
+  color: color-mix(in srgb, var(--dp-accent) 55%, var(--text-muted, var(--dp-fg-3)));
+  font-family: var(--dp-font-script);
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.local-guide__occasion {
+  display: inline-block;
+  margin-bottom: 0.7rem;
+  padding: 0.32rem 0.75rem;
+  color: var(--dp-accent-text);
+  background: color-mix(in srgb, var(--dp-accent) 12%, transparent);
+  border-radius: 999px;
+  font-family: var(--dp-font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.local-guide__place h3 {
+  margin: 0 0 0.7rem;
+  color: var(--text-soft, var(--dp-primary));
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.45rem, 2.2vw, 1.9rem);
+  font-weight: 500;
+  line-height: 1.15;
+}
+
+.local-guide__place p {
+  max-width: 52ch;
+  margin: 0 0 1.15rem;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-display);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.local-guide__place a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.local-guide__place a svg { transition: transform 0.2s ease; }
+.local-guide__place a:hover svg { transform: translateX(3px); }
+
+/* ---- Events: island calendar timeline ---- */
+
+.local-guide__events {
+  margin-top: clamp(3rem, 6vw, 5rem);
+  padding-top: clamp(2.5rem, 5vw, 4rem);
+  border-top: 1px solid var(--line, var(--dp-border));
+}
+
+.local-guide__events-label {
+  display: inline-block;
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-sans);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.local-guide__events-title {
+  margin: 0.85rem 0 1rem;
+  color: var(--text-soft, var(--dp-primary));
+  font-family: var(--dp-font-script);
+  font-size: clamp(1.9rem, 3.4vw, 2.9rem);
+  font-weight: 400;
+  line-height: 1.1;
+}
+
+.local-guide__events-lead {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-display);
+  font-size: clamp(1rem, 1.2vw, 1.12rem);
+  line-height: 1.75;
+}
+
+.local-guide__events-list {
+  margin: clamp(1.5rem, 3vw, 2.5rem) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.local-guide__event {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr);
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 2.5vw, 2rem) 0;
+  border-bottom: 1px solid var(--line, var(--dp-border));
+}
+
+.local-guide__event:last-child { border-bottom: 0; }
+
+.local-guide__event-when {
+  padding-top: 0.3rem;
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.local-guide__event-copy h4 {
+  margin: 0 0 0.35rem;
+  color: var(--text-soft, var(--dp-primary));
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.25rem, 1.9vw, 1.55rem);
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.local-guide__event-where {
+  display: block;
+  margin-bottom: 0.7rem;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-sans);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.local-guide__event-copy p {
+  max-width: 62ch;
+  margin: 0 0 1rem;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-display);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.local-guide__event-copy a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.local-guide__event-copy a svg { transition: transform 0.2s ease; }
+.local-guide__event-copy a:hover svg { transform: translateX(3px); }
+
+/* ---- Footer strip ---- */
+
+.local-guide__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-top: clamp(2.5rem, 5vw, 4rem);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  background: color-mix(in srgb, var(--dp-primary) 5%, var(--surface, #fff));
+  border: 1px solid var(--line, var(--dp-border));
+  border-radius: var(--dp-radius-lg);
+}
+
+.local-guide__footer strong {
+  color: var(--dp-accent-text);
+  font-family: var(--dp-font-script);
+  font-size: clamp(1.35rem, 2.2vw, 1.75rem);
+  font-weight: 400;
+}
+
+.local-guide__footer p {
+  margin: 0.45rem 0 0;
+  color: var(--text-muted, var(--dp-fg-3));
+  font-family: var(--dp-font-display);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.local-guide__footer .btn { flex: 0 0 auto; }
+
+@keyframes local-guide-fade {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* ---- Responsive ---- */
+
+@media (max-width: 820px) {
+  .local-guide__head { grid-template-columns: 1fr; align-items: start; }
+  .local-guide__tabs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .local-guide__body { grid-template-columns: 1fr; }
+  .local-guide__media { position: static; }
+  .local-guide__media img { aspect-ratio: 16 / 10; }
+}
+
+@media (max-width: 560px) {
+  .local-guide__event { grid-template-columns: 1fr; gap: 0.5rem; }
+  .local-guide__event-when { padding-top: 0; }
+
+  .local-guide__mobile-select {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 2.5rem;
+    color: var(--text-muted, var(--dp-fg-3));
+    font-family: var(--dp-font-sans);
+    font-size: 0.69rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .local-guide__mobile-select select {
+    width: 100%;
+    min-height: 54px;
+    padding: 0 2.75rem 0 1rem;
+    color: var(--text-soft, var(--dp-primary));
+    background: var(--surface, #fff);
+    border: 1px solid var(--line, var(--dp-border));
+    border-radius: var(--dp-radius-md);
+    font-family: var(--dp-font-display);
+    font-size: 1.15rem;
+  }
+
+  .local-guide__tabs { display: none; }
+  .local-guide__place { grid-template-columns: 2.25rem minmax(0, 1fr); gap: 0.75rem; }
+  .local-guide__footer { align-items: stretch; flex-direction: column; }
+  .local-guide__footer .btn { justify-content: center; width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .local-guide__tabs button,
+  .local-guide__tabs button::after,
+  .local-guide__place a svg,
+  .local-guide__event-copy a svg { transition: none; }
+  .local-guide__media,
+  .local-guide__places { animation: none; }
+}

--- a/test/scripts/instagram-story.test.mjs
+++ b/test/scripts/instagram-story.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   alreadyPublishedToday,
+  chooseStoryCard,
   storyDateKey,
 } from '../../scripts/instagram-story.mjs';
 
@@ -27,5 +28,26 @@ describe('Instagram Story daily publishing guard', () => {
   it('does not skip when the state has no valid publication timestamp', () => {
     expect(alreadyPublishedToday({})).toBe(false);
     expect(alreadyPublishedToday({ lastPublishedAt: 'invalid' })).toBe(false);
+  });
+});
+
+describe('Instagram Story editorial queue', () => {
+  const cards = [
+    { id: 'first', source: '/assets/images/excursions/first.webp' },
+    { id: 'second', source: '/assets/images/excursions/second.webp' },
+  ];
+
+  it('uses the first unused approved card rather than a random image', () => {
+    expect(chooseStoryCard(cards, { cycle: 1, usedCards: ['first'] }).selected.id).toBe('second');
+  });
+
+  it('respects legacy used image paths during the transition', () => {
+    expect(chooseStoryCard(cards, { cycle: 1, used: [cards[0].source] }).selected.id).toBe('second');
+  });
+
+  it('begins a new cycle only after every approved card is used', () => {
+    const result = chooseStoryCard(cards, { cycle: 1, usedCards: ['first', 'second'] });
+    expect(result.selected.id).toBe('first');
+    expect(result.nextState).toEqual({ cycle: 2, usedCards: ['first'] });
   });
 });


### PR DESCRIPTION
## What changed

Adds a curated **"Our Zanzibar Guide"** section to the Explore page (`#our-zanzibar-guide`) — restaurant recommendations and island events, presented in the brand's proposal design language.

### The guide ([ExploreLocalGuide.jsx](../blob/development/src/components/explore/ExploreLocalGuide.jsx))
- **8 area tabs** (Stone Town → Kizimkazi), each with 4 hand-picked restaurants: occasion pill, personal note, and a Google Maps link. Accessible tablist (roving tabindex, arrow/Home/End keys) with a `<select>` fallback under 560px.
- **Per-area photography** from existing trip assets (Forodhani street food, The Rock, Paje kitesurfing…), with a blurred area badge and sticky positioning beside the list.
- **"When the island celebrates."** — a 6-date events timeline (Forodhani Night Market, Sauti za Busara, ZIFF, Mwaka Kogwa, Water Sports Festival, Kendwa Full Moon Party). Festivals the site already sells link to their excursion pages; venue events open Maps.
- Fully translated: EN / DE / PL, including all restaurant and event copy.
- Area selection is component state mirrored to `?guide=` via `history.replaceState` — shareable deep links without router navigations, scroll jumps, or history pollution.

### Design
Styled after the Tanzania–Zanzibar proposal document, using only existing brand tokens: Kaushan Script headlines, Playfair serif copy, Montserrat letterspaced labels, coral pill chips, and a route-style timeline. Works in light and dark themes; respects `prefers-reduced-motion`.

### Entry points
- Footer link "Our Zanzibar Guide" with a new utensils icon (all locales)
- Site search entry matching food and event queries ("full moon party", "ziff", "where to eat"…)

### Fixes along the way
- **Explore hash scrolling**: the effect now re-runs on `location.key`, so clicking a `#our-zanzibar-guide` link when the hash is already in the URL scrolls again; switched to `scrollIntoView` so the fixed-nav `scroll-margin-top` offset is honoured.
- **Instagram Story script**: `fetchWithSafeRetries` now also retries transient HTTP 408/429/5xx on GET/HEAD (still never retries POSTs, so no double-publish risk).
- `.gitignore` now covers local scratch dirs (`.playwright-cli/`, `output/`, `tmp/`).

## Why

Guests keep asking "where should we really eat, and what's on?" — this puts the team's actual recommendations on the site, localized, with a WhatsApp CTA to continue the conversation.

## Reviewer notes

- Verified in the dev server: tab switching, deep links (`?guide=paje`), invalid-param fallback, repeat-click hash scrolling, internal festival links, both themes, and all three locales' JSON structure (identical area/place/event shapes). ESLint clean, no console errors.
- Event dates are deliberately evergreen (seasons like "Early February", not year-specific dates).
- Netlify: merging to `main` deploys production; this branch alone only produces a branch deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)