### PR TITLE
Remove link underlines site-wide

### DIFF
--- a/src/styles/booking/form.css
+++ b/src/styles/booking/form.css
@@ -228,7 +228,6 @@
   font-weight: 800;
   text-decoration: none;
 }
-.booking-privacy a:hover { text-decoration: underline; }
 
 .booking-status {
   margin: 0;

--- a/src/styles/homepage/contact.css
+++ b/src/styles/homepage/contact.css
@@ -92,7 +92,6 @@ a.contact__detail-value:hover { color: var(--dp-accent); }
   font-weight: 800;
   text-decoration: none;
 }
-.contact__privacy a:hover { text-decoration: underline; }
 
 .contact__status {
   font-family: var(--dp-font-sans);

--- a/src/styles/homepage/newsletter.css
+++ b/src/styles/homepage/newsletter.css
@@ -59,7 +59,6 @@
   font-weight: 800;
   text-decoration: none;
 }
-.newsletter__privacy a:hover { text-decoration: underline; }
 
 @media (max-width: 720px) {
   .newsletter {

--- a/src/styles/homepage/planner.css
+++ b/src/styles/homepage/planner.css
@@ -583,7 +583,6 @@
   font-weight: 800;
   text-decoration: none;
 }
-.planner__privacy a:hover { text-decoration: underline; }
 .planner__handoff {
   flex-shrink: 0;
   display: inline-flex;

--- a/src/styles/policy.css
+++ b/src/styles/policy.css
@@ -70,7 +70,6 @@
 .policy-meta a,
 .policy-section a {
   color: var(--dp-accent-text);
-  text-decoration: underline;
 }
 
 .policy-content {

--- a/src/styles/retreats.css
+++ b/src/styles/retreats.css
@@ -661,7 +661,6 @@ html[data-theme="dark"] .ret-teacher-card__copy li {
 .ret-detail-crumbs a:focus-visible {
   color: var(--dp-accent);
   outline: 0;
-  text-decoration: underline;
 }
 .ret-teacher-detail-hero {
   width: min(var(--site-max-width), 92%);

--- a/src/styles/site-shell.css
+++ b/src/styles/site-shell.css
@@ -125,7 +125,7 @@ button { font: inherit; }
 
 a {
   color: inherit;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 a:hover,


### PR DESCRIPTION
## Summary
- remove the Terms page link underline override
- prevent underlines globally across hover/focus states and bundled third-party styles
- remove matching hover underline exceptions from booking, newsletter, contact, planner, and retreat styles

## Validation
- npm run lint
- npm run typecheck
- npm run test (66 tests)
- npm run build (123/123 routes prerendered)
- desktop/mobile browser QA on Terms plus cross-route computed-style audit