### PR TITLE
fix: remove crawl origin from prerendered assets

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -107,6 +107,24 @@ function createServer(indexHtml) {
   });
 }
 
+function sanitizeSerializedHtml(html, port) {
+  // Vite adds modulepreload and stylesheet links while lazy chunks load.
+  // Chromium serializes those runtime-created hrefs as absolute URLs, which
+  // would otherwise leak this temporary crawl server into the deployed HTML.
+  const localOrigins = [
+    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
+  ];
+  let sanitized = html;
+  for (const origin of localOrigins) sanitized = sanitized.replaceAll(origin, '');
+
+  const leakedOrigin = sanitized.match(/https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/i);
+  if (leakedOrigin) {
+    throw new Error(`serialized HTML still contains local crawl origin ${leakedOrigin[0]}`);
+  }
+  return sanitized;
+}
+
 async function renderRoute(browser, port, path) {
   const page = await browser.newPage();
   try {
@@ -165,7 +183,8 @@ async function renderRoute(browser, port, path) {
       );
     }
     await new Promise((r) => setTimeout(r, 100));
-    return await page.evaluate(() => `<!doctype html>\n${document.documentElement.outerHTML}`);
+    const html = await page.evaluate(() => `<!doctype html>\n${document.documentElement.outerHTML}`);
+    return sanitizeSerializedHtml(html, port);
   } finally {
     await page.close().catch(() => {});
   }


### PR DESCRIPTION
## Summary
- strip the temporary Chromium crawl origin from runtime-created modulepreload and stylesheet URLs before writing prerendered HTML
- fail the strict build if any localhost or loopback crawl origin remains

## Verification
- npm ci
- npm audit (0 vulnerabilities)
- npm audit --omit=dev (0 vulnerabilities)
- npm run lint
- npm run typecheck
- npm test (103 passed)
- PRERENDER_STRICT=true npm run build (124/124 routes plus 404)
- recursive HTML scan confirms zero localhost/127.0.0.1 origins in dist